### PR TITLE
fix: FocusEvent callback needed

### DIFF
--- a/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
@@ -2277,6 +2277,7 @@ public partial class MapView : MapComponent
                     EventCallback<ClickEvent> e => e.HasDelegate,
                     EventCallback<BlurEvent> e => e.HasDelegate,
                     EventCallback<DragEvent> e => e.HasDelegate,
+                    EventCallback<FocusEvent> e => e.HasDelegate,
                     EventCallback<PointerEvent> e => e.HasDelegate,
                     EventCallback<KeyDownEvent> e => e.HasDelegate,
                     EventCallback<KeyUpEvent> e => e.HasDelegate,


### PR DESCRIPTION
Missed `FocusEvent` in #186 