### PR TITLE
Fix and document solution for wsv error

### DIFF
--- a/docs/pages/gettingStarted.md
+++ b/docs/pages/gettingStarted.md
@@ -76,9 +76,23 @@ nav_order: 2
    ```
 6. In `Program.cs`, add the following line to your `builder.Services` to inject logic components like `GeometryEngine`.
 
-```csharp
+   ```csharp
    builder.Services.AddGeoBlazor();
-```
+   ```
+
+   If you are using Blazor Server, you should also add the following lines to `Program.cs` to support the `.wsv` file type.
+
+   ```csharp
+   var provider = new FileExtensionContentTypeProvider();
+   provider.Mappings[".wsv"] = "application/octet-stream";
+
+   app.UseStaticFiles();
+   // NOTE: for some reason, you still need the plain "UseStaticFiles" call above
+   app.UseStaticFiles(new StaticFileOptions
+   {
+       ContentTypeProvider = provider
+   });
+   ```
 
 7. Create a new Razor Component in the `Pages` folder, or just use `Index.razor`. Add a `MapView`. Give it basic
 
@@ -109,14 +123,14 @@ nav_order: 2
    ```
 10. Add a Widget to the `MapView`, after the `WebMap`.
 
-```html
-<MapView Longitude="_longitude" Latitude="_latitude" Zoom="11" Style="height: 400px; width: 100%;"> 
-    <WebMap>
-        <PortalItem Id="4a6cb60ebbe3483a805999d481c2daa5" />
-    </WebMap>
-    <ScaleBarWidget Position="OverlayPosition.BottomLeft" />
-</MapView>
-```
+   ```html
+   <MapView Longitude="_longitude" Latitude="_latitude" Zoom="11" Style="height: 400px; width: 100%;"> 
+       <WebMap>
+           <PortalItem Id="4a6cb60ebbe3483a805999d481c2daa5" />
+       </WebMap>
+       <ScaleBarWidget Position="OverlayPosition.BottomLeft" />
+   </MapView>
+   ```
 11. Run your application and make sure you can see your map!
     ![Web Map Sample](../assets/images/webmap.png)
 12. Now that you have a great starting point, you can now start to customize the features available in your new app

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Server/Program.cs
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Server/Program.cs
@@ -1,5 +1,6 @@
 using dymaptic.GeoBlazor.Core;
 using dymaptic.GeoBlazor.Core.Sample.Shared;
+using Microsoft.AspNetCore.StaticFiles;
 
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -26,7 +27,14 @@ if (!app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
+var provider = new FileExtensionContentTypeProvider();
+provider.Mappings[".wsv"] = "application/octet-stream";
+
 app.UseStaticFiles();
+app.UseStaticFiles(new StaticFileOptions // NOTE: for some reason, you still need the plain "UseStaticFiles" call above
+{
+    ContentTypeProvider = provider
+});
 
 app.UseRouting();
 

--- a/src/dymaptic.GeoBlazor.Core/Components/Views/SceneView.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/SceneView.cs
@@ -228,7 +228,7 @@ public class SceneView : MapView
 
             await ViewJsModule!.InvokeVoidAsync("setAssetsPath", CancellationTokenSource.Token,
                 Configuration.GetValue<string?>("ArcGISAssetsPath",
-                    "./_content/dymaptic.GeoBlazor.Core/assets"));
+                    "/_content/dymaptic.GeoBlazor.Core/assets"));
 
             await ViewJsModule!.InvokeVoidAsync("buildMapView",
                 CancellationTokenSource.Token, Id, DotNetObjectReference,

--- a/src/dymaptic.GeoBlazor.Core/assetCopy.ps1
+++ b/src/dymaptic.GeoBlazor.Core/assetCopy.ps1
@@ -1,7 +1,12 @@
 ﻿$SourceFiles = "./node_modules/@arcgis/core/assets/*"
 $OutputDir = "./wwwroot/assets"
+$packageJson = (Get-Content "package.json" -Raw) | ConvertFrom-Json
+# read the version from package.json
+$ArcGISVersion = $packageJson.dependencies."@arcgis/core"
+# remove the ^ from the version
+$ArcGISVersion = $ArcGISVersion.Replace("^", "")
 
-If ((Get-Content "$OutputDir/ArcGISAssetsVersion.txt") -ne "4.26.5")
+If ((Get-Content "$OutputDir/ArcGISAssetsVersion.txt") -ne $ArcGISVersion)
 {
     Write-Output "Deleting old assets"
     Remove-Item './wwwroot/assets/*' -Recurse -Verbose
@@ -22,7 +27,7 @@ If ((Test-Path -Path './wwwroot/assets/*') -eq $false)
         pause
     }
 
-    Write-Output "4.26.5" | Out-File -FilePath "$OutputDir/ArcGISAssetsVersion.txt"
+    Write-Output $ArcGISVersion | Out-File -FilePath "$OutputDir/ArcGISAssetsVersion.txt"
 }
 Else
 {

--- a/src/dymaptic.GeoBlazor.Core/package-lock.json
+++ b/src/dymaptic.GeoBlazor.Core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
-        "@arcgis/core": "4.26.5",
+        "@arcgis/core": "^4.26.5",
         "esbuild": "^0.17.5",
         "protobufjs": "^7.2.2",
         "protobufjs-cli": "^1.1.1"

--- a/src/dymaptic.GeoBlazor.Core/package.json
+++ b/src/dymaptic.GeoBlazor.Core/package.json
@@ -12,7 +12,7 @@
   "author": "Tim Purdum",
   "license": "ISC",
   "dependencies": {
-    "@arcgis/core": "4.26.5",
+    "@arcgis/core": "^4.26.5",
     "esbuild": "^0.17.5",
     "protobufjs": "^7.2.2",
     "protobufjs-cli": "^1.1.1"


### PR DESCRIPTION
This removes the Blazor Server error about 404 for `stars.wsv` - Closes #166 

Also updated ArcGIS to 4.26.5, and updated the `assetCopy.ps1` file to auto-load the ArcGIS version from `package.json` so it needs only be updated in one place.