### PR TITLE
fix: add pattern matching for ios support

### DIFF
--- a/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
@@ -2257,15 +2257,13 @@ public partial class MapView : MapComponent
     {
         List<string> activeHandlers = new();
 
-        IEnumerable<PropertyInfo> funcCallbacks = GetType()
-            .GetProperties()
-            .Where(p => p.PropertyType.Name.StartsWith("Func"));
+        var properties = GetType().GetProperties();
+
+        IEnumerable<PropertyInfo> funcCallbacks = properties.Where(p => p.PropertyType.Name.StartsWith("Func"));
 
         activeHandlers.AddRange(funcCallbacks.Select(x => x.Name));
 
-        IEnumerable<PropertyInfo> eventCallbacks = GetType()
-            .GetProperties()
-            .Where(p => p.PropertyType.Name.StartsWith(nameof(EventCallback)));
+        IEnumerable<PropertyInfo> eventCallbacks = properties.Where(p => p.PropertyType.Name.StartsWith(nameof(EventCallback)));
 
         foreach (PropertyInfo callbackInfo in eventCallbacks)
         {

--- a/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
@@ -2264,19 +2264,31 @@ public partial class MapView : MapComponent
 
         foreach (PropertyInfo callbackInfo in callbacks)
         {
-            dynamic? callback = callbackInfo.GetValue(this);
+            object? callback = callbackInfo.GetValue(this);
 
-            try
+            if(callback != null)
             {
-                if (callback is not null && callback.HasDelegate)
+                var hasDelegate = callback switch
                 {
-                    activeHandlers.Add(callbackInfo.Name);
-                }
-            }
-            catch
-            {
-                // Funcs don't have "HasDelegate"
-                if (callback is not null && callback.GetType().Name.StartsWith("Func"))
+                    EventCallback e => e.HasDelegate,
+                    EventCallback<ClickEvent> e => e.HasDelegate,
+                    EventCallback<BlurEvent> e => e.HasDelegate,
+                    EventCallback<DragEvent> e => e.HasDelegate,
+                    EventCallback<PointerEvent> e => e.HasDelegate,
+                    EventCallback<KeyDownEvent> e => e.HasDelegate,
+                    EventCallback<KeyUpEvent> e => e.HasDelegate,
+                    EventCallback<Guid> e => e.HasDelegate,
+                    EventCallback<SpatialReference> e => e.HasDelegate,
+                    EventCallback<Extent> e => e.HasDelegate,
+                    EventCallback<ResizeEvent> e => e.HasDelegate,
+                    EventCallback<MouseWheelEvent> e => e.HasDelegate,
+                    EventCallback<LayerViewCreateEvent> e => e.HasDelegate,
+                    EventCallback<LayerViewDestroyEvent> e => e.HasDelegate,
+                    EventCallback<LayerViewCreateErrorEvent> e => e.HasDelegate,
+                    _ => false
+                };
+
+                if(hasDelegate || callback.GetType().Name.StartsWith("Func"))
                 {
                     activeHandlers.Add(callbackInfo.Name);
                 }

--- a/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
@@ -2257,16 +2257,21 @@ public partial class MapView : MapComponent
     {
         List<string> activeHandlers = new();
 
-        IEnumerable<PropertyInfo> callbacks = GetType()
+        IEnumerable<PropertyInfo> funcCallbacks = GetType()
             .GetProperties()
-            .Where(p => p.PropertyType.Name.StartsWith(nameof(EventCallback)) ||
-                p.PropertyType.Name.StartsWith("Func"));
+            .Where(p => p.PropertyType.Name.StartsWith("Func"));
 
-        foreach (PropertyInfo callbackInfo in callbacks)
+        activeHandlers.AddRange(funcCallbacks.Select(x => x.Name));
+
+        IEnumerable<PropertyInfo> eventCallbacks = GetType()
+            .GetProperties()
+            .Where(p => p.PropertyType.Name.StartsWith(nameof(EventCallback)));
+
+        foreach (PropertyInfo callbackInfo in eventCallbacks)
         {
             object? callback = callbackInfo.GetValue(this);
 
-            if(callback != null)
+            if(callback is not null)
             {
                 var hasDelegate = callback switch
                 {
@@ -2288,7 +2293,7 @@ public partial class MapView : MapComponent
                     _ => false
                 };
 
-                if(hasDelegate || callback.GetType().Name.StartsWith("Func"))
+                if(hasDelegate)
                 {
                     activeHandlers.Add(callbackInfo.Name);
                 }


### PR DESCRIPTION
Fixes #186 

Instead of using `dynamic` in `GetActiveEventHandlers`, we can detect if it's a callback using pattern matching.  This is allowed in iOS.

https://learn.microsoft.com/en-us/xamarin/ios/internals/limitations#systemreflectionemit

I tested using the Server and WASM projects, all events still show.
![image](https://github.com/dymaptic/GeoBlazor/assets/4753021/34cb992c-7c05-4409-948b-cded2e9cc3ef)
