### PR TITLE
Fix for css fixed-width, update docs

### DIFF
--- a/docs/pages/gettingStarted.md
+++ b/docs/pages/gettingStarted.md
@@ -35,10 +35,12 @@ nav_order: 2
    </div>
 4. In the root file that defines your html, add the following lines to the `<head>` section.
    This would be `_Layout.cshtml` for Blazor Server, or `index.html` for Blazor Wasm and Blazor Hybrid.
+   Note that `YourProject` is the namespace for the application that you are creating.
 
     ```html
     <link href="_content/dymaptic.GeoBlazor.Core"/>
     <link href="_content/dymaptic.GeoBlazor.Core/assets/esri/themes/light/main.css" rel="stylesheet" />
+    <link href="YourProject.styles.css" rel="stylesheet" />
     ```
     
     or (dark theme)
@@ -46,6 +48,7 @@ nav_order: 2
     ```html
     <link href="_content/dymaptic.GeoBlazor.Core"/>
     <link href="_content/dymaptic.GeoBlazor.Core/assets/esri/themes/dark/main.css" rel="stylesheet" />
+    <link href="YourProject.styles.css" rel="stylesheet" />
     ```
 
 5. In `_Imports.razor`, add the following lines, or add as needed to resolve code that you consume.

--- a/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor
@@ -5,8 +5,8 @@
     <CascadingValue Name="Parent" Value="this">
         <CascadingValue Name="JsModule" Value="ViewJsModule">
             <CascadingValue Name="MapRendered" Value="MapRendered">
-                <div class="map-wrapper">
-                    <div id="@($"map-container-{Id}")" class="@Class" style="@Style">
+                <div class="@Class map-wrapper" style="@Style">
+                    <div class="map-container" id="@($"map-container-{Id}")">
                         @ChildContent
                     </div>
                     <div class="dymaptic-branding">

--- a/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.css
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.css
@@ -1,7 +1,3 @@
-#map-container {
-    position: relative;
-}
-
 .dymaptic-branding {
     text-align: right;
     font-weight: 400;
@@ -16,4 +12,10 @@
 
 .map-wrapper {
     position: relative;
+}
+
+.map-container {
+    position: relative;
+    width: 100%;
+    height: 100%;
 }

--- a/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
+++ b/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
@@ -12,9 +12,9 @@
         </Description>
         <Title>GeoBlazor</Title>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageVersion>1.2.0</PackageVersion>
-        <Version>1.2.0</Version>
-        <PackageVersion>1.2.0</PackageVersion>
+        <PackageVersion>1.2.1</PackageVersion>
+        <Version>1.2.1</Version>
+        <PackageVersion>1.2.1</PackageVersion>
         <Authors>Tim Purdum, Christopher Moravec</Authors>
         <Company>dymaptic</Company>
         <Copyright>©2022 by dymaptic</Copyright>

--- a/src/dymaptic.GeoBlazor.Core/package-lock.json
+++ b/src/dymaptic.GeoBlazor.Core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dymaptic.GeoBlazor.Core",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dymaptic.GeoBlazor.Core",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "@arcgis/core": "^4.24.7",

--- a/src/dymaptic.GeoBlazor.Core/package.json
+++ b/src/dymaptic.GeoBlazor.Core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dymaptic.GeoBlazor.Core",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "https://www.geoblazor.com",
   "main": "arcGisInterop.js",
   "scripts": {


### PR DESCRIPTION
Small fix
- rearranged styling for `map-wrapper` and `map-container` so that both fixed and percent-based widths lay out correctly
- added reference to bundled css in `gettingStarted.md` required to load GeoBlazor css correctly (one of the new empty templates from MS has this line commented out)