### PR TITLE
Fix for XOffset/YOffset

### DIFF
--- a/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
@@ -82,8 +82,8 @@ export interface DotNetSimpleMarkerSymbol extends DotNetSymbol {
     path: string;
     size: number;
     style: string;
-    xoffset: number;
-    yoffset: number;
+    xOffset: number;
+    yOffset: number;
 }
 
 export interface DotNetSimpleLineSymbol extends DotNetSymbol {
@@ -97,8 +97,8 @@ export interface DotNetSimpleLineSymbol extends DotNetSymbol {
 
 export interface DotNetPictureMarkerSymbol extends DotNetSymbol {
     angle: number;
-    xoffset: number;
-    yoffset: number;
+    xOffset: number;
+    yOffset: number;
 
     height: number;
 
@@ -127,8 +127,8 @@ export interface DotNetTextSymbol extends DotNetSymbol {
     rotated: boolean;
     text: string;
     verticalAlignment: string;
-    xoffset: number;
-    yoffset: number;
+    xOffset: number;
+    yOffset: number;
 }
 
 export interface DotNetSpatialReference {

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -293,8 +293,8 @@ export function buildJsSymbol(symbol: DotNetSymbol | null): Symbol | null {
                 path: dnSimpleMarkerSymbol.path ?? undefined,
                 size: dnSimpleMarkerSymbol.size ?? 12,
                 style: dnSimpleMarkerSymbol.style as any ?? "circle",
-                xoffset: dnSimpleMarkerSymbol.xoffset ?? 0,
-                yoffset: dnSimpleMarkerSymbol.yoffset ?? 0
+                xoffset: dnSimpleMarkerSymbol.xOffset ?? 0,
+                yoffset: dnSimpleMarkerSymbol.yOffset ?? 0
             });
 
             if (dnSimpleMarkerSymbol.outline !== undefined && dnSimpleMarkerSymbol.outline !== null) {
@@ -318,8 +318,8 @@ export function buildJsSymbol(symbol: DotNetSymbol | null): Symbol | null {
             let dnPictureMarkerSymbol = symbol as DotNetPictureMarkerSymbol;
             let jsPictureMarkerSymbol = new PictureMarkerSymbol({
                 angle: dnPictureMarkerSymbol.angle ?? 0,
-                xoffset: dnPictureMarkerSymbol.xoffset ?? 0,
-                yoffset: dnPictureMarkerSymbol.yoffset ?? 0,
+                xoffset: dnPictureMarkerSymbol.xOffset ?? 0,
+                yoffset: dnPictureMarkerSymbol.yOffset ?? 0,
                 height: dnPictureMarkerSymbol.height ?? 12,
                 width: dnPictureMarkerSymbol.width ?? 12,
                 url: dnPictureMarkerSymbol.url


### PR DESCRIPTION
Closes #154 

This was a simple mismatched capitalization of `xoffset` vs. `xOffset` in `jsBuilder.ts`.