### PR TITLE
Fix widgets on refresh

### DIFF
--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Widgets.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Widgets.razor
@@ -40,6 +40,7 @@
         <div id="gallery-box"></div>
     </div>
 </div>
+<button @onclick="@(() => MapView!.Refresh())">Refresh</button>
 
 <MapView @ref="MapView" Longitude="-40" Latitude="28" Zoom="2" Class="map-view">
     <Map ArcGISDefaultBasemap="arcgis-navigation" />

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -1476,6 +1476,11 @@ export async function addWidget(widget: any, viewId: string): Promise<void> {
         if (hasValue(widget.containerId)) {
             let container = document.getElementById(widget.containerId);
             let innerContainer = document.createElement('div');
+            innerContainer.id = `widget-${widget.type}`;
+            let existingWidget = document.getElementById(`widget-${widget.type}`);
+            if (existingWidget !== null) {
+                container?.removeChild(existingWidget);
+            }
             container?.appendChild(innerContainer);
             newWidget.container = innerContainer;
         } else {
@@ -1488,12 +1493,7 @@ export async function addWidget(widget: any, viewId: string): Promise<void> {
 
 async function createWidget(widget: any, viewId: string): Promise<Widget | null> {
     let view = arcGisObjectRefs[viewId] as MapView;
-    if (arcGisObjectRefs.hasOwnProperty(widget.id)) {
-        // for now just skip if it already exists
-        // later we may want to replace it with a remove and add
-        // if new values are added
-        return null;
-    }
+    
     let newWidget: Widget;
     switch (widget.type) {
         case 'locate':


### PR DESCRIPTION
Closes #176 

Simply removed the check in the `arcGisObjectRefs` dictionary that was preventing re-creating widgets. I checked and none of the calls to `createWidget` seem susceptible to rapid-calling from the blazor render cycle, so this should be fine. We can't re-use the stored widgets, however, in case the properties of the widget were changed and the goal of the refresh is to update it.

On testing on `Widgets.razor` in the samples app, I noticed that I also needed to add logic to clear out existing widgets placed outside of the map view in container divs.