### PR TITLE
Plots 2000 points in < 3 seconds

### DIFF
--- a/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.ActionBase.md
+++ b/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.ActionBase.md
@@ -16,7 +16,8 @@ LayerList.
 </a>
 
 ```csharp
-public abstract class ActionBase : dymaptic.GeoBlazor.Core.Components.MapComponent
+public abstract class ActionBase : dymaptic.GeoBlazor.Core.Components.MapComponent,
+System.IEquatable<dymaptic.GeoBlazor.Core.Components.ActionBase>
 ```
 
 Inheritance [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object') &#129106; [Microsoft.AspNetCore.Components.ComponentBase](https://docs.microsoft.com/en-us/dotnet/api/Microsoft.AspNetCore.Components.ComponentBase 'Microsoft.AspNetCore.Components.ComponentBase') &#129106; [MapComponent](dymaptic.GeoBlazor.Core.Components.MapComponent.html 'dymaptic.GeoBlazor.Core.Components.MapComponent') &#129106; ActionBase
@@ -24,6 +25,8 @@ Inheritance [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.O
 Derived  
 &#8627; [ActionButton](dymaptic.GeoBlazor.Core.Components.ActionButton.html 'dymaptic.GeoBlazor.Core.Components.ActionButton')  
 &#8627; [ActionToggle](dymaptic.GeoBlazor.Core.Components.ActionToggle.html 'dymaptic.GeoBlazor.Core.Components.ActionToggle')
+
+Implements [System.IEquatable&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.IEquatable-1 'System.IEquatable`1')[ActionBase](dymaptic.GeoBlazor.Core.Components.ActionBase.html 'dymaptic.GeoBlazor.Core.Components.ActionBase')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.IEquatable-1 'System.IEquatable`1')
 ### Properties
 
 <a name='dymaptic.GeoBlazor.Core.Components.ActionBase.Active'></a>
@@ -131,3 +134,84 @@ public System.Nullable<bool> Visible { get; set; }
 
 #### Property Value
 [System.Nullable&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.Nullable-1 'System.Nullable`1')[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.Nullable-1 'System.Nullable`1')
+### Methods
+
+<a name='dymaptic.GeoBlazor.Core.Components.ActionBase.Equals(object)'></a>
+
+## ActionBase.Equals(object) Method
+
+Determines whether the specified object is equal to the current object.
+
+```csharp
+public override bool Equals(object? obj);
+```
+#### Parameters
+
+<a name='dymaptic.GeoBlazor.Core.Components.ActionBase.Equals(object).obj'></a>
+
+`obj` [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object')
+
+The object to compare with the current object.
+
+#### Returns
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')  
+[true](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool 'https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool') if the specified object  is equal to the current object; otherwise, [false](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool 'https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool').
+
+<a name='dymaptic.GeoBlazor.Core.Components.ActionBase.GetHashCode()'></a>
+
+## ActionBase.GetHashCode() Method
+
+Serves as the default hash function.
+
+```csharp
+public override int GetHashCode();
+```
+
+#### Returns
+[System.Int32](https://docs.microsoft.com/en-us/dotnet/api/System.Int32 'System.Int32')  
+A hash code for the current object.
+### Operators
+
+<a name='dymaptic.GeoBlazor.Core.Components.ActionBase.op_Equality(dymaptic.GeoBlazor.Core.Components.ActionBase,dymaptic.GeoBlazor.Core.Components.ActionBase)'></a>
+
+## ActionBase.operator ==(ActionBase, ActionBase) Operator
+
+Determines whether the specified [ActionBase](dymaptic.GeoBlazor.Core.Components.ActionBase.html 'dymaptic.GeoBlazor.Core.Components.ActionBase') is equal to the current [ActionBase](dymaptic.GeoBlazor.Core.Components.ActionBase.html 'dymaptic.GeoBlazor.Core.Components.ActionBase').
+
+```csharp
+public static bool operator ==(dymaptic.GeoBlazor.Core.Components.ActionBase? left, dymaptic.GeoBlazor.Core.Components.ActionBase? right);
+```
+#### Parameters
+
+<a name='dymaptic.GeoBlazor.Core.Components.ActionBase.op_Equality(dymaptic.GeoBlazor.Core.Components.ActionBase,dymaptic.GeoBlazor.Core.Components.ActionBase).left'></a>
+
+`left` [ActionBase](dymaptic.GeoBlazor.Core.Components.ActionBase.html 'dymaptic.GeoBlazor.Core.Components.ActionBase')
+
+<a name='dymaptic.GeoBlazor.Core.Components.ActionBase.op_Equality(dymaptic.GeoBlazor.Core.Components.ActionBase,dymaptic.GeoBlazor.Core.Components.ActionBase).right'></a>
+
+`right` [ActionBase](dymaptic.GeoBlazor.Core.Components.ActionBase.html 'dymaptic.GeoBlazor.Core.Components.ActionBase')
+
+#### Returns
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')
+
+<a name='dymaptic.GeoBlazor.Core.Components.ActionBase.op_Inequality(dymaptic.GeoBlazor.Core.Components.ActionBase,dymaptic.GeoBlazor.Core.Components.ActionBase)'></a>
+
+## ActionBase.operator !=(ActionBase, ActionBase) Operator
+
+Determines whether the specified [ActionBase](dymaptic.GeoBlazor.Core.Components.ActionBase.html 'dymaptic.GeoBlazor.Core.Components.ActionBase') is not equal to the current [ActionBase](dymaptic.GeoBlazor.Core.Components.ActionBase.html 'dymaptic.GeoBlazor.Core.Components.ActionBase').
+
+```csharp
+public static bool operator !=(dymaptic.GeoBlazor.Core.Components.ActionBase? left, dymaptic.GeoBlazor.Core.Components.ActionBase? right);
+```
+#### Parameters
+
+<a name='dymaptic.GeoBlazor.Core.Components.ActionBase.op_Inequality(dymaptic.GeoBlazor.Core.Components.ActionBase,dymaptic.GeoBlazor.Core.Components.ActionBase).left'></a>
+
+`left` [ActionBase](dymaptic.GeoBlazor.Core.Components.ActionBase.html 'dymaptic.GeoBlazor.Core.Components.ActionBase')
+
+<a name='dymaptic.GeoBlazor.Core.Components.ActionBase.op_Inequality(dymaptic.GeoBlazor.Core.Components.ActionBase,dymaptic.GeoBlazor.Core.Components.ActionBase).right'></a>
+
+`right` [ActionBase](dymaptic.GeoBlazor.Core.Components.ActionBase.html 'dymaptic.GeoBlazor.Core.Components.ActionBase')
+
+#### Returns
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')

--- a/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.Layers.LayerView.md
+++ b/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.Layers.LayerView.md
@@ -15,13 +15,16 @@ Represents the view for a single layer after it has been added to either a MapVi
 </a>
 
 ```csharp
-public class LayerView
+public class LayerView :
+System.IDisposable
 ```
 
 Inheritance [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object') &#129106; LayerView
 
 Derived  
 &#8627; [FeatureLayerView](dymaptic.GeoBlazor.Core.Components.Layers.FeatureLayerView.html 'dymaptic.GeoBlazor.Core.Components.Layers.FeatureLayerView')
+
+Implements [System.IDisposable](https://docs.microsoft.com/en-us/dotnet/api/System.IDisposable 'System.IDisposable')
 ### Properties
 
 <a name='dymaptic.GeoBlazor.Core.Components.Layers.LayerView.JsObjectReference'></a>
@@ -101,3 +104,16 @@ public bool Visible { get; set; }
 
 #### Property Value
 [System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')
+### Methods
+
+<a name='dymaptic.GeoBlazor.Core.Components.Layers.LayerView.Dispose()'></a>
+
+## LayerView.Dispose() Method
+
+Disposes the LayerView.
+
+```csharp
+public void Dispose();
+```
+
+Implements [Dispose()](https://docs.microsoft.com/en-us/dotnet/api/System.IDisposable.Dispose 'System.IDisposable.Dispose')

--- a/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.MapComponent.md
+++ b/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.MapComponent.md
@@ -80,7 +80,7 @@ public Microsoft.AspNetCore.Components.RenderFragment? ChildContent { get; set; 
 A unique identifier, used to track components across .NET and JavaScript.
 
 ```csharp
-public System.Guid Id { get; }
+public virtual System.Guid Id { get; }
 ```
 
 #### Property Value

--- a/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.MapComponent.md
+++ b/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.MapComponent.md
@@ -80,7 +80,7 @@ public Microsoft.AspNetCore.Components.RenderFragment? ChildContent { get; set; 
 A unique identifier, used to track components across .NET and JavaScript.
 
 ```csharp
-public virtual System.Guid Id { get; }
+public System.Guid Id { get; }
 ```
 
 #### Property Value

--- a/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.md
+++ b/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.md
@@ -20,10 +20,13 @@ of the popupTemplate's content or referenced within a simple string.
 </a>
 
 ```csharp
-public class ExpressionInfo : dymaptic.GeoBlazor.Core.Components.MapComponent
+public class ExpressionInfo : dymaptic.GeoBlazor.Core.Components.MapComponent,
+System.IEquatable<dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo>
 ```
 
 Inheritance [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object') &#129106; [Microsoft.AspNetCore.Components.ComponentBase](https://docs.microsoft.com/en-us/dotnet/api/Microsoft.AspNetCore.Components.ComponentBase 'Microsoft.AspNetCore.Components.ComponentBase') &#129106; [MapComponent](dymaptic.GeoBlazor.Core.Components.MapComponent.html 'dymaptic.GeoBlazor.Core.Components.MapComponent') &#129106; ExpressionInfo
+
+Implements [System.IEquatable&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.IEquatable-1 'System.IEquatable`1')[ExpressionInfo](dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.html 'dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.IEquatable-1 'System.IEquatable`1')
 ### Properties
 
 <a name='dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.Expression'></a>
@@ -82,3 +85,84 @@ public string? Title { get; set; }
 
 #### Property Value
 [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')
+### Methods
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.Equals(object)'></a>
+
+## ExpressionInfo.Equals(object) Method
+
+Determines whether the specified object is equal to the current object.
+
+```csharp
+public override bool Equals(object? obj);
+```
+#### Parameters
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.Equals(object).obj'></a>
+
+`obj` [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object')
+
+The object to compare with the current object.
+
+#### Returns
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')  
+[true](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool 'https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool') if the specified object  is equal to the current object; otherwise, [false](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool 'https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool').
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.GetHashCode()'></a>
+
+## ExpressionInfo.GetHashCode() Method
+
+Serves as the default hash function.
+
+```csharp
+public override int GetHashCode();
+```
+
+#### Returns
+[System.Int32](https://docs.microsoft.com/en-us/dotnet/api/System.Int32 'System.Int32')  
+A hash code for the current object.
+### Operators
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.op_Equality(dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo,dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo)'></a>
+
+## ExpressionInfo.operator ==(ExpressionInfo, ExpressionInfo) Operator
+
+Equality operator.
+
+```csharp
+public static bool operator ==(dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo? left, dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo? right);
+```
+#### Parameters
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.op_Equality(dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo,dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo).left'></a>
+
+`left` [ExpressionInfo](dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.html 'dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo')
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.op_Equality(dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo,dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo).right'></a>
+
+`right` [ExpressionInfo](dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.html 'dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo')
+
+#### Returns
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.op_Inequality(dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo,dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo)'></a>
+
+## ExpressionInfo.operator !=(ExpressionInfo, ExpressionInfo) Operator
+
+Inequality operator.
+
+```csharp
+public static bool operator !=(dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo? left, dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo? right);
+```
+#### Parameters
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.op_Inequality(dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo,dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo).left'></a>
+
+`left` [ExpressionInfo](dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.html 'dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo')
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.op_Inequality(dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo,dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo).right'></a>
+
+`right` [ExpressionInfo](dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo.html 'dymaptic.GeoBlazor.Core.Components.Popups.ExpressionInfo')
+
+#### Returns
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')

--- a/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.md
+++ b/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.md
@@ -15,10 +15,13 @@ The FieldInfo class defines how a Field participates, or in some cases, does not
 </a>
 
 ```csharp
-public class FieldInfo : dymaptic.GeoBlazor.Core.Components.MapComponent
+public class FieldInfo : dymaptic.GeoBlazor.Core.Components.MapComponent,
+System.IEquatable<dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo>
 ```
 
 Inheritance [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object') &#129106; [Microsoft.AspNetCore.Components.ComponentBase](https://docs.microsoft.com/en-us/dotnet/api/Microsoft.AspNetCore.Components.ComponentBase 'Microsoft.AspNetCore.Components.ComponentBase') &#129106; [MapComponent](dymaptic.GeoBlazor.Core.Components.MapComponent.html 'dymaptic.GeoBlazor.Core.Components.MapComponent') &#129106; FieldInfo
+
+Implements [System.IEquatable&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.IEquatable-1 'System.IEquatable`1')[FieldInfo](dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.html 'dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.IEquatable-1 'System.IEquatable`1')
 ### Constructors
 
 <a name='dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.FieldInfo()'></a>
@@ -177,6 +180,41 @@ public System.Nullable<bool> Visible { get; set; }
 [System.Nullable&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.Nullable-1 'System.Nullable`1')[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.Nullable-1 'System.Nullable`1')
 ### Methods
 
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.Equals(object)'></a>
+
+## FieldInfo.Equals(object) Method
+
+Determines whether the specified object is equal to the current object.
+
+```csharp
+public override bool Equals(object? obj);
+```
+#### Parameters
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.Equals(object).obj'></a>
+
+`obj` [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object')
+
+The object to compare with the current object.
+
+#### Returns
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')  
+[true](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool 'https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool') if the specified object  is equal to the current object; otherwise, [false](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool 'https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool').
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.GetHashCode()'></a>
+
+## FieldInfo.GetHashCode() Method
+
+Serves as the default hash function.
+
+```csharp
+public override int GetHashCode();
+```
+
+#### Returns
+[System.Int32](https://docs.microsoft.com/en-us/dotnet/api/System.Int32 'System.Int32')  
+A hash code for the current object.
+
 <a name='dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.RegisterChildComponent(dymaptic.GeoBlazor.Core.Components.MapComponent)'></a>
 
 ## FieldInfo.RegisterChildComponent(MapComponent) Method
@@ -240,3 +278,48 @@ The consumer needs to provide the missing child component
 
 [MissingRequiredOptionsChildElementException](dymaptic.GeoBlazor.Core.Exceptions.MissingRequiredOptionsChildElementException.html 'dymaptic.GeoBlazor.Core.Exceptions.MissingRequiredOptionsChildElementException')  
 The consumer needs to provide ONE of the options of child components
+### Operators
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.op_Equality(dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo,dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo)'></a>
+
+## FieldInfo.operator ==(FieldInfo, FieldInfo) Operator
+
+Equality operator
+
+```csharp
+public static bool operator ==(dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo? left, dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo? right);
+```
+#### Parameters
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.op_Equality(dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo,dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo).left'></a>
+
+`left` [FieldInfo](dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.html 'dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo')
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.op_Equality(dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo,dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo).right'></a>
+
+`right` [FieldInfo](dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.html 'dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo')
+
+#### Returns
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.op_Inequality(dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo,dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo)'></a>
+
+## FieldInfo.operator !=(FieldInfo, FieldInfo) Operator
+
+Inequality operator
+
+```csharp
+public static bool operator !=(dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo? left, dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo? right);
+```
+#### Parameters
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.op_Inequality(dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo,dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo).left'></a>
+
+`left` [FieldInfo](dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.html 'dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo')
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.op_Inequality(dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo,dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo).right'></a>
+
+`right` [FieldInfo](dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo.html 'dymaptic.GeoBlazor.Core.Components.Popups.FieldInfo')
+
+#### Returns
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')

--- a/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.md
+++ b/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.md
@@ -17,10 +17,13 @@ feature in the view is selected.
 </a>
 
 ```csharp
-public class PopupTemplate : dymaptic.GeoBlazor.Core.Components.MapComponent
+public class PopupTemplate : dymaptic.GeoBlazor.Core.Components.MapComponent,
+System.IEquatable<dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate>
 ```
 
 Inheritance [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object') &#129106; [Microsoft.AspNetCore.Components.ComponentBase](https://docs.microsoft.com/en-us/dotnet/api/Microsoft.AspNetCore.Components.ComponentBase 'Microsoft.AspNetCore.Components.ComponentBase') &#129106; [MapComponent](dymaptic.GeoBlazor.Core.Components.MapComponent.html 'dymaptic.GeoBlazor.Core.Components.MapComponent') &#129106; PopupTemplate
+
+Implements [System.IEquatable&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.IEquatable-1 'System.IEquatable`1')[PopupTemplate](dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.html 'dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.IEquatable-1 'System.IEquatable`1')
 ### Constructors
 
 <a name='dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.PopupTemplate()'></a>
@@ -261,6 +264,41 @@ public string? Title { get; set; }
 [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')
 ### Methods
 
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.Equals(object)'></a>
+
+## PopupTemplate.Equals(object) Method
+
+Determines whether the specified object is equal to the current object.
+
+```csharp
+public override bool Equals(object? obj);
+```
+#### Parameters
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.Equals(object).obj'></a>
+
+`obj` [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object')
+
+The object to compare with the current object.
+
+#### Returns
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')  
+[true](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool 'https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool') if the specified object  is equal to the current object; otherwise, [false](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool 'https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/bool').
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.GetHashCode()'></a>
+
+## PopupTemplate.GetHashCode() Method
+
+Serves as the default hash function.
+
+```csharp
+public override int GetHashCode();
+```
+
+#### Returns
+[System.Int32](https://docs.microsoft.com/en-us/dotnet/api/System.Int32 'System.Int32')  
+A hash code for the current object.
+
 <a name='dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.OnTriggerAction(string)'></a>
 
 ## PopupTemplate.OnTriggerAction(string) Method
@@ -344,3 +382,48 @@ The consumer needs to provide the missing child component
 
 [MissingRequiredOptionsChildElementException](dymaptic.GeoBlazor.Core.Exceptions.MissingRequiredOptionsChildElementException.html 'dymaptic.GeoBlazor.Core.Exceptions.MissingRequiredOptionsChildElementException')  
 The consumer needs to provide ONE of the options of child components
+### Operators
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.op_Equality(dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate,dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate)'></a>
+
+## PopupTemplate.operator ==(PopupTemplate, PopupTemplate) Operator
+
+Equality operator
+
+```csharp
+public static bool operator ==(dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate? left, dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate? right);
+```
+#### Parameters
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.op_Equality(dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate,dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate).left'></a>
+
+`left` [PopupTemplate](dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.html 'dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate')
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.op_Equality(dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate,dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate).right'></a>
+
+`right` [PopupTemplate](dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.html 'dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate')
+
+#### Returns
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.op_Inequality(dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate,dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate)'></a>
+
+## PopupTemplate.operator !=(PopupTemplate, PopupTemplate) Operator
+
+Inequality operator
+
+```csharp
+public static bool operator !=(dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate? left, dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate? right);
+```
+#### Parameters
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.op_Inequality(dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate,dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate).left'></a>
+
+`left` [PopupTemplate](dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.html 'dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate')
+
+<a name='dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.op_Inequality(dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate,dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate).right'></a>
+
+`right` [PopupTemplate](dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate.html 'dymaptic.GeoBlazor.Core.Components.Popups.PopupTemplate')
+
+#### Returns
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')

--- a/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.Symbols.Symbol.md
+++ b/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.Symbols.Symbol.md
@@ -42,6 +42,19 @@ public dymaptic.GeoBlazor.Core.Objects.MapColor? Color { get; set; }
 #### Property Value
 [MapColor](dymaptic.GeoBlazor.Core.Objects.MapColor.html 'dymaptic.GeoBlazor.Core.Objects.MapColor')
 
+<a name='dymaptic.GeoBlazor.Core.Components.Symbols.Symbol.Id'></a>
+
+## Symbol.Id Property
+
+A unique identifier, used to track components across .NET and JavaScript.
+
+```csharp
+public override System.Guid Id { get; }
+```
+
+#### Property Value
+[System.Guid](https://docs.microsoft.com/en-us/dotnet/api/System.Guid 'System.Guid')
+
 <a name='dymaptic.GeoBlazor.Core.Components.Symbols.Symbol.Type'></a>
 
 ## Symbol.Type Property

--- a/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.Symbols.Symbol.md
+++ b/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.Symbols.Symbol.md
@@ -42,19 +42,6 @@ public dymaptic.GeoBlazor.Core.Objects.MapColor? Color { get; set; }
 #### Property Value
 [MapColor](dymaptic.GeoBlazor.Core.Objects.MapColor.html 'dymaptic.GeoBlazor.Core.Objects.MapColor')
 
-<a name='dymaptic.GeoBlazor.Core.Components.Symbols.Symbol.Id'></a>
-
-## Symbol.Id Property
-
-A unique identifier, used to track components across .NET and JavaScript.
-
-```csharp
-public override System.Guid Id { get; }
-```
-
-#### Property Value
-[System.Guid](https://docs.microsoft.com/en-us/dotnet/api/System.Guid 'System.Guid')
-
 <a name='dymaptic.GeoBlazor.Core.Components.Symbols.Symbol.Type'></a>
 
 ## Symbol.Type Property

--- a/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.Views.MapView.md
+++ b/docs/pages/classes/dymaptic.GeoBlazor.Core.Components.Views.MapView.md
@@ -28,6 +28,21 @@ Derived
 
 ### Example
 <a target="_blank" href="https://samples.geoblazor.com/navigation">Sample - Navigation</a>
+### Fields
+
+<a name='dymaptic.GeoBlazor.Core.Components.Views.MapView.ExtentChangedInJs'></a>
+
+## MapView.ExtentChangedInJs Field
+
+A boolean flag to indicate that the map extent has been modified in JavaScript, and therefore should not be  
+modifiable by markup until [Refresh()](dymaptic.GeoBlazor.Core.Components.Views.MapView.html#dymaptic.GeoBlazor.Core.Components.Views.MapView.Refresh() 'dymaptic.GeoBlazor.Core.Components.Views.MapView.Refresh()') is called
+
+```csharp
+public bool ExtentChangedInJs;
+```
+
+#### Field Value
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')
 ### Properties
 
 <a name='dymaptic.GeoBlazor.Core.Components.Views.MapView.AllowDefaultEsriLogin'></a>

--- a/docs/pages/classes/dymaptic.GeoBlazor.Core.Model.LogicComponent.md
+++ b/docs/pages/classes/dymaptic.GeoBlazor.Core.Model.LogicComponent.md
@@ -11,7 +11,8 @@ parent: Classes
 A base class for non-map components, such as GeometryEngine, Projection, etc.
 
 ```csharp
-public abstract class LogicComponent
+public abstract class LogicComponent :
+System.IDisposable
 ```
 
 Inheritance [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object') &#129106; LogicComponent
@@ -19,6 +20,8 @@ Inheritance [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.O
 Derived  
 &#8627; [GeometryEngine](dymaptic.GeoBlazor.Core.Model.GeometryEngine.html 'dymaptic.GeoBlazor.Core.Model.GeometryEngine')  
 &#8627; [Projection](dymaptic.GeoBlazor.Core.Model.Projection.html 'dymaptic.GeoBlazor.Core.Model.Projection')
+
+Implements [System.IDisposable](https://docs.microsoft.com/en-us/dotnet/api/System.IDisposable 'System.IDisposable')
 ### Constructors
 
 <a name='dymaptic.GeoBlazor.Core.Model.LogicComponent.LogicComponent(Microsoft.JSInterop.IJSRuntime,Microsoft.Extensions.Configuration.IConfiguration)'></a>
@@ -58,6 +61,18 @@ public System.Func<dymaptic.GeoBlazor.Core.Exceptions.JavascriptException,System
 #### Property Value
 [System.Func&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.Func-2 'System.Func`2')[JavascriptException](dymaptic.GeoBlazor.Core.Exceptions.JavascriptException.html 'dymaptic.GeoBlazor.Core.Exceptions.JavascriptException')[,](https://docs.microsoft.com/en-us/dotnet/api/System.Func-2 'System.Func`2')[System.Threading.Tasks.Task](https://docs.microsoft.com/en-us/dotnet/api/System.Threading.Tasks.Task 'System.Threading.Tasks.Task')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.Func-2 'System.Func`2')
 ### Methods
+
+<a name='dymaptic.GeoBlazor.Core.Model.LogicComponent.Dispose()'></a>
+
+## LogicComponent.Dispose() Method
+
+Disposes of the Logic Component and cancels all external calls
+
+```csharp
+public void Dispose();
+```
+
+Implements [Dispose()](https://docs.microsoft.com/en-us/dotnet/api/System.IDisposable.Dispose 'System.IDisposable.Dispose')
 
 <a name='dymaptic.GeoBlazor.Core.Model.LogicComponent.OnJavascriptError(dymaptic.GeoBlazor.Core.Exceptions.JavascriptError)'></a>
 

--- a/docs/pages/customGraphics.md
+++ b/docs/pages/customGraphics.md
@@ -3,7 +3,6 @@ layout: page
 title: "Custom Graphics"
 nav_order: 6
 ---
-
 # Custom Graphics
 
 While many `FeatureLayer` and `TileLayer` services come pre-loaded with images, GeoBlazor also supports custom
@@ -11,8 +10,10 @@ While many `FeatureLayer` and `TileLayer` services come pre-loaded with images, 
 
 ## Defining Graphics in Razor Markup
 
-The simplest way to define custom graphics is using the Razor Component markup syntax. Below is an example of 
-iterating through a C# list of `Point`s and creating `Graphics` in Razor markup.
+The simplest way to define custom graphics is using the Razor Component markup syntax. Below is an example of
+adding a single `Graphic` in Razor markup.
+
+***Note that iterating through collections in markup creates very poor performance and may cause crashing, especially in WebAssembly. See the C# example below for a better approach for multiple graphics.***
 
 ```html
 <MapView @ref="_view" class="map-view" OnMapRendered="OnMapRendered">
@@ -21,15 +22,12 @@ iterating through a C# list of `Point`s and creating `Graphics` in Razor markup.
     </Extent>
     <Map ArcGISDefaultBasemap="arcgis-topographic">
         <GraphicsLayer>
-            @foreach (Point graphicPoint in _graphicPoints.Count)
-            {
-                <Graphic>
-                    <Point Longitude="graphicPoint.Longitude" Latitude="graphicPoint.Latitude" />
-                    <SimpleMarkerSymbol Color="@(new MapColor("red"))" Size="6">
-                        <Outline Color="@(new MapColor("white"))" />
-                    </SimpleMarkerSymbol>
-                </Graphic>
-            }
+            <Graphic>
+                <Point Longitude="@_graphicPoint.Longitude" Latitude="@_graphicPoint.Latitude" />
+                <SimpleMarkerSymbol Color="@(new MapColor("red"))" Size="6">
+                    <Outline Color="@(new MapColor("white"))" />
+                </SimpleMarkerSymbol>
+            </Graphic>
         </GraphicsLayer>
     </Map>
 </MapView>
@@ -40,51 +38,25 @@ iterating through a C# list of `Point`s and creating `Graphics` in Razor markup.
 Both `MapView` and `GraphicsLayer` support programmatically adding graphics after the map view is rendered.
 
 1. `GraphicsLayer.Add(graphic)` and `GraphicsLayer.Add(graphics)` allows you to add single or multiple graphics to the layer.
+
 ```csharp
-await graphicsLayer.Add(new Graphic
-{
-    Geometry = new Point
-    {
-        Longitude = -118.80500,
-        Latitude = 34.02700
-    },
-    Symbol = new SimpleMarkerSymbol
-    {
-        Color = new MapColor("red"),
-        Size = 6,
-        Outline = new SimpleLineSymbol
-        {
-            Color = new MapColor("white")
-        }
-    }
-});
+await graphicsLayer.Add(new Graphic(new Point(-118.80500, 34.02700), new SimpleMarkerSymbol(new Outline(new MapColor("white"), new MapColor("red"))));
 ```
 
 2. `MapView.AddGraphic(graphic)` and `MapView.AddGraphics(graphics)` allows you to add single or multiple graphics to the map view.
+
 ```csharp
-await mapView.AddGraphic(new Graphic
-{
-    Geometry = new Point
-    {
-        Longitude = -118.80500,
-        Latitude = 34.02700
-    },
-    Symbol = new SimpleMarkerSymbol
-    {
-        Color = new MapColor("red"),
-        Size = 6,
-        Outline = new SimpleLineSymbol
-        {
-            Color = new MapColor("white")
-        }
-    }
-});
+await mapView.AddGraphic(new Graphic(new Point(-118.80500, 34.02700), new SimpleMarkerSymbol(new Outline(new MapColor("white"), new MapColor("red"))));
 ```
 
 Both classes also support `Remove` and `Clear` methods to remove or clear all graphics from the layer.
 
 Note that while you can define `Graphics` in a `FeatureLayer` via Razor Component markup, the `FeatureLayer` does not support
 altering the graphics collection (aka `Source`) after the map is rendered.
+
+## Multiple Graphics in a Collection
+
+For stable performance, *always* use `MapView.AddGraphics(IEnumerable&lt;Graphic&gt; graphics)` or `GraphicsLayer.Add(IEnumerable&lt;Graphic&gt; graphics)` to add collections of graphics, and do not define them in markup with a loop.
 
 ## Altering a Rendered Graphic
 

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ManyPoints.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ManyPoints.razor
@@ -1,0 +1,65 @@
+﻿@page "/many-points"
+
+<PageTitle>Many Points</PageTitle>
+<h1>Many Points</h1>
+<div class="links-div">
+    <a class="btn btn-secondary" target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-Graphic.html">ArcGIS API for JavaScript</a>
+</div>
+<p class="instructions">
+    GeoBlazor can support a large number of geometries, such as the 2000 points generated and shown in this example.
+    In order to get performant rendering of your graphics, be sure to call <code>MapView.AddGraphics(IEnumerable&lt;Graphic&gt;)</code> or <code>GraphicsLayer.Add(IEnumerable&lt;Graphic&gt;)</code>,
+    rather than trying to add all the graphics individually. It should take just a few seconds to load all the graphics in this example.
+</p>
+
+<div>
+    <MapView @ref="_mapView" Longitude="_longitude" Latitude="_latitude" Zoom="9" Style="height: 400px; width: 100%;"
+             OnMapRendered="OnMapRendered">
+        <Map ArcGISDefaultBasemap="arcgis-topographic">
+        </Map>
+    </MapView>
+</div>
+
+
+@code
+{
+    private async Task OnMapRendered()
+    {
+        if (!_pointsAdded)
+        {
+            _pointsAdded = true;
+            await AddManyPoints();
+        }
+    }
+
+    private async Task AddManyPoints()
+    {
+        // simulate getting a lot of points from somewhere
+        var points = await Task.Run(() => GenerateSomePoints(34.027, -118.805, 2000));
+
+        // convert these points to graphics
+        var graphics = points.Select(p => new Graphic(p, _mySymbol)).ToList();
+        Console.WriteLine($"{DateTime.Now} - Graphics Generated");
+        await _mapView!.AddGraphics(graphics);
+        Console.WriteLine($"{DateTime.Now} - Graphics Registered");
+    }
+
+
+    private static List<Point> GenerateSomePoints(double centerLat, double centerLong, int count = 10)
+    {
+        var data = new List<Point>();
+        for (int i = 0; i < count; i++)
+        {
+            var r = new Point(centerLong + Random.Shared.NextDouble(), centerLat + Random.Shared.NextDouble());
+            data.Add(r);
+        }
+
+        return data;
+    }
+    
+    private readonly double _latitude = 34.5; 
+    private readonly double _longitude = -118.5;
+    private MapView? _mapView;
+    private bool _pointsAdded;
+    private readonly SimpleMarkerSymbol _mySymbol = 
+        new SimpleMarkerSymbol(new Outline(new MapColor(255, 255, 255), 1), new MapColor(81, 46, 132));
+}

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ManyPoints.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ManyPoints.razor
@@ -8,17 +8,14 @@
 <p class="instructions">
     GeoBlazor can support a large number of geometries, such as the 2000 points generated and shown in this example.
     In order to get performant rendering of your graphics, be sure to call <code>MapView.AddGraphics(IEnumerable&lt;Graphic&gt;)</code> or <code>GraphicsLayer.Add(IEnumerable&lt;Graphic&gt;)</code>,
-    rather than trying to add all the graphics individually. It should take just a few seconds to load all the graphics in this example.
+    rather than trying to add all the graphics individually.
 </p>
 
-<div>
-    <MapView @ref="_mapView" Longitude="_longitude" Latitude="_latitude" Zoom="9" Style="height: 400px; width: 100%;"
-             OnMapRendered="OnMapRendered">
-        <Map ArcGISDefaultBasemap="arcgis-topographic">
-        </Map>
-    </MapView>
-</div>
-
+<MapView @ref="_mapView" Longitude="_longitude" Latitude="_latitude" Zoom="9" Style="height: 400px; width: 100%;"
+         OnMapRendered="OnMapRendered">
+    <Map ArcGISDefaultBasemap="arcgis-topographic">
+    </Map>
+</MapView>
 
 @code
 {
@@ -34,10 +31,14 @@
     private async Task AddManyPoints()
     {
         // simulate getting a lot of points from somewhere
-        var points = await Task.Run(() => GenerateSomePoints(34.027, -118.805, 2000));
+        List<Point> points = await Task.Run(() => GenerateSomePoints(34.027, -118.805, 2000));
 
         // convert these points to graphics
-        var graphics = points.Select(p => new Graphic(p, _mySymbol)).ToList();
+        var graphics = points.Select(p => new Graphic(p, _mySymbol, attributes: new Dictionary<string, object>()
+        {
+            {"Name", "My Point"},
+            {"Description", "This is a point"}
+        })).ToList();
         Console.WriteLine($"{DateTime.Now} - Graphics Generated");
         await _mapView!.AddGraphics(graphics);
         Console.WriteLine($"{DateTime.Now} - Graphics Registered");

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ManyPoints_MarkupTest.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ManyPoints_MarkupTest.razor
@@ -23,8 +23,8 @@
                                      {"Description", "This is a point"}
                                  })">
                 <Point Latitude="@point.Latitude" Longitude="@point.Longitude" />
-                <SimpleMarkerSymbol Color="new MapColor(81, 46, 132)">
-                    <Outline Color="new MapColor(255, 255, 255)" Width="1" />
+                <SimpleMarkerSymbol Color="@(new MapColor(81, 46, 132))">
+                    <Outline Color="@(new MapColor(255, 255, 255))" Width="1" />
                 </SimpleMarkerSymbol>
             </Graphic>
         }
@@ -37,7 +37,7 @@
     {
         if (_points is null)
         {
-            _points = GenerateSomePoints(34.027, -118.805, 50);
+            _points = GenerateSomePoints(34.027, -118.805, 425);
         }
     }
 

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ManyPoints_MarkupTest.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ManyPoints_MarkupTest.razor
@@ -1,0 +1,63 @@
+﻿@page "/many-points-markup"
+
+<PageTitle>Many Points</PageTitle>
+<h1>Many Points</h1>
+<div class="links-div">
+    <a class="btn btn-secondary" target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-Graphic.html">ArcGIS API for JavaScript</a>
+</div>
+<p class="instructions">
+    This file is simply to demonstrate the <b>WRONG</b> way to add lots of points to the map. It will cause lots of rendering loop issues and will continually drag down performance.
+</p>
+
+<MapView @ref="_mapView" Longitude="_longitude" Latitude="_latitude" Zoom="9" Style="height: 400px; width: 100%;"
+         OnMapRendered="OnMapRendered">
+    <Map ArcGISDefaultBasemap="arcgis-topographic">
+    </Map>
+    @if (_points is not null)
+    {
+        foreach (Point point in _points)
+        {
+            <Graphic Attributes="@(new Dictionary<string, object>()
+                                 {
+                                     {"Name", "Point"},
+                                     {"Description", "This is a point"}
+                                 })">
+                <Point Latitude="@point.Latitude" Longitude="@point.Longitude" />
+                <SimpleMarkerSymbol Color="new MapColor(81, 46, 132)">
+                    <Outline Color="new MapColor(255, 255, 255)" Width="1" />
+                </SimpleMarkerSymbol>
+            </Graphic>
+        }
+    }
+</MapView>
+
+@code
+{
+    private void OnMapRendered()
+    {
+        if (_points is null)
+        {
+            _points = GenerateSomePoints(34.027, -118.805, 50);
+        }
+    }
+
+
+    private static List<Point> GenerateSomePoints(double centerLat, double centerLong, int count = 10)
+    {
+        var data = new List<Point>();
+        for (int i = 0; i < count; i++)
+        {
+            var r = new Point(centerLong + Random.Shared.NextDouble(), centerLat + Random.Shared.NextDouble());
+            data.Add(r);
+        }
+
+        return data;
+    }
+    
+    private readonly double _latitude = 34.5; 
+    private readonly double _longitude = -118.5;
+    private MapView? _mapView;
+    private List<Point>? _points;
+    private readonly SimpleMarkerSymbol _mySymbol = 
+        new SimpleMarkerSymbol(new Outline(new MapColor(255, 255, 255), 1), new MapColor(81, 46, 132));
+}

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Tests.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Tests.razor
@@ -69,6 +69,13 @@
 
 </MapView>
 
+<h2>Delayed Render with Graphics</h2>
+<MapView @ref="_delayedMapView" Style="height: 600px; width: 100%;">
+    <Map>
+        <OpenStreetMapLayer />
+    </Map>
+</MapView>
+
 @code {
 
     private void OnMapRendered()
@@ -76,7 +83,7 @@
         _mapRendered = true;
     }
 
-    protected override void OnAfterRender(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         _lats.Clear();
         _longs.Clear();
@@ -84,6 +91,18 @@
         {
             _lats.Add(_random.NextDouble() * 10 + 50.0);
             _longs.Add(_random.NextDouble() * 10 + 11.0);
+        }
+
+        if (!_delayedMapSet && !firstRender)
+        {
+            List<Graphic> graphics = new();
+            for (var i = 0; i < 2000; i++)
+            {
+                graphics.Add(new Graphic(new Point(_random.NextDouble() * 10 + 11.0, 
+                    _random.NextDouble() * 10 + 50.0)));
+            }
+            await _delayedMapView!.AddGraphics(graphics);
+            _delayedMapSet = true;
         }
     }
 
@@ -165,4 +184,6 @@
     private readonly List<double> _lats = new();
     private readonly List<double> _longs = new();
     private MapView? _view3;
+    private MapView? _delayedMapView;
+    private bool _delayedMapSet;
 }

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Shared/NavMenu.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Shared/NavMenu.razor
@@ -71,6 +71,7 @@
         new("", "Home", "oi-home"),
         new("navigation", "Navigation", "oi-compass"),
         new("drawing", "Drawing", "oi-pencil"),
+        new("many-points", "Many Points", "oi-calculator"),
         new("scene", "Scene", "oi-globe"),
         new("widgets", "Widgets", "oi-location"),
         new("basemaps", "Basemaps", "oi-map"),

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/dymaptic.GeoBlazor.Core.Sample.Shared.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/dymaptic.GeoBlazor.Core.Sample.Shared.csproj
@@ -6,19 +6,19 @@
 
 
     <ItemGroup>
-        <SupportedPlatform Include="browser"/>
+        <SupportedPlatform Include="browser" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Markdig" Version="0.30.4"/>
-        <PackageReference Include="MarkdigExtensions.SyntaxHighlighting" Version="1.0.3"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="6.0.13"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.13"/>
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="6.0.0"/>
+        <PackageReference Include="Markdig" Version="0.30.4" />
+        <PackageReference Include="MarkdigExtensions.SyntaxHighlighting" Version="1.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="6.0.13" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.13" />
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\dymaptic.GeoBlazor.Core\dymaptic.GeoBlazor.Core.csproj"/>
+        <ProjectReference Include="..\..\src\dymaptic.GeoBlazor.Core\dymaptic.GeoBlazor.Core.csproj" />
     </ItemGroup>
 
     <ItemGroup>
@@ -29,10 +29,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="wwwroot\pages"/>
+        <Folder Include="wwwroot\pages" />
     </ItemGroup>
 
     <Target Name="Copy Razor Files" AfterTargets="Build">
-        <Exec Command="powershell .\razorCopy.ps1"/>
+        <Exec Command="pwsh .\razorCopy.ps1" />
     </Target>
 </Project>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/wwwroot/functions.js
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/wwwroot/functions.js
@@ -28,6 +28,14 @@ window.getCalciteSelectValue = (calciteSelect) => {
     return calciteSelect.selectedOption.value;
 }
 
+window.setWaitCursor = (wait) => {
+    if (wait) {
+        document.body.style.cursor = 'wait';
+    } else {
+        document.body.style.cursor = 'default';
+    }
+}
+
 function elementIsVisible(item) {
 
     let eleTop = item.offsetTop;

--- a/src/dymaptic.GeoBlazor.Core/Components/ActionBase.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/ActionBase.cs
@@ -14,7 +14,7 @@ namespace dymaptic.GeoBlazor.Core.Components;
 ///     </a>
 /// </summary>
 [JsonConverter(typeof(ActionBaseConverter))]
-public abstract class ActionBase : MapComponent
+public abstract class ActionBase : MapComponent, IEquatable<ActionBase>
 {
     /// <summary>
     ///     The title of the action.
@@ -77,6 +77,38 @@ public abstract class ActionBase : MapComponent
     internal virtual ActionBaseSerializationRecord ToSerializationRecord()
     {
         return new ActionBaseSerializationRecord(Title, ClassName, Active, Disabled, Visible, Id, Type);
+    }
+
+    public bool Equals(ActionBase? other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+
+        return Title == other.Title && ClassName == other.ClassName && Id == other.Id && Active == other.Active && 
+            Disabled == other.Disabled && Visible == other.Visible && 
+            Equals(CallbackFunction, other.CallbackFunction) && Type == other.Type;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (obj.GetType() != this.GetType()) return false;
+
+        return Equals((ActionBase)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Title, ClassName, Id, Active, Disabled, Visible, CallbackFunction, Type);
+    }
+
+    public static bool operator ==(ActionBase? left, ActionBase? right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(ActionBase? left, ActionBase? right)
+    {
+        return !Equals(left, right);
     }
 }
 

--- a/src/dymaptic.GeoBlazor.Core/Components/ActionBase.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/ActionBase.cs
@@ -79,6 +79,7 @@ public abstract class ActionBase : MapComponent, IEquatable<ActionBase>
         return new ActionBaseSerializationRecord(Title, ClassName, Active, Disabled, Visible, Id, Type);
     }
 
+    /// <inheritdoc />
     public bool Equals(ActionBase? other)
     {
         if (ReferenceEquals(null, other)) return false;
@@ -88,6 +89,7 @@ public abstract class ActionBase : MapComponent, IEquatable<ActionBase>
             Equals(CallbackFunction, other.CallbackFunction) && Type == other.Type;
     }
 
+    /// <inheritdoc />
     public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
@@ -96,16 +98,24 @@ public abstract class ActionBase : MapComponent, IEquatable<ActionBase>
         return Equals((ActionBase)obj);
     }
 
+    /// <inheritdoc />
     public override int GetHashCode()
     {
         return HashCode.Combine(Title, ClassName, Id, Active, Disabled, Visible, CallbackFunction, Type);
     }
 
+    /// <summary>
+    ///     Determines whether the specified <see cref="ActionBase" /> is equal to the current <see cref="ActionBase" />.
+    /// </summary>
+    /// <returns></returns>
     public static bool operator ==(ActionBase? left, ActionBase? right)
     {
         return Equals(left, right);
     }
 
+    /// <summary>
+    ///    Determines whether the specified <see cref="ActionBase" /> is not equal to the current <see cref="ActionBase" />.
+    /// </summary>
     public static bool operator !=(ActionBase? left, ActionBase? right)
     {
         return !Equals(left, right);

--- a/src/dymaptic.GeoBlazor.Core/Components/ActionBase.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/ActionBase.cs
@@ -73,6 +73,35 @@ public abstract class ActionBase : MapComponent
     ///     Specifies the type of action. Choose between "button" or "toggle".
     /// </summary>
     public virtual string Type { get; } = default!;
+    
+    internal virtual ActionBaseSerializationRecord ToSerializationRecord()
+    {
+        return new ActionBaseSerializationRecord(Title, ClassName, Active, Disabled, Visible, Id, Type);
+    }
+}
+
+[JsonConverter(typeof(ActionBaseSerializationConverter))]
+internal record ActionBaseSerializationRecord(
+        [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Title, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? ClassName, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]bool? Active, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]bool? Disabled, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]bool? Visible, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Id, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string Type) 
+    : MapComponentSerializationRecord;
+
+internal class ActionBaseSerializationConverter : JsonConverter<ActionBaseSerializationRecord>
+{
+    public override ActionBaseSerializationRecord? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void Write(Utf8JsonWriter writer, ActionBaseSerializationRecord value, JsonSerializerOptions options)
+    {
+        writer.WriteRawValue(JsonSerializer.Serialize(value, value.GetType(), options));
+    }
 }
 
 /// <summary>
@@ -92,7 +121,17 @@ public class ActionButton : ActionBase
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Image { get; set; }
+    
+    internal override ActionBaseSerializationRecord ToSerializationRecord()
+    {
+        return new ActionButtonSerializationRecord(Title, ClassName, Active, Disabled, Visible, Id, Type, Image);
+    }
 }
+
+internal record ActionButtonSerializationRecord(string? Title, string? ClassName, bool? Active, bool? Disabled, 
+    bool? Visible, string? Id, string Type, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Image) 
+    : ActionBaseSerializationRecord(Title, ClassName, Active, Disabled, Visible, Id, Type);
 
 /// <summary>
 ///     A customizable toggle used in the LayerList widget that performs a specific action(s) which can be toggled on/off.
@@ -108,7 +147,17 @@ public class ActionToggle : ActionBase
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Value { get; set; }
+    
+    internal override ActionBaseSerializationRecord ToSerializationRecord()
+    {
+        return new ActionToggleSerializationRecord(Title, ClassName, Active, Disabled, Visible, Id, Type, Value);
+    }
 }
+
+internal record ActionToggleSerializationRecord(string? Title, string? ClassName, bool? Active, bool? Disabled, 
+    bool? Visible, string? Id, string Type, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]bool? Value) 
+    : ActionBaseSerializationRecord(Title, ClassName, Active, Disabled, Visible, Id, Type);
 
 internal class ActionBaseConverter : JsonConverter<ActionBase>
 {

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/Extent.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/Extent.cs
@@ -138,7 +138,6 @@ public class Extent : Geometry, IEquatable<Extent>
     public bool Equals(Extent? other)
     {
         if (ReferenceEquals(null, other)) return false;
-        if (ReferenceEquals(this, other)) return true;
 
         return Xmax.Equals(other.Xmax) && Xmin.Equals(other.Xmin) && Ymax.Equals(other.Ymax) &&
             Ymin.Equals(other.Ymin) && Nullable.Equals(Zmax, other.Zmax) && Nullable.Equals(Zmin, other.Zmin) &&
@@ -149,7 +148,6 @@ public class Extent : Geometry, IEquatable<Extent>
     public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
-        if (ReferenceEquals(this, obj)) return true;
         if (obj.GetType() != GetType()) return false;
 
         return Equals((Extent)obj);

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/Extent.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/Extent.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using System.Text.Json.Serialization;
 
 
 namespace dymaptic.GeoBlazor.Core.Components.Geometries;
@@ -159,4 +160,18 @@ public class Extent : Geometry, IEquatable<Extent>
     {
         return HashCode.Combine(Xmax, Xmin, Ymax, Ymin, Zmax, Zmin, Mmax, Mmin);
     }
+
+    internal override GeometrySerializationRecord ToSerializationRecord()
+    {
+        return new ExtentSerializationRecord(Xmax, Xmin, Ymax, Ymin, Zmax, Zmin, Mmax, Mmin, 
+            SpatialReference?.ToSerializationRecord());
+    }
 }
+
+internal record ExtentSerializationRecord(double Xmax, double Xmin, double Ymax, double Ymin, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? Zmax = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? Zmin = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? Mmax = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? Mmin = null, 
+    SpatialReferenceSerializationRecord? SpatialReference = null): 
+    GeometrySerializationRecord("extent", null, SpatialReference);

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/Geometry.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/Geometry.cs
@@ -87,6 +87,31 @@ public class Geometry : MapComponent
         Extent?.ValidateRequiredChildren();
         SpatialReference?.ValidateRequiredChildren();
     }
+    
+    internal virtual GeometrySerializationRecord ToSerializationRecord()
+    {
+        return new GeometrySerializationRecord(Type, Extent?.ToSerializationRecord() as ExtentSerializationRecord, 
+            SpatialReference?.ToSerializationRecord());
+    }
+}
+
+[JsonConverter(typeof(GeometrySerializationConverter))]
+internal record GeometrySerializationRecord(string Type, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]ExtentSerializationRecord? Extent,
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]SpatialReferenceSerializationRecord? SpatialReference)
+    : MapComponentSerializationRecord;
+
+internal class GeometrySerializationConverter : JsonConverter<GeometrySerializationRecord>
+{
+    public override GeometrySerializationRecord? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void Write(Utf8JsonWriter writer, GeometrySerializationRecord value, JsonSerializerOptions options)
+    {
+        writer.WriteRawValue(JsonSerializer.Serialize(value, value.GetType(), options));
+    }
 }
 
 internal class GeometryConverter : JsonConverter<Geometry>
@@ -180,6 +205,6 @@ internal class GeometryTypeConverter : EnumToKebabCaseStringConverter<GeometryTy
             .Replace("Geometry", string.Empty)
             .Replace("Type", string.Empty);
 
-        return value is not null ? (GeometryType)Enum.Parse(typeof(GeometryType), value, true) : default(GeometryType)!;
+        return value is not null ? (GeometryType)Enum.Parse(typeof(GeometryType), value, true) : default(GeometryType);
     }
 }

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/Point.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/Point.cs
@@ -129,4 +129,20 @@ public class Point : Geometry, IEquatable<Point>
     {
         return HashCode.Combine(base.GetHashCode(), Latitude, Longitude, X, Y, Z);
     }
+
+    internal override GeometrySerializationRecord ToSerializationRecord()
+    {
+        return new PointSerializationRecord(Longitude, Latitude, X, Y, Z, SpatialReference?.ToSerializationRecord(),
+            Extent?.ToSerializationRecord() as ExtentSerializationRecord);
+    }
 }
+
+internal record PointSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? Longitude = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? Latitude = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? X = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? Y = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? Z = null, 
+    SpatialReferenceSerializationRecord? SpatialReference = null, 
+    ExtentSerializationRecord? Extent = null) 
+    : GeometrySerializationRecord("point", Extent, SpatialReference);

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/Point.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/Point.cs
@@ -108,8 +108,7 @@ public class Point : Geometry, IEquatable<Point>
     public bool Equals(Point? other)
     {
         if (ReferenceEquals(null, other)) return false;
-        if (ReferenceEquals(this, other)) return true;
-
+        
         return (Latitude.Equals(other.Latitude) && Longitude.Equals(other.Longitude)) ||
             (X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z));
     }
@@ -118,7 +117,6 @@ public class Point : Geometry, IEquatable<Point>
     public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
-        if (ReferenceEquals(this, obj)) return true;
         if (obj.GetType() != GetType()) return false;
 
         return Equals((Point)obj);

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/PolyLine.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/PolyLine.cs
@@ -92,4 +92,15 @@ public class PolyLine : Geometry, IEquatable<PolyLine>
     {
         return Paths.GetHashCode();
     }
+    
+    internal override GeometrySerializationRecord ToSerializationRecord()
+    {
+        return new PolyLineSerializationRecord(Paths, SpatialReference?.ToSerializationRecord(),
+            Extent?.ToSerializationRecord() as ExtentSerializationRecord);
+    }
 }
+
+internal record PolyLineSerializationRecord(MapPath[] Paths, 
+        SpatialReferenceSerializationRecord? SpatialReference = null, 
+        ExtentSerializationRecord? Extent = null)
+    : GeometrySerializationRecord("polyline", Extent, SpatialReference);

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/PolyLine.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/PolyLine.cs
@@ -72,7 +72,6 @@ public class PolyLine : Geometry, IEquatable<PolyLine>
     public bool Equals(PolyLine? other)
     {
         if (ReferenceEquals(null, other)) return false;
-        if (ReferenceEquals(this, other)) return true;
 
         return Paths.Equals(other.Paths);
     }
@@ -81,7 +80,6 @@ public class PolyLine : Geometry, IEquatable<PolyLine>
     public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
-        if (ReferenceEquals(this, obj)) return true;
         if (obj.GetType() != GetType()) return false;
 
         return Equals((PolyLine)obj);

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/Polygon.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/Polygon.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Objects;
 using Microsoft.AspNetCore.Components;
+using System.Text.Json.Serialization;
 
 
 namespace dymaptic.GeoBlazor.Core.Components.Geometries;
@@ -91,4 +92,15 @@ public class Polygon : Geometry, IEquatable<Polygon>
     {
         return Rings.GetHashCode();
     }
+
+    internal override GeometrySerializationRecord ToSerializationRecord()
+    {
+        return new PolygonSerializationRecord(Rings, SpatialReference?.ToSerializationRecord(),
+            Extent?.ToSerializationRecord() as ExtentSerializationRecord);
+    }
 }
+
+internal record PolygonSerializationRecord(MapPath[] Rings, 
+        SpatialReferenceSerializationRecord? SpatialReference = null, 
+        ExtentSerializationRecord? Extent = null)
+    : GeometrySerializationRecord("polygon", Extent, SpatialReference);

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/Polygon.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/Polygon.cs
@@ -72,7 +72,6 @@ public class Polygon : Geometry, IEquatable<Polygon>
     public bool Equals(Polygon? other)
     {
         if (ReferenceEquals(null, other)) return false;
-        if (ReferenceEquals(this, other)) return true;
 
         return Rings.Equals(other.Rings);
     }
@@ -81,7 +80,6 @@ public class Polygon : Geometry, IEquatable<Polygon>
     public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
-        if (ReferenceEquals(this, obj)) return true;
         if (obj.GetType() != GetType()) return false;
 
         return Equals((Polygon)obj);

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/SpatialReference.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/SpatialReference.cs
@@ -116,6 +116,11 @@ public class SpatialReference : MapComponent, IEquatable<SpatialReference>
     [Parameter]
     public string? Wkt { get; set; }
 
+    internal SpatialReferenceSerializationRecord ToSerializationRecord()
+    {
+        return new SpatialReferenceSerializationRecord(Wkid);
+    }
+
     /// <inheritdoc />
     public bool Equals(SpatialReference? other)
     {
@@ -219,3 +224,6 @@ internal class SpatialReferenceConverter : JsonConverter<SpatialReference>
         writer.WriteEndObject();
     }
 }
+
+internal record SpatialReferenceSerializationRecord([property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]int? Wkid)
+    : MapComponentSerializationRecord;

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayer.cs
@@ -477,7 +477,8 @@ public class FeatureLayer : Layer
     /// </param>
     public async Task<PopupTemplate> CreatePopupTemplate(CreatePopupTemplateOptions? options = null)
     {
-        return await JsLayerReference!.InvokeAsync<PopupTemplate>("createPopupTemplate", options);
+        return await JsLayerReference!.InvokeAsync<PopupTemplate>("createPopupTemplate", 
+            CancellationTokenSource.Token, options);
     }
 
     /// <summary>
@@ -489,7 +490,7 @@ public class FeatureLayer : Layer
     /// </summary>
     public async Task<Query> CreateQuery()
     {
-        return await JsLayerReference!.InvokeAsync<Query>("createQuery");
+        return await JsLayerReference!.InvokeAsync<Query>("createQuery", CancellationTokenSource.Token);
     }
 
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayerView.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayerView.cs
@@ -44,7 +44,7 @@ public class FeatureLayerView : LayerView
     /// </param>
     public async Task SetFilter(FeatureFilter? filter)
     {
-        await JsObjectReference!.InvokeVoidAsync("setFilter", filter);
+        await JsObjectReference!.InvokeVoidAsync("setFilter", CancellationTokenSource.Token, filter);
         Filter = filter;
     }
 
@@ -60,7 +60,8 @@ public class FeatureLayerView : LayerView
     public async Task<HighlightHandle> Highlight(int objectId)
     {
         IJSObjectReference objectRef =
-            await JsObjectReference!.InvokeAsync<IJSObjectReference>("highlight", objectId);
+            await JsObjectReference!.InvokeAsync<IJSObjectReference>("highlight", 
+                CancellationTokenSource.Token, objectId);
 
         return new HighlightHandle(objectRef);
     }
@@ -77,7 +78,8 @@ public class FeatureLayerView : LayerView
     public async Task<HighlightHandle> Highlight(IEnumerable<int> objectIds)
     {
         IJSObjectReference objectRef =
-            await JsObjectReference!.InvokeAsync<IJSObjectReference>("highlight", objectIds);
+            await JsObjectReference!.InvokeAsync<IJSObjectReference>("highlight", 
+                CancellationTokenSource.Token, objectIds);
 
         return new HighlightHandle(objectRef);
     }
@@ -94,7 +96,8 @@ public class FeatureLayerView : LayerView
     public async Task<HighlightHandle> Highlight(Graphic graphic)
     {
         IJSObjectReference objectRef =
-            await JsObjectReference!.InvokeAsync<IJSObjectReference>("highlight", graphic);
+            await JsObjectReference!.InvokeAsync<IJSObjectReference>("highlight", 
+                CancellationTokenSource.Token, graphic);
 
         return new HighlightHandle(objectRef);
     }
@@ -111,7 +114,8 @@ public class FeatureLayerView : LayerView
     public async Task<HighlightHandle> Highlight(IEnumerable<Graphic> graphics)
     {
         IJSObjectReference objectRef =
-            await JsObjectReference!.InvokeAsync<IJSObjectReference>("highlight", graphics);
+            await JsObjectReference!.InvokeAsync<IJSObjectReference>("highlight", 
+                CancellationTokenSource.Token, graphics);
 
         return new HighlightHandle(objectRef);
     }
@@ -125,7 +129,7 @@ public class FeatureLayerView : LayerView
     /// </summary>
     public async Task<Query> CreateQuery()
     {
-        return await JsObjectReference!.InvokeAsync<Query>("createQuery");
+        return await JsObjectReference!.InvokeAsync<Query>("createQuery", CancellationTokenSource.Token);
     }
 
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/GraphicsLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/GraphicsLayer.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.JSInterop;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 
@@ -87,10 +88,25 @@ public class GraphicsLayer : Layer
     /// </param>
     public async Task Add(IEnumerable<Graphic> graphics)
     {
-        foreach (Graphic graphic in graphics)
+        List<Graphic> newGraphics = graphics.ToList();
+        _graphics.UnionWith(newGraphics);
+        foreach (Graphic graphic in newGraphics)
         {
-            await RegisterChildComponent(graphic);
+            graphic.View ??= View;
+            graphic.JsModule ??= JsModule;
+            graphic.LayerId ??= Id;
+            graphic.Parent ??= this;
         }
+
+        if (JsLayerReference is null)
+        {
+            LayerChanged = true;
+
+            return;
+        }
+
+        IEnumerable<GraphicSerializationRecord> records = newGraphics.Select(g => g.ToSerializationRecord());
+        await JsLayerReference!.InvokeVoidAsync("addMany", records, View?.Id);
     }
 
     /// <summary>
@@ -135,14 +151,12 @@ public class GraphicsLayer : Layer
         switch (child)
         {
             case Graphic graphic:
-                if (!_graphics.Any(g => g.Equals(graphic)))
+                graphic.View ??= View;
+                graphic.JsModule ??= JsModule;
+                graphic.LayerId ??= Id;
+                graphic.Parent ??= this;
+                if (_graphics.Add(graphic))
                 {
-                    graphic.View ??= View;
-                    graphic.JsModule ??= JsModule;
-                    graphic.LayerId ??= Id;
-                    graphic.Parent ??= this;
-                    _graphics.Add(graphic);
-
                     if (JsLayerReference is not null)
                     {
                         await JsLayerReference.InvokeVoidAsync("add", graphic, View?.Id);

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/GraphicsLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/GraphicsLayer.cs
@@ -106,7 +106,8 @@ public class GraphicsLayer : Layer
         }
 
         IEnumerable<GraphicSerializationRecord> records = newGraphics.Select(g => g.ToSerializationRecord());
-        await JsLayerReference!.InvokeVoidAsync("addMany", records, View?.Id);
+        await JsLayerReference!.InvokeVoidAsync("addMany", 
+            CancellationTokenSource.Token, records, View?.Id);
     }
 
     /// <summary>
@@ -159,7 +160,9 @@ public class GraphicsLayer : Layer
                 {
                     if (JsLayerReference is not null)
                     {
-                        await JsLayerReference.InvokeVoidAsync("add", graphic, View?.Id);
+                        GraphicSerializationRecord record = graphic.ToSerializationRecord();
+                        await JsLayerReference.InvokeVoidAsync("add", 
+                            CancellationTokenSource.Token, record, View?.Id);
                     }
                     else
                     {
@@ -183,7 +186,15 @@ public class GraphicsLayer : Layer
             case Graphic graphic:
                 if (_graphics.Remove(graphic) && JsLayerReference is not null)
                 {
-                    await JsLayerReference.InvokeVoidAsync("remove", graphic);
+                    try
+                    {
+                        await JsLayerReference.InvokeVoidAsync("remove", 
+                            CancellationTokenSource.Token, graphic);
+                    }
+                    catch
+                    {
+                        // object disposed
+                    }
                 }
                 else
                 {
@@ -233,7 +244,8 @@ public class GraphicsLayer : Layer
         {
             if (!graphic.IsRendered)
             {
-                await JsLayerReference!.InvokeVoidAsync("add", graphic);
+                await JsLayerReference!.InvokeVoidAsync("add", 
+                    CancellationTokenSource.Token, graphic);
             }
         }
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/Layer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/Layer.cs
@@ -137,6 +137,8 @@ public abstract class Layer : MapComponent
             await AbortManager.DisposeAsync();
         }
 
+        LayerView?.Dispose();
+
         await base.DisposeAsync();
     }
 
@@ -158,7 +160,6 @@ public abstract class Layer : MapComponent
         IJSObjectReference arcGisJsInterop = await GetArcGisJsInterop();
 
         JsLayerReference = await arcGisJsInterop.InvokeAsync<IJSObjectReference>("createLayer",
-
             // ReSharper disable once RedundantCast
             cancellationToken, (object)this, true, View?.Id);
         await JsLayerReference.InvokeVoidAsync("load", cancellationToken, abortSignal);
@@ -194,7 +195,8 @@ public abstract class Layer : MapComponent
         if ((!MapRendered && JsLayerReference is null) || JsModule is null) return;
 
         // ReSharper disable once RedundantCast
-        await JsModule!.InvokeVoidAsync("updateLayer", (object)this, View!.Id);
+        await JsModule!.InvokeVoidAsync("updateLayer", CancellationTokenSource.Token, 
+            (object)this, View!.Id);
     }
 
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/LayerObject.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/LayerObject.cs
@@ -1,4 +1,5 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Symbols;
+using Microsoft.JSInterop;
 using System.Text.Json.Serialization;
 
 
@@ -33,7 +34,13 @@ public abstract class LayerObject : MapComponent
     /// </param>
     public async Task SetSymbol(Symbol symbol)
     {
-        await RegisterChildComponent(symbol);
+        Symbol = symbol;
+
+        if (JsObjectReference is not null)
+        {
+            await JsObjectReference.InvokeVoidAsync("setSymbol", 
+                Symbol.ToSerializationRecord());
+        }
     }
 
     /// <inheritdoc />
@@ -42,10 +49,12 @@ public abstract class LayerObject : MapComponent
         switch (child)
         {
             case Symbol symbol:
-                if (!symbol.Equals(Symbol))
+                if (View?.ExtentChangedInJs == true)
                 {
-                    Symbol = symbol;
+                    return;
                 }
+                
+                await SetSymbol(symbol);
 
                 break;
             default:
@@ -77,4 +86,6 @@ public abstract class LayerObject : MapComponent
         base.ValidateRequiredChildren();
         Symbol?.ValidateRequiredChildren();
     }
+    
+    protected IJSObjectReference? JsObjectReference = null!;
 }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/LayerObject.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/LayerObject.cs
@@ -87,5 +87,8 @@ public abstract class LayerObject : MapComponent
         Symbol?.ValidateRequiredChildren();
     }
     
+    /// <summary>
+    ///    The <see cref="IJSObjectReference" /> for the layer object.
+    /// </summary>
     protected IJSObjectReference? JsObjectReference = null!;
 }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/LayerView.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/LayerView.cs
@@ -10,7 +10,7 @@ namespace dymaptic.GeoBlazor.Core.Components.Layers;
 ///         JS API
 ///     </a>
 /// </summary>
-public class LayerView
+public class LayerView: IDisposable
 {
     /// <summary>
     ///     The layer being viewed.
@@ -41,6 +41,28 @@ public class LayerView
     ///     Value is true when the layer is updating; for example, if it is in the process of fetching data.
     /// </summary>
     public bool Visible { get; init; }
+
+    private void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            CancellationTokenSource.Cancel();
+        }
+    }
+
+    /// <summary>
+    ///    Disposes the LayerView.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    ///    Creates a cancellation token to control external calls
+    /// </summary>
+    protected CancellationTokenSource CancellationTokenSource = new();
 }
 
 #pragma warning disable CS1574, CS0419

--- a/src/dymaptic.GeoBlazor.Core/Components/MapComponent.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/MapComponent.razor.cs
@@ -110,6 +110,8 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable
                 // it's fine
             }
         }
+        
+        CancellationTokenSource.Cancel();
     }
 
     /// <summary>
@@ -243,7 +245,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable
     /// </param>
     public async Task SetVisibility(bool visible)
     {
-        await JsModule!.InvokeVoidAsync("setVisibility", Id, visible);
+        await JsModule!.InvokeVoidAsync("setVisibility", CancellationTokenSource.Token, Id, visible);
     }
 
     /// <inheritdoc />
@@ -297,13 +299,13 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable
             case >= 100:
                 // this is here to support the pro extension library
                 IJSObjectReference proModule = await JsRuntime
-                    .InvokeAsync<IJSObjectReference>("import",
+                    .InvokeAsync<IJSObjectReference>("import", CancellationTokenSource.Token,
                         "./_content/dymaptic.GeoBlazor.Pro/js/arcGisPro.js");
 
                 return await proModule.InvokeAsync<IJSObjectReference>("getCore");
             default:
                 return await JsRuntime
-                    .InvokeAsync<IJSObjectReference>("import",
+                    .InvokeAsync<IJSObjectReference>("import", CancellationTokenSource.Token,
                         "./_content/dymaptic.GeoBlazor.Core/js/arcGisJsInterop.js");
         }
     }
@@ -318,12 +320,17 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable
         switch ((int)licenseType)
         {
             case >= 100:
-                return await JsRuntime.InvokeAsync<IJSObjectReference>("import",
+                return await JsRuntime.InvokeAsync<IJSObjectReference>("import", CancellationTokenSource.Token,
                     "./_content/dymaptic.GeoBlazor.Pro/js/arcGisPro.js");
             default:
                 return null;
         }
     }
+
+    /// <summary>
+    ///    Creates a cancellation token to control external calls
+    /// </summary>
+    protected CancellationTokenSource CancellationTokenSource = new();
 
     private readonly Dictionary<string, (Delegate Handler, IJSObjectReference JsObjRef)> _watchers = new();
     private readonly Dictionary<string, (Delegate Handler, IJSObjectReference JsObjRef)> _listeners = new();

--- a/src/dymaptic.GeoBlazor.Core/Components/MapComponent.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/MapComponent.razor.cs
@@ -779,3 +779,5 @@ internal class MapComponentConverter : JsonConverter<MapComponent>
         writer.WriteRawValue(JsonSerializer.Serialize(value, typeof(object), newOptions));
     }
 }
+
+internal record MapComponentSerializationRecord;

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/AttachmentsPopupContent.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/AttachmentsPopupContent.cs
@@ -37,4 +37,15 @@ public class AttachmentsPopupContent : PopupContent
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Title { get; set; }
+
+    internal override PopupContentSerializationRecord ToSerializationRecord()
+    {
+        return new AttachmentsPopupContentSerializationRecord(Description, DisplayType, Title);
+    }
 }
+
+internal record AttachmentsPopupContentSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Description, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? DisplayType, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Title) 
+    : PopupContentSerializationRecord("attachments");

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/ExpressionInfo.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/ExpressionInfo.cs
@@ -56,6 +56,7 @@ public class ExpressionInfo : MapComponent, IEquatable<ExpressionInfo>
         return new(Expression, Name, Title, ReturnType);
     }
 
+    /// <inheritdoc />
     public bool Equals(ExpressionInfo? other)
     {
         if (ReferenceEquals(null, other)) return false;
@@ -64,6 +65,7 @@ public class ExpressionInfo : MapComponent, IEquatable<ExpressionInfo>
             ReturnType == other.ReturnType;
     }
 
+    /// <inheritdoc />
     public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
@@ -72,16 +74,23 @@ public class ExpressionInfo : MapComponent, IEquatable<ExpressionInfo>
         return Equals((ExpressionInfo)obj);
     }
 
+    /// <inheritdoc />
     public override int GetHashCode()
     {
         return HashCode.Combine(Expression, Name, Title, ReturnType);
     }
 
+    /// <summary>
+    ///    Equality operator.
+    /// </summary>
     public static bool operator ==(ExpressionInfo? left, ExpressionInfo? right)
     {
         return Equals(left, right);
     }
 
+    /// <summary>
+    ///    Inequality operator.
+    /// </summary>
     public static bool operator !=(ExpressionInfo? left, ExpressionInfo? right)
     {
         return !Equals(left, right);

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/ExpressionInfo.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/ExpressionInfo.cs
@@ -17,7 +17,7 @@ namespace dymaptic.GeoBlazor.Core.Components.Popups;
 ///         API for JS
 ///     </a>
 /// </summary>
-public class ExpressionInfo : MapComponent
+public class ExpressionInfo : MapComponent, IEquatable<ExpressionInfo>
 {
     /// <summary>
     ///     An Arcade expression following the specification defined by the Arcade Popup Profile. Expressions must return a
@@ -54,6 +54,37 @@ public class ExpressionInfo : MapComponent
     internal ExpressionInfoSerializationRecord ToSerializationRecord()
     {
         return new(Expression, Name, Title, ReturnType);
+    }
+
+    public bool Equals(ExpressionInfo? other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+
+        return Expression == other.Expression && Name == other.Name && Title == other.Title && 
+            ReturnType == other.ReturnType;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (obj.GetType() != this.GetType()) return false;
+
+        return Equals((ExpressionInfo)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Expression, Name, Title, ReturnType);
+    }
+
+    public static bool operator ==(ExpressionInfo? left, ExpressionInfo? right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(ExpressionInfo? left, ExpressionInfo? right)
+    {
+        return !Equals(left, right);
     }
 }
 

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/ExpressionInfo.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/ExpressionInfo.cs
@@ -50,7 +50,19 @@ public class ExpressionInfo : MapComponent
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ReturnType? ReturnType { get; set; }
+    
+    internal ExpressionInfoSerializationRecord ToSerializationRecord()
+    {
+        return new(Expression, Name, Title, ReturnType);
+    }
 }
+
+internal record ExpressionInfoSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Expression, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Name, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Title,
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]ReturnType? ReturnType) 
+    : MapComponentSerializationRecord;
 
 /// <summary>
 ///     Indicates the return type of the Arcade expression.

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/ExpressionPopupContent.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/ExpressionPopupContent.cs
@@ -32,7 +32,16 @@ public class ExpressionPopupContent : PopupContent
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ElementExpressionInfo? ExpressionInfo { get; set; }
+    
+    internal override PopupContentSerializationRecord ToSerializationRecord()
+    {
+        return new ExpressionPopupContentSerializationRecord(ExpressionInfo);
+    }
 }
+
+internal record ExpressionPopupContentSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]ElementExpressionInfo? ExpressionInfo) 
+    : PopupContentSerializationRecord("expression");
 
 /// <summary>
 ///     Defines an Arcade expression used to create an ExpressionContent element in a PopupTemplate. The expression must

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldInfo.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldInfo.cs
@@ -59,11 +59,17 @@ public class FieldInfo : MapComponent, IEquatable<FieldInfo>
 #pragma warning restore BL0005
     }
 
+    /// <summary>
+    ///    Equality operator
+    /// </summary>
     public static bool operator ==(FieldInfo? left, FieldInfo? right)
     {
         return Equals(left, right);
     }
 
+    /// <summary>
+    ///    Inequality operator
+    /// </summary>
     public static bool operator !=(FieldInfo? left, FieldInfo? right)
     {
         return !Equals(left, right);
@@ -117,6 +123,7 @@ public class FieldInfo : MapComponent, IEquatable<FieldInfo>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public FieldInfoFormat? Format { get; set; }
 
+    /// <inheritdoc />
     public bool Equals(FieldInfo? other)
     {
         if (ReferenceEquals(null, other)) return false;
@@ -169,6 +176,7 @@ public class FieldInfo : MapComponent, IEquatable<FieldInfo>
         Format?.ValidateRequiredChildren();
     }
 
+    /// <inheritdoc />
     public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
@@ -177,6 +185,7 @@ public class FieldInfo : MapComponent, IEquatable<FieldInfo>
         return Equals((FieldInfo)obj);
     }
 
+    /// <inheritdoc />
     public override int GetHashCode()
     {
         return HashCode.Combine(FieldName, Label, IsEditable, Tooltip, Visible, StringFieldOption, Format);

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldInfo.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldInfo.cs
@@ -149,4 +149,20 @@ public class FieldInfo : MapComponent
         base.ValidateRequiredChildren();
         Format?.ValidateRequiredChildren();
     }
+    
+    internal FieldInfoSerializationRecord ToSerializationRecord()
+    {
+        return new FieldInfoSerializationRecord(FieldName, Label, Tooltip, StringFieldOption, 
+            Format?.ToSerializationRecord(), IsEditable, Visible);
+    }
 }
+
+internal record FieldInfoSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? FieldName = null,
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Label = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Tooltip = null,
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? StringFieldOption = null,
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]FieldInfoFormatSerializationRecord? Format = null,
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]bool? IsEditable = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]bool? Visible = null) 
+    : MapComponentSerializationRecord;

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldInfo.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldInfo.cs
@@ -11,7 +11,7 @@ namespace dymaptic.GeoBlazor.Core.Components.Popups;
 ///         JS API
 ///     </a>
 /// </summary>
-public class FieldInfo : MapComponent
+public class FieldInfo : MapComponent, IEquatable<FieldInfo>
 {
     /// <summary>
     ///     Parameterless constructor for using as a razor component
@@ -57,6 +57,16 @@ public class FieldInfo : MapComponent
         IsEditable = isEditable;
         Visible = visible;
 #pragma warning restore BL0005
+    }
+
+    public static bool operator ==(FieldInfo? left, FieldInfo? right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(FieldInfo? left, FieldInfo? right)
+    {
+        return !Equals(left, right);
     }
 
     /// <summary>
@@ -107,6 +117,15 @@ public class FieldInfo : MapComponent
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public FieldInfoFormat? Format { get; set; }
 
+    public bool Equals(FieldInfo? other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+
+        return (FieldName == other.FieldName) && (Label == other.Label) && (IsEditable == other.IsEditable) &&
+            (Tooltip == other.Tooltip) && (Visible == other.Visible) &&
+            (StringFieldOption == other.StringFieldOption) && Equals(Format, other.Format);
+    }
+
     /// <inheritdoc />
     public override async Task RegisterChildComponent(MapComponent child)
     {
@@ -149,20 +168,39 @@ public class FieldInfo : MapComponent
         base.ValidateRequiredChildren();
         Format?.ValidateRequiredChildren();
     }
-    
+
+    public override bool Equals(object? obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (obj.GetType() != GetType()) return false;
+
+        return Equals((FieldInfo)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(FieldName, Label, IsEditable, Tooltip, Visible, StringFieldOption, Format);
+    }
+
     internal FieldInfoSerializationRecord ToSerializationRecord()
     {
-        return new FieldInfoSerializationRecord(FieldName, Label, Tooltip, StringFieldOption, 
+        return new FieldInfoSerializationRecord(FieldName, Label, Tooltip, StringFieldOption,
             Format?.ToSerializationRecord(), IsEditable, Visible);
     }
 }
 
-internal record FieldInfoSerializationRecord(
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? FieldName = null,
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Label = null, 
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Tooltip = null,
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? StringFieldOption = null,
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]FieldInfoFormatSerializationRecord? Format = null,
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]bool? IsEditable = null, 
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]bool? Visible = null) 
+internal record FieldInfoSerializationRecord([property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        string? FieldName = null,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        string? Label = null,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        string? Tooltip = null,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        string? StringFieldOption = null,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        FieldInfoFormatSerializationRecord? Format = null,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        bool? IsEditable = null,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        bool? Visible = null)
     : MapComponentSerializationRecord;

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldInfoFormat.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldInfoFormat.cs
@@ -63,4 +63,15 @@ public class FieldInfoFormat : MapComponent
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? DateFormat { get; set; }
+    
+    internal FieldInfoFormatSerializationRecord ToSerializationRecord()
+    {
+        return new FieldInfoFormatSerializationRecord(Places, DigitSeparator, DateFormat);
+    }
 }
+
+internal record FieldInfoFormatSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]int? Places,
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]bool? DigitSeparator,
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? DateFormat) 
+    : MapComponentSerializationRecord;

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldsPopupContent.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldsPopupContent.cs
@@ -127,4 +127,15 @@ public class FieldsPopupContent : PopupContent
             }
         }
     }
+
+    internal override PopupContentSerializationRecord ToSerializationRecord()
+    {
+        return new FieldsPopupContentSerializationRecord(FieldInfos?.ToArray(), Description, Title);
+    }
 }
+
+internal record FieldsPopupContentSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]FieldInfo[]? FieldInfos, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Description = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Title = null)
+    : PopupContentSerializationRecord("fields");

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/MediaInfo.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/MediaInfo.cs
@@ -15,6 +15,24 @@ public abstract class MediaInfo : MapComponent
     ///     Indicates the type of media
     /// </summary>
     public abstract string Type { get; }
+    
+    internal abstract MediaInfoSerializationRecord ToSerializationRecord();
+}
+
+[JsonConverter(typeof(MediaInfoSerializationConverter))]
+internal record MediaInfoSerializationRecord(string Type): MapComponentSerializationRecord;
+
+internal class MediaInfoSerializationConverter : JsonConverter<MediaInfoSerializationRecord>
+{
+    public override MediaInfoSerializationRecord? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void Write(Utf8JsonWriter writer, MediaInfoSerializationRecord value, JsonSerializerOptions options)
+    {
+        writer.WriteRawValue(JsonSerializer.Serialize(value, value.GetType(), options));
+    }
 }
 
 /// <summary>
@@ -94,7 +112,19 @@ public class BarChartMediaInfo : MediaInfo
         base.ValidateRequiredChildren();
         Value?.ValidateRequiredChildren();
     }
+    
+    internal override MediaInfoSerializationRecord ToSerializationRecord()
+    {
+        return new BarChartMediaInfoSerializationRecord(AltText, Caption, Title, Value?.ToSerializationRecord());
+    }
 }
+
+internal record BarChartMediaInfoSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? AltText, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Caption, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Title, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]ChartMediaInfoValueSerializationRecord? Value)
+    : MediaInfoSerializationRecord("bar-chart");
 
 /// <summary>
 ///     The ChartMediaInfoValue class contains information for popups regarding how charts should be constructed.
@@ -185,7 +215,19 @@ public class ChartMediaInfoValue : MapComponent
             }
         }
     }
+    
+    internal ChartMediaInfoValueSerializationRecord ToSerializationRecord()
+    {
+        return new ChartMediaInfoValueSerializationRecord(Fields, NormalizeField, TooltipField, 
+            Series?.Select(s => s.ToSerializationRecord()));
+    }
 }
+
+internal record ChartMediaInfoValueSerializationRecord(IEnumerable<string> Fields, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? NormalizeField, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? TooltipField, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]IEnumerable<ChartMediaInfoValueSeriesSerializationRecord>? Series)
+    : MapComponentSerializationRecord;
 
 /// <summary>
 ///     The ChartMediaInfoValueSeries class is a read-only support class that represents information specific to how data
@@ -246,7 +288,18 @@ public class ChartMediaInfoValueSeries : MapComponent
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public double? Value { get; set; }
+    
+    internal ChartMediaInfoValueSeriesSerializationRecord ToSerializationRecord()
+    {
+        return new ChartMediaInfoValueSeriesSerializationRecord(FieldName, Tooltip, Value);
+    }
 }
+
+internal record ChartMediaInfoValueSeriesSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? FieldName, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Tooltip, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? Value)
+    : MapComponentSerializationRecord;
 
 /// <summary>
 ///     A ColumnChartMediaInfo is a type of chart media element that represents a column chart displayed within a popup.
@@ -325,7 +378,19 @@ public class ColumnChartMediaInfo : MediaInfo
         base.ValidateRequiredChildren();
         Value?.ValidateRequiredChildren();
     }
+    
+    internal override MediaInfoSerializationRecord ToSerializationRecord()
+    {
+        return new ColumnChartMediaInfoSerializationRecord(AltText, Caption, Title, Value?.ToSerializationRecord());
+    }
 }
+
+internal record ColumnChartMediaInfoSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? AltText, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Caption, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Title, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]ChartMediaInfoValueSerializationRecord? Value)
+    : MediaInfoSerializationRecord("column-chart");
 
 /// <summary>
 ///     An ImageMediaInfo is a type of media element that represents images to display within a popup.
@@ -413,7 +478,21 @@ public class ImageMediaInfo : MediaInfo
         base.ValidateRequiredChildren();
         Value?.ValidateRequiredChildren();
     }
+    
+    internal override MediaInfoSerializationRecord ToSerializationRecord()
+    {
+        return new ImageMediaInfoSerializationRecord(AltText, Caption, Title, Value?.ToSerializationRecord(), 
+            RefreshInterval);
+    }
 }
+
+internal record ImageMediaInfoSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? AltText, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Caption, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Title, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]ImageMediaInfoValueSerializationRecord? Value,
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? RefreshInterval)
+    : MediaInfoSerializationRecord("image-media");
 
 /// <summary>
 ///     The ImageMediaInfoValue class contains information for popups regarding how images should be retrieved.
@@ -437,7 +516,17 @@ public class ImageMediaInfoValue : MapComponent
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? SourceURL { get; set; }
+    
+    internal ImageMediaInfoValueSerializationRecord ToSerializationRecord()
+    {
+        return new(LinkURL, SourceURL);
+    }
 }
+
+internal record ImageMediaInfoValueSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? LinkURL, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? SourceURL)
+    : MapComponentSerializationRecord;
 
 /// <summary>
 ///     A LineChartMediaInfo is a type of chart media element that represents a line chart displayed within a popup.
@@ -516,7 +605,19 @@ public class LineChartMediaInfo : MediaInfo
         base.ValidateRequiredChildren();
         Value?.ValidateRequiredChildren();
     }
+    
+    internal override MediaInfoSerializationRecord ToSerializationRecord()
+    {
+        return new LineChartMediaInfoSerializationRecord(AltText, Caption, Title, Value?.ToSerializationRecord());
+    }
 }
+
+internal record LineChartMediaInfoSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? AltText, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Caption, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Title, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]ChartMediaInfoValueSerializationRecord? Value)
+    : MediaInfoSerializationRecord("line-chart");
 
 /// <summary>
 ///     A PieChartMediaInfo is a type of chart media element that represents a pie chart displayed within a popup.
@@ -595,7 +696,19 @@ public class PieChartMediaInfo : MediaInfo
         base.ValidateRequiredChildren();
         Value?.ValidateRequiredChildren();
     }
+    
+    internal override MediaInfoSerializationRecord ToSerializationRecord()
+    {
+        return new PieChartMediaInfoSerializationRecord(AltText, Caption, Title, Value?.ToSerializationRecord());
+    }
 }
+
+internal record PieChartMediaInfoSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? AltText, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Caption, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Title, 
+    ChartMediaInfoValueSerializationRecord? Value)
+    : MediaInfoSerializationRecord("pie-chart");
 
 internal class MediaInfoConverter : JsonConverter<MediaInfo>
 {

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/MediaPopupContent.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/MediaPopupContent.cs
@@ -92,4 +92,17 @@ public class MediaPopupContent : PopupContent
             }
         }
     }
+    
+    internal override PopupContentSerializationRecord ToSerializationRecord()
+    {
+        return new MediaPopupContentSerializationRecord(ActiveMediaInfoIndex, Description, Title, 
+            MediaInfos?.Select(x => x.ToSerializationRecord()));
+    }
 }
+
+internal record MediaPopupContentSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? ActiveMediaInfoIndex,
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Description, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Title,
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]IEnumerable<MediaInfoSerializationRecord>? MediaInfos)
+    : PopupContentSerializationRecord("media");

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/PopupContent.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/PopupContent.cs
@@ -19,6 +19,27 @@ public abstract class PopupContent : MapComponent
     /// </summary>
     [JsonPropertyName("type")]
     public abstract string Type { get; }
+    
+    internal virtual PopupContentSerializationRecord ToSerializationRecord()
+    {
+        return new PopupContentSerializationRecord(Type);
+    }
+}
+
+[JsonConverter(typeof(PopupContentSerializationConverter))]
+internal record PopupContentSerializationRecord(string Type) : MapComponentSerializationRecord;
+
+internal class PopupContentSerializationConverter : JsonConverter<PopupContentSerializationRecord>
+{
+    public override PopupContentSerializationRecord? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void Write(Utf8JsonWriter writer, PopupContentSerializationRecord value, JsonSerializerOptions options)
+    {
+        writer.WriteRawValue(JsonSerializer.Serialize(value, value.GetType(), options));
+    }
 }
 
 internal class PopupContentConverter : JsonConverter<PopupContent>

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/PopupTemplate.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/PopupTemplate.cs
@@ -89,11 +89,17 @@ public class PopupTemplate : MapComponent, IEquatable<PopupTemplate>
 #pragma warning restore BL0005
     }
 
+    /// <summary>
+    ///     Equality operator
+    /// </summary>
     public static bool operator ==(PopupTemplate? left, PopupTemplate? right)
     {
         return Equals(left, right);
     }
 
+    /// <summary>
+    ///     Inequality operator
+    /// </summary>
     public static bool operator !=(PopupTemplate? left, PopupTemplate? right)
     {
         return !Equals(left, right);
@@ -191,6 +197,7 @@ public class PopupTemplate : MapComponent, IEquatable<PopupTemplate>
     /// </summary>
     public DotNetObjectReference<PopupTemplate> DotNetPopupTemplateReference => DotNetObjectReference.Create(this);
 
+    /// <inheritdoc />
     public bool Equals(PopupTemplate? other)
     {
         if (ReferenceEquals(null, other)) return false;
@@ -330,6 +337,7 @@ public class PopupTemplate : MapComponent, IEquatable<PopupTemplate>
         }
     }
 
+    /// <inheritdoc />
     public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
@@ -338,6 +346,7 @@ public class PopupTemplate : MapComponent, IEquatable<PopupTemplate>
         return Equals((PopupTemplate)obj);
     }
 
+    /// <inheritdoc />
     public override int GetHashCode()
     {
         var hashCode = new HashCode();

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/PopupTemplate.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/PopupTemplate.cs
@@ -14,7 +14,7 @@ namespace dymaptic.GeoBlazor.Core.Components.Popups;
 ///         JS API
 ///     </a>
 /// </summary>
-public class PopupTemplate : MapComponent
+public class PopupTemplate : MapComponent, IEquatable<PopupTemplate>
 {
     /// <summary>
     ///     Parameterless constructor for using as a razor component
@@ -87,6 +87,16 @@ public class PopupTemplate : MapComponent
             Actions = actions.ToHashSet();
         }
 #pragma warning restore BL0005
+    }
+
+    public static bool operator ==(PopupTemplate? left, PopupTemplate? right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(PopupTemplate? left, PopupTemplate? right)
+    {
+        return !Equals(left, right);
     }
 
     /// <summary>
@@ -180,6 +190,16 @@ public class PopupTemplate : MapComponent
     ///     Object reference for callbacks from JavaScript.
     /// </summary>
     public DotNetObjectReference<PopupTemplate> DotNetPopupTemplateReference => DotNetObjectReference.Create(this);
+
+    public bool Equals(PopupTemplate? other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+
+        return (StringContent == other.StringContent) && (Title == other.Title) && Equals(OutFields, other.OutFields) &&
+            (OverwriteActions == other.OverwriteActions) && (ReturnGeometry == other.ReturnGeometry) &&
+            Content.Equals(other.Content) && Equals(FieldInfos, other.FieldInfos) &&
+            Equals(ExpressionInfos, other.ExpressionInfos) && Equals(Actions, other.Actions);
+    }
 
     /// <summary>
     ///     JS-invokable method for triggering actions.
@@ -310,6 +330,30 @@ public class PopupTemplate : MapComponent
         }
     }
 
+    public override bool Equals(object? obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (obj.GetType() != GetType()) return false;
+
+        return Equals((PopupTemplate)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        var hashCode = new HashCode();
+        hashCode.Add(StringContent);
+        hashCode.Add(Title);
+        hashCode.Add(OutFields);
+        hashCode.Add(OverwriteActions);
+        hashCode.Add(ReturnGeometry);
+        hashCode.Add(Content);
+        hashCode.Add(FieldInfos);
+        hashCode.Add(ExpressionInfos);
+        hashCode.Add(Actions);
+
+        return hashCode.ToHashCode();
+    }
+
     internal PopupTemplateSerializationRecord ToSerializationRecord()
     {
         return new PopupTemplateSerializationRecord(Title, StringContent, OutFields,
@@ -320,14 +364,22 @@ public class PopupTemplate : MapComponent
     }
 }
 
-internal record PopupTemplateSerializationRecord(
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Title, 
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? StringContent = null, 
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]IEnumerable<string>? OutFields = null,
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]IEnumerable<FieldInfoSerializationRecord>? FieldInfos = null, 
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]IEnumerable<PopupContentSerializationRecord>? Contents = null,
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]IEnumerable<ExpressionInfoSerializationRecord>? ExpressionInfos = null, 
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]bool? OverwriteActions = null,
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]bool? ReturnGeometry = null, 
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]IEnumerable<ActionBaseSerializationRecord>? Actions = null)
+internal record PopupTemplateSerializationRecord([property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        string? Title,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        string? StringContent = null,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        IEnumerable<string>? OutFields = null,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        IEnumerable<FieldInfoSerializationRecord>? FieldInfos = null,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        IEnumerable<PopupContentSerializationRecord>? Contents = null,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        IEnumerable<ExpressionInfoSerializationRecord>? ExpressionInfos = null,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        bool? OverwriteActions = null,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        bool? ReturnGeometry = null,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        IEnumerable<ActionBaseSerializationRecord>? Actions = null)
     : MapComponentSerializationRecord;

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/PopupTemplate.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/PopupTemplate.cs
@@ -309,4 +309,25 @@ public class PopupTemplate : MapComponent
             }
         }
     }
+
+    internal PopupTemplateSerializationRecord ToSerializationRecord()
+    {
+        return new PopupTemplateSerializationRecord(Title, StringContent, OutFields,
+            FieldInfos?.Select(f => f.ToSerializationRecord()),
+            Content.Select(c => c.ToSerializationRecord()),
+            ExpressionInfos?.Select(e => e.ToSerializationRecord()), OverwriteActions,
+            ReturnGeometry, Actions?.Select(a => a.ToSerializationRecord()));
+    }
 }
+
+internal record PopupTemplateSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Title, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? StringContent = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]IEnumerable<string>? OutFields = null,
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]IEnumerable<FieldInfoSerializationRecord>? FieldInfos = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]IEnumerable<PopupContentSerializationRecord>? Contents = null,
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]IEnumerable<ExpressionInfoSerializationRecord>? ExpressionInfos = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]bool? OverwriteActions = null,
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]bool? ReturnGeometry = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]IEnumerable<ActionBaseSerializationRecord>? Actions = null)
+    : MapComponentSerializationRecord;

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/RelationshipPopupContent.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/RelationshipPopupContent.cs
@@ -70,7 +70,22 @@ public class RelationshipPopupContent : PopupContent
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Title { get; set; }
+    
+    internal override PopupContentSerializationRecord ToSerializationRecord()
+    {
+        return new RelationshipPopupContentSerializationRecord(Description, DisplayCount, DisplayType, 
+            OrderByFields.Select(r => r.ToSerializationRecord()).ToArray(), RelationshipId, Title);
+    }
 }
+
+internal record RelationshipPopupContentSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Description, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]int? DisplayCount, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? DisplayType,
+    RelatedRecordsInfoFieldOrderSerializationRecord[] OrderByFields, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]int? RelationshipId, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Title) 
+    : PopupContentSerializationRecord("relationship");
 
 /// <summary>
 ///     The RelatedRecordsInfoFieldOrder class indicates the field display order for the related records in a layer's
@@ -95,4 +110,11 @@ public class RelatedRecordsInfoFieldOrder : MapComponent
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public OrderBy? Order { get; set; }
+    
+    internal RelatedRecordsInfoFieldOrderSerializationRecord ToSerializationRecord()
+    {
+        return new RelatedRecordsInfoFieldOrderSerializationRecord(Field, Order);
+    }
 }
+
+internal record RelatedRecordsInfoFieldOrderSerializationRecord(string? Field, OrderBy? Order);

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/TextPopupContent.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/TextPopupContent.cs
@@ -30,3 +30,7 @@ public class TextPopupContent : PopupContent
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Text { get; set; }
 }
+
+internal record TextPopupContentSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Text) 
+    : PopupContentSerializationRecord("text");

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/MapFont.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/MapFont.cs
@@ -81,4 +81,16 @@ public class MapFont : MapComponent, IEquatable<MapFont>
     {
         return HashCode.Combine(Size, Family, FontStyle, Weight);
     }
+    
+    internal MapFontSerializationRecord ToSerializationRecord()
+    {
+        return new MapFontSerializationRecord(Size, Family, FontStyle, Weight);
+    }
 }
+
+internal record MapFontSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]int? Size, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Family, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? FontStyle, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Weight)
+    : MapComponentSerializationRecord;

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/PictureMarkerSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/PictureMarkerSymbol.cs
@@ -96,7 +96,6 @@ public class PictureMarkerSymbol : MarkerSymbol, IEquatable<PictureMarkerSymbol>
     public bool Equals(PictureMarkerSymbol? other)
     {
         if (ReferenceEquals(null, other)) return false;
-        if (ReferenceEquals(this, other)) return true;
 
         return Nullable.Equals(Height, other.Height) && Nullable.Equals(Width, other.Width) && (Url == other.Url) &&
             (Color == other.Color);
@@ -106,7 +105,6 @@ public class PictureMarkerSymbol : MarkerSymbol, IEquatable<PictureMarkerSymbol>
     public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
-        if (ReferenceEquals(this, obj)) return true;
         if (obj.GetType() != GetType()) return false;
 
         return Equals((PictureMarkerSymbol)obj);

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/PictureMarkerSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/PictureMarkerSymbol.cs
@@ -117,4 +117,17 @@ public class PictureMarkerSymbol : MarkerSymbol, IEquatable<PictureMarkerSymbol>
     {
         return HashCode.Combine(Height, Width, Url, Color);
     }
+
+    internal override SymbolSerializationRecord ToSerializationRecord()
+    {
+        return new PictureMarkerSymbolSerializationRecord(Url, Width, Height, Angle, XOffset, YOffset);
+    }
 }
+
+internal record PictureMarkerSymbolSerializationRecord(string Url, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? Width = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? Height = null,
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? Angle = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? XOffset = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? YOffset = null): 
+    SymbolSerializationRecord("picture-marker", null);

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleFillSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleFillSymbol.cs
@@ -80,7 +80,6 @@ public class SimpleFillSymbol : FillSymbol, IEquatable<SimpleFillSymbol>
     public bool Equals(SimpleFillSymbol? other)
     {
         if (ReferenceEquals(null, other)) return false;
-        if (ReferenceEquals(this, other)) return true;
 
         return Equals(Outline, other.Outline) && (FillStyle == other.FillStyle) && (Color == other.Color);
     }
@@ -131,7 +130,6 @@ public class SimpleFillSymbol : FillSymbol, IEquatable<SimpleFillSymbol>
     public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
-        if (ReferenceEquals(this, obj)) return true;
         if (obj.GetType() != GetType()) return false;
 
         return Equals((SimpleFillSymbol)obj);
@@ -153,7 +151,7 @@ public class SimpleFillSymbol : FillSymbol, IEquatable<SimpleFillSymbol>
 internal record SimpleFillSymbolSerializationRecord(
     [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]SimpleLineSymbolSerializationRecord? Outline = null, 
     MapColor? Color = null, 
-    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]FillStyle? FillStyle = null) 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]FillStyle? Style = null) 
     : SymbolSerializationRecord("simple-fill", Color);
 
 /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleFillSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleFillSymbol.cs
@@ -142,7 +142,19 @@ public class SimpleFillSymbol : FillSymbol, IEquatable<SimpleFillSymbol>
     {
         return HashCode.Combine(Outline, FillStyle, Color);
     }
+
+    internal override SymbolSerializationRecord ToSerializationRecord()
+    {
+        return new SimpleFillSymbolSerializationRecord(
+            Outline?.ToSerializationRecord() as SimpleLineSymbolSerializationRecord, Color, FillStyle);
+    }
 }
+
+internal record SimpleFillSymbolSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]SimpleLineSymbolSerializationRecord? Outline = null, 
+    MapColor? Color = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]FillStyle? FillStyle = null) 
+    : SymbolSerializationRecord("simple-fill", Color);
 
 /// <summary>
 ///     The possible fill style for the <see cref="SimpleFillSymbol" />

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleLineSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleLineSymbol.cs
@@ -93,7 +93,17 @@ public class SimpleLineSymbol : LineSymbol, IEquatable<SimpleLineSymbol>
     {
         return LineStyle.GetHashCode();
     }
+
+    internal override SymbolSerializationRecord ToSerializationRecord()
+    {
+        return new SimpleLineSymbolSerializationRecord(Color, Width, LineStyle);
+    }
 }
+
+internal record SimpleLineSymbolSerializationRecord(MapColor? Color = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? Width = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]LineStyle? LineStyle = null)
+    : SymbolSerializationRecord("simple-line", Color);
 
 /// <summary>
 ///     Possible line style values for <see cref="SimpleLineSymbol" />

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleLineSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleLineSymbol.cs
@@ -73,7 +73,6 @@ public class SimpleLineSymbol : LineSymbol, IEquatable<SimpleLineSymbol>
     public bool Equals(SimpleLineSymbol? other)
     {
         if (ReferenceEquals(null, other)) return false;
-        if (ReferenceEquals(this, other)) return true;
 
         return (LineStyle == other.LineStyle) && (Color == other.Color);
     }
@@ -82,7 +81,6 @@ public class SimpleLineSymbol : LineSymbol, IEquatable<SimpleLineSymbol>
     public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
-        if (ReferenceEquals(this, obj)) return true;
         if (obj.GetType() != GetType()) return false;
 
         return Equals((SimpleLineSymbol)obj);

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleMarkerSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleMarkerSymbol.cs
@@ -102,7 +102,6 @@ public class SimpleMarkerSymbol : MarkerSymbol, IEquatable<SimpleMarkerSymbol>
     public bool Equals(SimpleMarkerSymbol? other)
     {
         if (ReferenceEquals(null, other)) return false;
-        if (ReferenceEquals(this, other)) return true;
 
         return Equals(Outline, other.Outline) &&
             Nullable.Equals(Size, other.Size) &&
@@ -156,7 +155,6 @@ public class SimpleMarkerSymbol : MarkerSymbol, IEquatable<SimpleMarkerSymbol>
     public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
-        if (ReferenceEquals(this, obj)) return true;
         if (obj.GetType() != GetType()) return false;
 
         return Equals((SimpleMarkerSymbol)obj);

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleMarkerSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleMarkerSymbol.cs
@@ -192,4 +192,21 @@ public class SimpleMarkerSymbol : MarkerSymbol, IEquatable<SimpleMarkerSymbol>
 
         return style1 == style2;
     }
+
+    internal override SymbolSerializationRecord ToSerializationRecord()
+    {
+        return new SimpleMarkerSymbolSerializationRecord(
+            Outline?.ToSerializationRecord() as SimpleLineSymbolSerializationRecord,
+            Color, Size, Style, Angle, XOffset, YOffset);
+    }
 }
+
+internal record SimpleMarkerSymbolSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]SimpleLineSymbolSerializationRecord? Outline = null, 
+    MapColor? Color = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? Size = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Style = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? Angle = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? XOffset = null,
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]double? YOffset = null)
+    : SymbolSerializationRecord("simple-marker", Color);

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/Symbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/Symbol.cs
@@ -29,6 +29,11 @@ public abstract class Symbol : MapComponent
     ///     The symbol type
     /// </summary>
     public virtual string Type => default!;
+    
+    internal virtual SymbolSerializationRecord ToSerializationRecord()
+    {
+        return new(Type, Color);
+    }
 }
 
 internal class SymbolJsonConverter : JsonConverter<Symbol>
@@ -75,5 +80,23 @@ internal class SymbolJsonConverter : JsonConverter<Symbol>
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
         writer.WriteRawValue(JsonSerializer.Serialize(value, typeof(object), newOptions));
+    }
+}
+
+[JsonConverter(typeof(SymbolSerializationConverter))]
+internal record SymbolSerializationRecord(string Type, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]MapColor? Color)
+    : MapComponentSerializationRecord;
+
+internal class SymbolSerializationConverter : JsonConverter<SymbolSerializationRecord>
+{
+    public override SymbolSerializationRecord? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void Write(Utf8JsonWriter writer, SymbolSerializationRecord value, JsonSerializerOptions options)
+    {
+        writer.WriteRawValue(JsonSerializer.Serialize(value, value.GetType(), options));
     }
 }

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/TextSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/TextSymbol.cs
@@ -102,7 +102,6 @@ public class TextSymbol : Symbol, IEquatable<TextSymbol>
     public bool Equals(TextSymbol? other)
     {
         if (ReferenceEquals(null, other)) return false;
-        if (ReferenceEquals(this, other)) return true;
 
         return Equals(HaloColor, other.HaloColor) && (HaloSize == other.HaloSize) && (Text == other.Text) &&
             Equals(Font, other.Font) && Equals(Color, other.Color);
@@ -154,7 +153,6 @@ public class TextSymbol : Symbol, IEquatable<TextSymbol>
     public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
-        if (ReferenceEquals(this, obj)) return true;
         if (obj.GetType() != GetType()) return false;
 
         return Equals((TextSymbol)obj);

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/TextSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/TextSymbol.cs
@@ -165,4 +165,17 @@ public class TextSymbol : Symbol, IEquatable<TextSymbol>
     {
         return HashCode.Combine(HaloColor, HaloSize, Text, Font, Color);
     }
+
+    internal override SymbolSerializationRecord ToSerializationRecord()
+    {
+        return new TextSymbolSerializationRecord(Text, Color, HaloColor, HaloSize, Font?.ToSerializationRecord());
+    }
 }
+
+internal record TextSymbolSerializationRecord(
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]string? Text, 
+    MapColor? Color = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]MapColor? HaloColor = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]int? HaloSize = null, 
+    [property:JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]MapFontSerializationRecord? Font = null)
+    : SymbolSerializationRecord("text", Color);

--- a/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
@@ -1171,10 +1171,19 @@ public partial class MapView : MapComponent
     /// </summary>
     public async Task AddGraphics(IEnumerable<Graphic> graphics)
     {
-        foreach (Graphic graphic in graphics)
+        List<Graphic> newGraphics = graphics.ToList();
+        foreach (Graphic graphic in newGraphics)
         {
-            await AddGraphic(graphic);
+            graphic.View = this;
+            graphic.JsModule = ViewJsModule;
+            graphic.Parent = this;
+            _graphics.Add(graphic);
         }
+        
+        if (ViewJsModule is null) return;
+        
+        IEnumerable<GraphicSerializationRecord> records = newGraphics.Select(g => g.ToSerializationRecord());
+        await ViewJsModule!.InvokeVoidAsync("addGraphics", records, Id);
     }
 
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
@@ -947,6 +947,7 @@ public partial class MapView : MapComponent
         ShouldUpdate = false;
 
         ViewExtentUpdate change = await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("updateView",
+            CancellationTokenSource.Token,
             new
             {
                 Id,
@@ -1092,7 +1093,8 @@ public partial class MapView : MapComponent
     public async Task QueryFeatures(Query query, FeatureLayer featureLayer, Symbol displaySymbol,
         PopupTemplate popupTemplate)
     {
-        await ViewJsModule!.InvokeVoidAsync("queryFeatureLayer", (object)query,
+        await ViewJsModule!.InvokeVoidAsync("queryFeatureLayer",
+            CancellationTokenSource.Token, (object)query,
             (object)featureLayer, (object)displaySymbol, (object)popupTemplate, Id);
     }
 
@@ -1110,8 +1112,8 @@ public partial class MapView : MapComponent
     /// </param>
     public async Task FindPlaces(AddressQuery query, Symbol displaySymbol, PopupTemplate popupTemplate)
     {
-        await ViewJsModule!.InvokeVoidAsync("findPlaces", (object)query,
-            (object)displaySymbol, (object)popupTemplate, Id);
+        await ViewJsModule!.InvokeVoidAsync("findPlaces", CancellationTokenSource.Token, 
+            (object)query, (object)displaySymbol, (object)popupTemplate, Id);
     }
 
     /// <summary>
@@ -1125,8 +1127,8 @@ public partial class MapView : MapComponent
     /// </param>
     public async Task ShowPopup(PopupTemplate template, Point location)
     {
-        await ViewJsModule!.InvokeVoidAsync("showPopup", (object)template,
-            (object)location, Id);
+        await ViewJsModule!.InvokeVoidAsync("showPopup", CancellationTokenSource.Token, 
+            (object)template, (object)location, Id);
     }
 
     /// <summary>
@@ -1140,8 +1142,8 @@ public partial class MapView : MapComponent
     /// </param>
     public async Task ShowPopupWithGraphic(Graphic graphic, PopupOptions options)
     {
-        await ViewJsModule!.InvokeVoidAsync("showPopupWithGraphic", (object)graphic,
-            (object)options, Id);
+        await ViewJsModule!.InvokeVoidAsync("showPopupWithGraphic", CancellationTokenSource.Token, 
+            (object)graphic, (object)options, Id);
     }
 
     /// <summary>
@@ -1154,7 +1156,7 @@ public partial class MapView : MapComponent
     /// </param>
     public async Task OpenPopup(PopupOpenOptions? options = null)
     {
-        await ViewJsModule!.InvokeVoidAsync("openPopup", Id, options);
+        await ViewJsModule!.InvokeVoidAsync("openPopup", CancellationTokenSource.Token, Id, options);
     }
 
     /// <summary>
@@ -1163,7 +1165,7 @@ public partial class MapView : MapComponent
     /// </summary>
     public async Task ClosePopup()
     {
-        await ViewJsModule!.InvokeVoidAsync("closePopup", Id);
+        await ViewJsModule!.InvokeVoidAsync("closePopup", CancellationTokenSource.Token, Id);
     }
 
     /// <summary>
@@ -1183,7 +1185,7 @@ public partial class MapView : MapComponent
         if (ViewJsModule is null) return;
         
         IEnumerable<GraphicSerializationRecord> records = newGraphics.Select(g => g.ToSerializationRecord());
-        await ViewJsModule!.InvokeVoidAsync("addGraphics", records, Id);
+        await ViewJsModule!.InvokeVoidAsync("addGraphics", CancellationTokenSource.Token, records, Id);
     }
 
     /// <summary>
@@ -1203,7 +1205,7 @@ public partial class MapView : MapComponent
 
             if (ViewJsModule is null) return;
 
-            await ViewJsModule!.InvokeVoidAsync("addGraphic", (object)graphic, Id);
+            await ViewJsModule!.InvokeVoidAsync("addGraphic", graphic.ToSerializationRecord(), Id);
         }
     }
 
@@ -1222,7 +1224,7 @@ public partial class MapView : MapComponent
 
         if (ViewJsModule is null) return;
 
-        await ViewJsModule!.InvokeVoidAsync("clearViewGraphics", Id);
+        await ViewJsModule!.InvokeVoidAsync("clearViewGraphics", CancellationTokenSource.Token, Id);
     }
 
     /// <summary>
@@ -1257,7 +1259,8 @@ public partial class MapView : MapComponent
 
         if (ViewJsModule is null || !added) return;
 
-        await ViewJsModule!.InvokeVoidAsync("addLayer", (object)layer, Id, isBasemapLayer);
+        await ViewJsModule!.InvokeVoidAsync("addLayer", (object)layer, Id, 
+            CancellationTokenSource.Token, isBasemapLayer);
     }
 
     /// <summary>
@@ -1294,7 +1297,8 @@ public partial class MapView : MapComponent
 
         if (ViewJsModule is null || !removed) return;
 
-        await ViewJsModule!.InvokeVoidAsync("removeLayer", layer.Id, Id, isBasemapLayer);
+        await ViewJsModule!.InvokeVoidAsync("removeLayer", CancellationTokenSource.Token, 
+            layer.Id, Id, isBasemapLayer);
     }
 
     /// <summary>
@@ -1313,7 +1317,7 @@ public partial class MapView : MapComponent
     public async Task<Direction[]> DrawRouteAndGetDirections(Symbol routeSymbol, string routeUrl)
     {
         return await ViewJsModule!.InvokeAsync<Direction[]?>("drawRouteAndGetDirections",
-            routeUrl, (object)routeSymbol, Id) ?? Array.Empty<Direction>();
+            CancellationTokenSource.Token, routeUrl, (object)routeSymbol, Id) ?? Array.Empty<Direction>();
     }
 
     /// <summary>
@@ -1330,7 +1334,7 @@ public partial class MapView : MapComponent
     /// </param>
     public async Task SolveServiceArea(string serviceAreaUrl, double[] driveTimeCutOffs, Symbol serviceAreaSymbol)
     {
-        await ViewJsModule!.InvokeVoidAsync("solveServiceArea",
+        await ViewJsModule!.InvokeVoidAsync("solveServiceArea", CancellationTokenSource.Token,
             serviceAreaUrl, driveTimeCutOffs, serviceAreaSymbol, Id);
     }
 
@@ -1348,7 +1352,8 @@ public partial class MapView : MapComponent
 
         if (ViewJsModule is null) return;
 
-        await ViewJsModule!.InvokeVoidAsync("removeGraphic", graphic, Id);
+        await ViewJsModule!.InvokeVoidAsync("removeGraphic", CancellationTokenSource.Token, 
+            graphic, Id);
     }
 
     /// <summary>
@@ -1368,7 +1373,8 @@ public partial class MapView : MapComponent
 
         if (ViewJsModule is null) return;
 
-        await ViewJsModule!.InvokeVoidAsync("removeGraphics", graphics, Id);
+        await ViewJsModule!.InvokeVoidAsync("removeGraphics", CancellationTokenSource.Token, 
+            graphics, Id);
     }
 
     /// <summary>
@@ -1386,7 +1392,8 @@ public partial class MapView : MapComponent
             if (ViewJsModule is null || !MapRendered) return;
 
             ViewExtentUpdate change =
-                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setCenter", (object)point, Id);
+                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setCenter", 
+                    CancellationTokenSource.Token, (object)point, Id);
             Extent = change.Extent;
             Zoom = change.Zoom;
             Scale = change.Scale;
@@ -1404,7 +1411,7 @@ public partial class MapView : MapComponent
 
         if (ViewJsModule is not null && MapRendered)
         {
-            center = await ViewJsModule!.InvokeAsync<Point?>("getCenter", Id);
+            center = await ViewJsModule!.InvokeAsync<Point?>("getCenter", CancellationTokenSource.Token, Id);
 
             if (center is not null)
             {
@@ -1433,7 +1440,8 @@ public partial class MapView : MapComponent
             ExtentSetByCode = true;
 
             ViewExtentUpdate change =
-                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setZoom", Zoom, Id);
+                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setZoom", Zoom, 
+                    CancellationTokenSource.Token, Id);
             Extent = change.Extent;
             Latitude = change.Center?.Latitude;
             Longitude = change.Center?.Longitude;
@@ -1450,7 +1458,7 @@ public partial class MapView : MapComponent
     {
         if (ViewJsModule is not null)
         {
-            Zoom = await ViewJsModule!.InvokeAsync<double>("getZoom", Id);
+            Zoom = await ViewJsModule!.InvokeAsync<double>("getZoom", CancellationTokenSource.Token, Id);
         }
 
         return Zoom;
@@ -1469,7 +1477,8 @@ public partial class MapView : MapComponent
             ExtentSetByCode = true;
 
             ViewExtentUpdate change =
-                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setScale", Scale, Id);
+                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setScale", 
+                    CancellationTokenSource.Token, Scale, Id);
             Extent = change.Extent;
             Latitude = change.Center?.Latitude;
             Longitude = change.Center?.Longitude;
@@ -1486,7 +1495,7 @@ public partial class MapView : MapComponent
     {
         if (ViewJsModule is not null)
         {
-            Scale = await ViewJsModule!.InvokeAsync<double>("getScale", Id);
+            Scale = await ViewJsModule!.InvokeAsync<double>("getScale", CancellationTokenSource.Token, Id);
         }
 
         return Scale;
@@ -1505,7 +1514,8 @@ public partial class MapView : MapComponent
             ExtentSetByCode = true;
 
             ViewExtentUpdate change =
-                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setRotation", Rotation, Id);
+                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setRotation", 
+                    CancellationTokenSource.Token, Rotation, Id);
             Extent = change.Extent;
             Latitude = change.Center?.Latitude;
             Longitude = change.Center?.Longitude;
@@ -1522,7 +1532,7 @@ public partial class MapView : MapComponent
     {
         if (ViewJsModule is not null)
         {
-            Rotation = await ViewJsModule!.InvokeAsync<double>("getRotation", Id);
+            Rotation = await ViewJsModule!.InvokeAsync<double>("getRotation", CancellationTokenSource.Token, Id);
         }
 
         return Rotation;
@@ -1543,7 +1553,8 @@ public partial class MapView : MapComponent
             ExtentSetByCode = true;
 
             ViewExtentUpdate change =
-                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setExtent", (object)Extent, Id);
+                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setExtent", 
+                    CancellationTokenSource.Token, (object)Extent, Id);
             Latitude = change.Center?.Latitude;
             Longitude = change.Center?.Longitude;
             Zoom = change.Zoom;
@@ -1560,7 +1571,7 @@ public partial class MapView : MapComponent
     {
         if (ViewJsModule is not null)
         {
-            Extent = await ViewJsModule!.InvokeAsync<Extent?>("getExtent", Id);
+            Extent = await ViewJsModule!.InvokeAsync<Extent?>("getExtent", CancellationTokenSource.Token, Id);
         }
 
         return Extent;
@@ -1577,7 +1588,8 @@ public partial class MapView : MapComponent
 
             if (ViewJsModule is null) return;
 
-            await ViewJsModule!.InvokeVoidAsync("setConstraints", (object)Constraints, Id);
+            await ViewJsModule!.InvokeVoidAsync("setConstraints", 
+                CancellationTokenSource.Token, (object)Constraints, Id);
         }
     }
 
@@ -1592,7 +1604,8 @@ public partial class MapView : MapComponent
 
             if (ViewJsModule is null) return;
 
-            await ViewJsModule!.InvokeVoidAsync("setHighlightOptions", (object)HighlightOptions, Id);
+            await ViewJsModule!.InvokeVoidAsync("setHighlightOptions", 
+                CancellationTokenSource.Token, (object)HighlightOptions, Id);
         }
     }
 
@@ -1607,7 +1620,8 @@ public partial class MapView : MapComponent
 
             if (ViewJsModule is null) return;
 
-            await ViewJsModule!.InvokeVoidAsync("setSpatialReference", (object)SpatialReference, Id);
+            await ViewJsModule!.InvokeVoidAsync("setSpatialReference", 
+                CancellationTokenSource.Token, (object)SpatialReference, Id);
         }
     }
 
@@ -1618,7 +1632,8 @@ public partial class MapView : MapComponent
     {
         if (ViewJsModule is not null)
         {
-            SpatialReference = await ViewJsModule!.InvokeAsync<SpatialReference?>("getSpatialReference", Id);
+            SpatialReference = await ViewJsModule!.InvokeAsync<SpatialReference?>("getSpatialReference", 
+                CancellationTokenSource.Token, Id);
         }
 
         return SpatialReference;
@@ -1652,7 +1667,8 @@ public partial class MapView : MapComponent
         ExtentSetByCode = true;
 
         ViewExtentUpdate change =
-            await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("goToExtent", extent, Id);
+            await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("goToExtent", 
+                CancellationTokenSource.Token, extent, Id);
         Extent = change.Extent;
         Latitude = change.Center?.Latitude;
         Longitude = change.Center?.Longitude;
@@ -1676,7 +1692,8 @@ public partial class MapView : MapComponent
         ExtentSetByCode = true;
 
         ViewExtentUpdate change =
-            await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("goToGraphics", graphics, Id);
+            await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("goToGraphics", 
+                CancellationTokenSource.Token, graphics, Id);
         Extent = change.Extent;
         Latitude = change.Center?.Latitude;
         Longitude = change.Center?.Longitude;
@@ -1739,7 +1756,8 @@ public partial class MapView : MapComponent
             if (IsServer)
             {
                 var eventId = Guid.NewGuid();
-                await ViewJsModule!.InvokeVoidAsync("hitTest", pointObject, eventId, Id, isEvent, options);
+                await ViewJsModule!.InvokeVoidAsync("hitTest", CancellationTokenSource.Token, 
+                    pointObject, eventId, Id, isEvent, options);
                 var json = _hitTestResults[eventId].ToString();
                 _hitTestResults.Remove(eventId);
 
@@ -1747,7 +1765,8 @@ public partial class MapView : MapComponent
                     new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
             }
 
-            return await ViewJsModule!.InvokeAsync<HitTestResult>("hitTest", pointObject, null, Id, isEvent, options);
+            return await ViewJsModule!.InvokeAsync<HitTestResult>("hitTest", 
+                CancellationTokenSource.Token, pointObject, null, Id, isEvent, options);
         }
         catch (Exception ex)
         {
@@ -1784,7 +1803,8 @@ public partial class MapView : MapComponent
     {
         try
         {
-            if (ViewJsModule != null) await ViewJsModule.InvokeVoidAsync("disposeView", Id);
+            if (ViewJsModule != null) await ViewJsModule.InvokeVoidAsync("disposeView", 
+                CancellationTokenSource.Token, Id);
         }
         catch (JSDisconnectedException)
         {
@@ -1897,11 +1917,11 @@ public partial class MapView : MapComponent
 
             NeedsRender = false;
 
-            await ViewJsModule!.InvokeVoidAsync("setAssetsPath",
+            await ViewJsModule!.InvokeVoidAsync("setAssetsPath", CancellationTokenSource.Token, 
                 Configuration.GetValue<string?>("ArcGISAssetsPath",
                     "./_content/dymaptic.GeoBlazor.Core/assets"));
 
-            await ViewJsModule.InvokeVoidAsync("buildMapView", Id,
+            await ViewJsModule.InvokeVoidAsync("buildMapView", CancellationTokenSource.Token, Id,
                 DotNetObjectReference, Longitude, Latitude, Rotation, Map, Zoom, Scale,
                 ApiKey, mapType, Widgets, Graphics, SpatialReference, Constraints, Extent,
                 EventRateLimitInMilliseconds, GetActiveEventHandlers(), IsServer, HighlightOptions);
@@ -1931,11 +1951,13 @@ public partial class MapView : MapComponent
         {
             if (widget.GetType().Namespace!.Contains("Core"))
             {
-                await ViewJsModule!.InvokeVoidAsync("addWidget", widget, Id);
+                await ViewJsModule!.InvokeVoidAsync("addWidget", 
+                    CancellationTokenSource.Token, widget, Id);
             }
             else
             {
-                await ProJsModule!.InvokeVoidAsync("addProWidget", widget, Id);
+                await ProJsModule!.InvokeVoidAsync("addProWidget", 
+                    CancellationTokenSource.Token, widget, Id);
             }
         });
     }
@@ -1954,7 +1976,8 @@ public partial class MapView : MapComponent
         {
             try
             {
-                await ViewJsModule!.InvokeVoidAsync("removeWidget", widget.Id, Id);
+                await ViewJsModule!.InvokeVoidAsync("removeWidget", 
+                    CancellationTokenSource.Token, widget.Id, Id);
             }
             catch (JSDisconnectedException)
             {

--- a/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
@@ -1172,12 +1172,12 @@ public partial class MapView : MapComponent
     public async Task AddGraphics(IEnumerable<Graphic> graphics)
     {
         List<Graphic> newGraphics = graphics.ToList();
+        _graphics.UnionWith(newGraphics);
         foreach (Graphic graphic in newGraphics)
         {
             graphic.View = this;
             graphic.JsModule = ViewJsModule;
             graphic.Parent = this;
-            _graphics.Add(graphic);
         }
         
         if (ViewJsModule is null) return;

--- a/src/dymaptic.GeoBlazor.Core/Components/Views/SceneView.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/SceneView.cs
@@ -59,7 +59,8 @@ public class SceneView : MapView
             if (ViewJsModule is null) return;
 
             ViewExtentUpdate change =
-                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setCenter", (object)point, Id);
+                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setCenter", 
+                    CancellationTokenSource.Token, (object)point, Id);
             Extent = change.Extent;
             Zoom = change.Zoom;
             Scale = change.Scale;
@@ -80,7 +81,8 @@ public class SceneView : MapView
             ExtentSetByCode = true;
 
             ViewExtentUpdate change =
-                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setZoom", Zoom, Id);
+                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setZoom", 
+                    CancellationTokenSource.Token, Zoom, Id);
             Extent = change.Extent;
             Latitude = change.Center?.Latitude;
             Longitude = change.Center?.Longitude;
@@ -102,7 +104,8 @@ public class SceneView : MapView
             ExtentSetByCode = true;
 
             ViewExtentUpdate change =
-                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setScale", Scale, Id);
+                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setScale",
+                    CancellationTokenSource.Token, Scale, Id);
             Extent = change.Extent;
             Latitude = change.Center?.Latitude;
             Longitude = change.Center?.Longitude;
@@ -126,7 +129,8 @@ public class SceneView : MapView
             ExtentSetByCode = true;
 
             ViewExtentUpdate change =
-                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setExtent", (object)Extent, Id);
+                await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("setExtent", 
+                    CancellationTokenSource.Token, (object)Extent, Id);
             Latitude = change.Center?.Latitude;
             Longitude = change.Center?.Longitude;
             Zoom = change.Zoom;
@@ -146,7 +150,8 @@ public class SceneView : MapView
         ExtentSetByCode = true;
 
         ViewExtentUpdate change =
-            await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("goToGraphics", graphics, Id);
+            await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("goToGraphics", 
+                CancellationTokenSource.Token, graphics, Id);
         Extent = change.Extent;
         Latitude = change.Center?.Latitude;
         Longitude = change.Center?.Longitude;
@@ -168,7 +173,7 @@ public class SceneView : MapView
         ShouldUpdate = false;
 
         ViewExtentUpdate change = await ViewJsModule!.InvokeAsync<ViewExtentUpdate>("updateView",
-            new
+            CancellationTokenSource.Token, new
             {
                 Id,
                 Latitude,
@@ -221,11 +226,12 @@ public class SceneView : MapView
 
             NeedsRender = false;
 
-            await ViewJsModule!.InvokeVoidAsync("setAssetsPath",
+            await ViewJsModule!.InvokeVoidAsync("setAssetsPath", CancellationTokenSource.Token,
                 Configuration.GetValue<string?>("ArcGISAssetsPath",
                     "./_content/dymaptic.GeoBlazor.Core/assets"));
 
-            await ViewJsModule!.InvokeVoidAsync("buildMapView", Id, DotNetObjectReference,
+            await ViewJsModule!.InvokeVoidAsync("buildMapView", 
+                CancellationTokenSource.Token, Id, DotNetObjectReference,
                 Longitude, Latitude, Rotation, Map, Zoom, Scale,
                 ApiKey, mapType, Widgets, Graphics, SpatialReference, Constraints, Extent,
                 EventRateLimitInMilliseconds, GetActiveEventHandlers(), IsServer, HighlightOptions, ZIndex, Tilt);

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/PopupWidget.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/PopupWidget.cs
@@ -185,7 +185,8 @@ public class PopupWidget : Widget
     /// </summary>
     public async Task<Graphic> GetSelectedFeature()
     {
-        return await JsObjectReference!.InvokeAsync<Graphic>("getSelectedFeature");
+        return await JsObjectReference!.InvokeAsync<Graphic>("getSelectedFeature",
+            CancellationTokenSource.Token);
     }
 
     /// <summary>
@@ -193,7 +194,7 @@ public class PopupWidget : Widget
     /// </summary>
     public async Task SetContent(string stringContent)
     {
-        await JsObjectReference!.InvokeVoidAsync("setContent", stringContent);
+        await JsObjectReference!.InvokeVoidAsync("setContent", CancellationTokenSource.Token, stringContent);
     }
 
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Model/GeometryEngine.cs
+++ b/src/dymaptic.GeoBlazor.Core/Model/GeometryEngine.cs
@@ -70,7 +70,8 @@ public class GeometryEngine : LogicComponent
     public async Task<Polygon[]> Buffer(IEnumerable<Geometry> geometries, IEnumerable<double> distances,
         LinearUnit? unit = null, bool? unionResults = null)
     {
-        return await InvokeAsync<Polygon[]>("buffer", geometries, distances, unit, unionResults);
+        return await InvokeAsync<Polygon[]>("buffer", CancellationTokenSource.Token, 
+            geometries, distances, unit, unionResults);
     }
 
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -1106,6 +1106,7 @@ export async function addGraphic(graphicObject: DotNetGraphic, viewId: string, g
         if (graphicsLayer === undefined || graphicsLayer === null) {
             if (!hasValue(view?.graphics)) return;
             view.graphics?.add(graphic as Graphic);
+            console.log(new Date() + " - added to map");
         } else if (typeof (graphicsLayer) === 'object') {
             graphicsLayer.add(graphic as Graphic);
         } else {

--- a/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
@@ -18,6 +18,7 @@ export interface DotNetGraphic {
     geometry: any;
     attributes: any;
 
+    dotNetGraphicReference: any;
     symbol: DotNetSymbol;
 }
 

--- a/src/dymaptic.GeoBlazor.Core/Scripts/graphic.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/graphic.ts
@@ -19,7 +19,9 @@ export default class GraphicWrapper {
     }
 
     setAttribute(name: string, value: any): void {
-        this.graphic.attributes[name] = value;
+        if (this.graphic.attributes[name] !== value) {
+            this.graphic.attributes[name] = value;
+        }
     }
 
     getAttribute(name: string): any {
@@ -32,7 +34,9 @@ export default class GraphicWrapper {
 
     setGeometry(geometry: DotNetGeometry): void {
         let jsGeometry = buildJsGeometry(geometry);
-        this.graphic.geometry = jsGeometry as Geometry;
+        if (jsGeometry !== null && this.graphic.geometry !== jsGeometry) {
+            this.graphic.geometry = jsGeometry;
+        }
     }
 
     getGeometry(): DotNetGeometry | null {
@@ -40,7 +44,9 @@ export default class GraphicWrapper {
     }
 
     setSymbol(symbol: any): void {
-        this.graphic.symbol = symbol;
+        if (this.graphic.symbol !== symbol) {
+            this.graphic.symbol = symbol;
+        }
     }
 
     getSymbol(): any {
@@ -56,7 +62,10 @@ export default class GraphicWrapper {
     }
 
     setPopupTemplate(popupTemplate: DotNetPopupTemplate, viewId: string): void {
-        this.graphic.popupTemplate = buildJsPopupTemplate(popupTemplate, viewId);
+        let jsPopupTemplate = buildJsPopupTemplate(popupTemplate, viewId);
+        if (jsPopupTemplate !== null && this.graphic.popupTemplate !== jsPopupTemplate) {
+            this.graphic.popupTemplate = jsPopupTemplate;
+        }
     }
 
     getPopupTemplate(): DotNetPopupTemplate | null {

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -149,14 +149,14 @@ export async function buildJsGraphic(graphicObject: any, register: boolean, view
         let layer = arcGisObjectRefs[graphicObject.layerId] as Layer;
         graphic.layer = layer;
     }
-
-    if (graphicObject.dotNetGraphicReference !== undefined) {
-        let wrapper = new GraphicWrapper(graphic);
-        // @ts-ignore
-        let objectRef = DotNet.createJSObjectReference(wrapper);
-        await graphicObject.dotNetGraphicReference.invokeMethodAsync("OnGraphicCreated", objectRef);
-    }
+    
     if (register) {
+        if (graphicObject.dotNetGraphicReference !== undefined) {
+            let wrapper = new GraphicWrapper(graphic);
+            // @ts-ignore
+            let objectRef = DotNet.createJSObjectReference(wrapper);
+            await graphicObject.dotNetGraphicReference.invokeMethodAsync("OnGraphicCreated", objectRef);
+        }
         arcGisObjectRefs[graphicObject.id] = graphic;
     }
     return graphic;

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -155,7 +155,7 @@ export async function buildJsGraphic(graphicObject: any, register: boolean, view
             let wrapper = new GraphicWrapper(graphic);
             // @ts-ignore
             let objectRef = DotNet.createJSObjectReference(wrapper);
-            await graphicObject.dotNetGraphicReference.invokeMethodAsync("OnGraphicCreated", objectRef);
+            graphicObject.dotNetGraphicReference.invokeMethodAsync("OnGraphicCreated", objectRef);
         }
         arcGisObjectRefs[graphicObject.id] = graphic;
     }

--- a/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
+++ b/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
@@ -10,8 +10,8 @@
         </Description>
         <Title>GeoBlazor</Title>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageVersion>2.0.1-beta-1</PackageVersion>
-        <Version>2.0.1-beta-1</Version>
+        <PackageVersion>2.0.1-beta-2</PackageVersion>
+        <Version>2.0.1-beta-2</Version>
         <Authors>Tim Purdum, Christopher Moravec, Mara Stoica, Tim Rawson</Authors>
         <Company>dymaptic</Company>
         <Copyright>©2023 by dymaptic</Copyright>
@@ -21,7 +21,6 @@
         <RepositoryType>git</RepositoryType>
         <PackageIcon>Blazor-API-500px.png</PackageIcon>
         <GeneratePackageOnBuild Condition="$(Configuration) == 'RELEASE'">true</GeneratePackageOnBuild>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -34,7 +33,8 @@
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0"/>
     </ItemGroup>
-    <PropertyGroup>
+    <PropertyGroup Condition="$(Configuration) == 'RELEASE'">
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <DefaultDocumentationFolder>Documentation</DefaultDocumentationFolder>
         <DefaultDocumentationGeneratedPages>Types</DefaultDocumentationGeneratedPages>
         <DefaultDocumentationGeneratedAccessModifiers>Public</DefaultDocumentationGeneratedAccessModifiers>

--- a/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
+++ b/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
@@ -10,8 +10,8 @@
         </Description>
         <Title>GeoBlazor</Title>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageVersion>2.0.0</PackageVersion>
-        <Version>2.0.0</Version>
+        <PackageVersion>2.0.1-beta-1</PackageVersion>
+        <Version>2.0.1-beta-1</Version>
         <Authors>Tim Purdum, Christopher Moravec, Mara Stoica, Tim Rawson</Authors>
         <Company>dymaptic</Company>
         <Copyright>©2023 by dymaptic</Copyright>
@@ -97,7 +97,7 @@
         <Exec Command="npm run releaseBuild"/>
     </Target>
 
-    <Target Name="Copy Files" AfterTargets="Build" Condition="$(CoreSkipDocuments) != 'true'">
+    <Target Name="Copy Files" AfterTargets="Build"  Condition="$(Configuration) == 'RELEASE'">
         <Message Importance="high" Text="Launching Async File Copy Script"/>
         <ExecAsync FilePath="pwsh" Arguments="./docCopy.ps1" ContinueOnError="true"/>
     </Target>

--- a/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
+++ b/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
@@ -10,8 +10,8 @@
         </Description>
         <Title>GeoBlazor</Title>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageVersion>2.0.1-beta-2</PackageVersion>
-        <Version>2.0.1-beta-2</Version>
+        <PackageVersion>2.0.1-beta-3</PackageVersion>
+        <Version>2.0.1-beta-3</Version>
         <Authors>Tim Purdum, Christopher Moravec, Mara Stoica, Tim Rawson</Authors>
         <Company>dymaptic</Company>
         <Copyright>©2023 by dymaptic</Copyright>

--- a/src/dymaptic.GeoBlazor.Core/package-lock.json
+++ b/src/dymaptic.GeoBlazor.Core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dymaptic.GeoBlazor.Core",
-  "version": "2.0.0",
+  "version": "2.0.1-beta-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dymaptic.GeoBlazor.Core",
-      "version": "2.0.0",
+      "version": "2.0.1-beta-1",
       "license": "ISC",
       "dependencies": {
         "@arcgis/core": "^4.25.0",

--- a/src/dymaptic.GeoBlazor.Core/package-lock.json
+++ b/src/dymaptic.GeoBlazor.Core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dymaptic.GeoBlazor.Core",
-  "version": "2.0.1-beta-2",
+  "version": "2.0.1-beta-3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dymaptic.GeoBlazor.Core",
-      "version": "2.0.1-beta-2",
+      "version": "2.0.1-beta-3",
       "license": "ISC",
       "dependencies": {
         "@arcgis/core": "^4.25.0",

--- a/src/dymaptic.GeoBlazor.Core/package-lock.json
+++ b/src/dymaptic.GeoBlazor.Core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dymaptic.GeoBlazor.Core",
-  "version": "2.0.1-beta-1",
+  "version": "2.0.1-beta-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dymaptic.GeoBlazor.Core",
-      "version": "2.0.1-beta-1",
+      "version": "2.0.1-beta-2",
       "license": "ISC",
       "dependencies": {
         "@arcgis/core": "^4.25.0",

--- a/src/dymaptic.GeoBlazor.Core/package.json
+++ b/src/dymaptic.GeoBlazor.Core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dymaptic.GeoBlazor.Core",
-  "version": "2.0.1-beta-2",
+  "version": "2.0.1-beta-3",
   "description": "https://www.geoblazor.com",
   "main": "arcGisInterop.js",
   "scripts": {

--- a/src/dymaptic.GeoBlazor.Core/package.json
+++ b/src/dymaptic.GeoBlazor.Core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dymaptic.GeoBlazor.Core",
-  "version": "2.0.1-beta-1",
+  "version": "2.0.1-beta-2",
   "description": "https://www.geoblazor.com",
   "main": "arcGisInterop.js",
   "scripts": {

--- a/src/dymaptic.GeoBlazor.Core/package.json
+++ b/src/dymaptic.GeoBlazor.Core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dymaptic.GeoBlazor.Core",
-  "version": "2.0.0",
+  "version": "2.0.1-beta-1",
   "description": "https://www.geoblazor.com",
   "main": "arcGisInterop.js",
   "scripts": {


### PR DESCRIPTION
Closes #141 
- `MapView.AddGraphics(IEnumerable<Graphic>)` and `GraphicsLayer.Add(IEnumerable<Graphic>)` use a special `SerializationRecord` for all graphics and sub-entities. This speeds up serialization by at least 10x
- Moved the registration of the graphic JsObjectRef to _after_ all the graphics are generated and added in `graphicsLayer.ts`, which allows the user to not notice the time this takes
- Improved the graphics `HashSet` performance by calling `UnionWith` when adding a collection of graphics