### PR TITLE
Feature/gbv2 doc adjustments

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,15 @@ application with the full power of ArcGIS.
 
 ## Documentation Pages
 - [Getting Started](pages/gettingStarted) - How to set up your first GeoBlazor application
+- [Features](pages/features) - How to set up your first GeoBlazor application
 - [Authentication](pages/authentication) - Advanced options for authenticating with ArcGIS
-- [API Documentation](pages/classes/index) - Detailed technical specification for GeoBlazor types and classes
+- [Managing Extent](pages/managingExtent) - Methods to set and retrieve the extent of a view in GeoBlazor
+- [Custom Graphics](pages/customGraphics) - Customizing your graphics with GeoBlazor
+- [Events and Property Changes](pages/reactive) - Methods to listen for event and property changes in GeoBlazor
+- [Hit Test](pages/hitTestAndQueries) - A variety of queries supported by GeoBlazor
+- [Asset Files](pages/assetFiles) - Description of default and customized asset loading
+- [Full API Documentation](pages/classes/index) - Detailed technical specification for GeoBlazor types and classes
+
 
 ## Useful Links
 - [Home Page](https://www.geoblazor.com) - Main website

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ application with the full power of ArcGIS.
 
 ## Documentation Pages
 - [Getting Started](pages/gettingStarted) - How to set up your first GeoBlazor application
-- [Features](pages/features) - How to set up your first GeoBlazor application
+- [Features](pages/features) - Available features supported by GeoBlazor
 - [Authentication](pages/authentication) - Advanced options for authenticating with ArcGIS
 - [Managing Extent](pages/managingExtent) - Methods to set and retrieve the extent of a view in GeoBlazor
 - [Custom Graphics](pages/customGraphics) - Customizing your graphics with GeoBlazor

--- a/docs/pages/gettingStarted.md
+++ b/docs/pages/gettingStarted.md
@@ -111,6 +111,5 @@ nav_order: 2
 11. Run your application and make sure you can see your map!
    ![Web Map Sample](../assets/images/webmap.png)
 12. Now that you have a great starting point, you can now start to customize the features available in your new app using Geoblazor's capabilites:<br/>
-     -Learn more about the variety of widgets, types, layers, properties, and methods in the [Classes](https://docs.geoblazor.com/pages/assetFiles.html) section.<br/>
-     -Learn more about available EventCallbacks and Event handlers in the [Events and Property Changes](https://docs.geoblazor.com/pages/reactive.html) section.
-
+     -Take a look at the [Documentation](https://docs.geoblazor.com/index.html) pages to learn more.<br/>
+     

--- a/docs/pages/gettingStarted.md
+++ b/docs/pages/gettingStarted.md
@@ -66,7 +66,7 @@ nav_order: 2
    @using dymaptic.GeoBlazor.Core.Components.Widgets
    @using dymaptic.GeoBlazor.Core.Objects
    ```
-6. In `Program.cs`, add the following line to your `builder.Services` to inject logic omponents like `GeometryEngine`.
+6. In `Program.cs`, add the following line to your `builder.Services` to inject logic components like `GeometryEngine`.
 
 ```csharp
    builder.Services.AddGeoBlazor();
@@ -88,8 +88,8 @@ nav_order: 2
       private readonly double _longitude = -118.805;
    } 
    ```
-9. Within the `MapView`, define a `Map`. To load a pre-generated map from ArcGIS Online or Portal, get the Map Id (PortalItem Id)
-   of the map, and use the `WebMap` component.
+9. Within the `MapView`, define a map using the `WebMap` component.  To load a pre-generated map from ArcGIS Online or Portal, get the Map Id (PortalItem Id)
+   of the map.
 
    ```html
    <MapView Longitude="_longitude" Latitude="_latitude" Zoom="11" Style="height: 400px; width: 100%;"> 
@@ -110,3 +110,7 @@ nav_order: 2
    ```
 11. Run your application and make sure you can see your map!
    ![Web Map Sample](../assets/images/webmap.png)
+12. Now that you have a great starting point, you can now start to customize the features available in your new app using Geoblazor's capabilites:<br/>
+     -Learn more about the variety of widgets, types, layers, properties, and methods in the [Classes](https://docs.geoblazor.com/pages/assetFiles.html) section.<br/>
+     -Learn more about available EventCallbacks and Event handlers in the [Events and Property Changes](https://docs.geoblazor.com/pages/reactive.html) section.
+


### PR DESCRIPTION
Reviewed the Documentation pages.  This PR:
- corrects a couple spelling errors.  
- Adds additional documentation links on the main page covering the pages with new content and features which have been added since the last version so that the side-bar menu has the same items/links as the main documentation page.
- a documentation page link at the bottom of the getting started page.