### PR TITLE
Feature/193 feature edits

### DIFF
--- a/samples/dymaptic.GeoBlazor.Core.Sample.Maui/Platforms/Android/PermissionManagingBlazorWebChromeClient.cs
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Maui/Platforms/Android/PermissionManagingBlazorWebChromeClient.cs
@@ -16,7 +16,6 @@ using WebView = Android.Webkit.WebView;
 
 namespace dymaptic.GeoBlazor.Core.Sample.Maui.Platforms.Android;
 
-#nullable enable
 /// <summary>
 ///     Borrowed from https://github.com/MackinnonBuck/MauiBlazorPermissionsExample
 /// </summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayer.cs
@@ -229,6 +229,9 @@ public class FeatureLayer : Layer
     /// </summary>
     public Relationship[]? Relationships { get; set; }
     
+    /// <summary>
+    ///     The template used in an associated layer's FeatureForm Widget (Available in GeoBlazor Pro). All of the properties and field configurations set on the layer's FeatureForm are handled via the FormTemplate.
+    /// </summary>
     public FormTemplate? FormTemplate { get; set; }
 
     /// <inheritdoc />
@@ -303,6 +306,10 @@ public class FeatureLayer : Layer
         await RegisterChildComponent(template);
     }
 
+    /// <summary>
+    ///     Applies edits to features in a layer. New features can be created and existing features can be updated or deleted. Feature geometries and/or attributes may be modified. Only applicable to layers in a feature service and client-side features set through the FeatureLayer's source property. Attachments can also be added, updated or deleted.
+    ///     If client-side features are added, removed or updated at runtime using applyEdits() then use FeatureLayer's queryFeatures() method to return updated features.
+    /// </summary>
     public async Task<FeatureEditsResult> ApplyEdits(FeatureEdits edits, FeatureEditOptions? options = null)
     {
         return await JsLayerReference!.InvokeAsync<FeatureEditsResult>("applyEdits", edits, options, 
@@ -983,54 +990,225 @@ public class CreatePopupTemplateOptions
     public HashSet<string>? VisibleFieldNames { get; set; }
 }
 
+/// <summary>
+///     Object containing features and attachments to be added, updated or deleted.
+///     For use with <see cref="FeatureLayer.ApplyEdits"/>
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html#applyEdits">ArcGIS JS API</a>
+/// </summary>
 public class FeatureEdits
 {
+    /// <summary>
+    ///     An array or a collection of features to be added. Values of non nullable fields must be provided when adding new features. Date fields must have numeric values representing universal time.
+    /// </summary>
     public IEnumerable<Graphic>? AddFeatures { get; set; }
+    /// <summary>
+    ///     An array or a collection of features to be updated. Each feature must have valid objectId. Values of non nullable fields must be provided when updating features. Date fields must have numeric values representing universal time.
+    /// </summary>
     public IEnumerable<Graphic>? UpdateFeatures { get; set; }
+    /// <summary>
+    ///     An array or a collection of features, or an array of objects with objectId or globalId of each feature to be deleted. When an array or collection of features is passed, each feature must have a valid objectId. When an array of objects is used, each object must have a valid value set for objectId or globalId property.
+    /// </summary>
     public IEnumerable<Graphic>? DeleteFeatures { get; set; }
+    /// <summary>
+    ///     An array of attachments to be added. Applies only when the options.globalIdUsed parameter is set to true. User must provide globalIds for all attachments to be added.
+    /// </summary>
     public IEnumerable<AttachmentEdit>? AddAttachments { get; set; }
+    /// <summary>
+    ///     An array of attachments to be updated. Applies only when the options.globalIdUsed parameter is set to true. User must provide globalIds for all attachments to be updated.
+    /// </summary>
     public IEnumerable<AttachmentEdit>? UpdateAttachments { get; set; }
+    /// <summary>
+    ///     An array of globalIds for attachments to be deleted. Applies only when the options.globalIdUsed parameter is set to true.
+    /// </summary>
     public IEnumerable<string>? DeleteAttachments { get; set; }
 }
 
+
+/// <summary>
+///     AttachmentEdit represents an attachment that can be added, updated or deleted via applyEdits. This object can be either pre-uploaded data or base 64 encoded data.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html#AttachmentEdit">ArcGIS JS API</a>
+/// </summary>
 public class AttachmentEdit
 {
+    /// <summary>
+    ///     The feature, objectId or globalId of feature associated with the attachment.
+    /// </summary>
     public Graphic Feature { get; set; } = default!;
+    
+    /// <summary>
+    ///     The attachment to be added, updated or deleted.
+    /// </summary>
     public Attachment Attachment { get; set; } = default!;
 }
 
+/// <summary>
+///     The attachment to be added, updated or deleted in an <see cref="AttachmentEdit"/>.
+/// </summary>
 public class Attachment
 {
+    /// <summary>
+    ///     The globalId of the attachment to be added or updated. These Global IDs must be from the Global ID field created by ArcGIS. For more information on ArcGIS generated Global IDs, see the Global IDs and Attachments and relationship classes sections in the <a target="_blank" href="https://enterprise.arcgis.com/en/server/latest/publish-services/windows/prepare-data-for-offline-use.htm#ESRI_SECTION1_CDC34577197B43A980E4B5021DB1C32A">Data Preparation</a> documentation.
+    /// </summary>
     public string GlobalId { get; set; } = default!;
+    
+    /// <summary>
+    ///     The name of the attachment. This parameter must be set if the attachment type is Blob.
+    /// </summary>
     public string? Name { get; set; }
+    
+    /// <summary>
+    ///     The content type of the attachment. For example, 'image/jpeg'. See the ArcGIS REST API documentation for more information on supported attachment types.
+    /// </summary>
     public string? ContentType { get; set; }
+    
+    /// <summary>
+    ///     The id of pre-loaded attachment.
+    /// </summary>
     public string? UploadId { get; set; }
+    
+    /// <summary>
+    ///     The attachment data.
+    /// </summary>
     public string? Data { get; set; }
 }
 
+/// <summary>
+///     The options to use with <see cref="FeatureLayer.ApplyEdits"/>.
+/// </summary>
 public class FeatureEditOptions
 {
+    /// <summary>
+    ///     The geodatabase version to apply the edits. This parameter applies only if the capabilities.data.isVersioned property of the layer is true. If the gdbVersion parameter is not specified, edits are made to the published map’s version.
+    /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? GdbVersion { get; set; }
+    
+    /// <summary>
+    ///     Indicates whether the edit results should return the time edits were applied. If true, the feature service will return the time edits were applied in the edit result's editMoment property. Only applicable with ArcGIS Server services only.
+    /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? ReturnEditMoment { get; set; }
+    
+    /// <summary>
+    ///     If set to original-and-current-features, the EditedFeatureResult parameter will be included in the applyEdits response. It contains all edited features participating in composite relationships in a database as result of editing a feature. Note that even for deletions, the geometry and attributes of the deleted feature are returned. The original-and-current-features option is only valid when rollbackOnFailureEnabled is true. The default value is none, which will not include the EditedFeatureResult parameter in the response. This is only applicable with ArcGIS Server services only.
+    /// </summary>
+    /// <remarks>
+    ///     Possible values: "none" | "original-and-current-features"
+    /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ReturnServiceEditsOption { get; set; }
+    
+    /// <summary>
+    ///     Indicates whether the edits should be applied only if all submitted edits succeed. If false, the server will apply the edits that succeed even if some of the submitted edits fail. If true, the server will apply the edits only if all edits succeed. The layer's capabilities.editing.supportsRollbackOnFailure property must be true if using this parameter. If supportsRollbackOnFailure is false for a layer, then rollbackOnFailureEnabled will always be true, regardless of how the parameter is set.
+    /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? RollbackOnFailureEnabled { get; set; }
+    
+    /// <summary>
+    ///     Indicates whether the edits can be applied using globalIds of features or attachments. This parameter applies only if the layer's capabilities.editing.supportsGlobalId property is true. When false, globalIds submitted with the features are ignored and the service assigns new globalIds to the new features. When true, the globalIds must be submitted with the new features. When updating existing features, if the globalIdUsed is false, the objectIds of the features to be updated must be provided. If the globalIdUsed is true, globalIds of features to be updated must be provided. When deleting existing features, set this property to false as deletes operation only accepts objectIds at the current version of the API.
+    ///     When adding, updating or deleting attachments, globalIdUsed parameter must be set to true and the attachment globalId must be set. For new attachments, the user must provide globalIds. In order for an attachment to be updated or deleted, clients must include its globalId. Attachments are not supported in an edit payload when globalIdUsed is false.
+    /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? GlobalIdUsed { get; set; }
 }
 
+/// <summary>
+///     The result of <see cref="FeatureLayer.ApplyEdits"/>.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html#EditsResult">ArcGIS JS API</a>
+/// </summary>
+/// <param name="AddFeatureResults">
+///     Result of adding features.     
+/// </param>
+/// <param name="UpdateFeatureResults">
+///     Result of updating features.
+/// </param>
+/// <param name="DeleteFeatureResults">
+///     Result of deleting features.
+/// </param>
+/// <param name="AddAttachmentResults">
+///     Result of adding attachments.
+/// </param>
+/// <param name="UpdateAttachmentResults">
+///     Result of updating attachments.
+/// </param>
+/// <param name="DeleteAttachmentResults">
+///     Result of deleting attachments.
+/// </param>
+/// <param name="EditedFeatureResults">
+///     Edited features as result of editing a feature that participates in composite relationships in a database. This parameter is returned only when the returnServiceEditsOption parameter of the applyEdits() method is set to original-and-current-features.
+/// </param>
+/// <param name="EditMoment">
+///     The time edits were applied to the feature service. This parameter is returned only when the returnEditMoment parameter of the applyEdits() method is set to true.
+/// </param>
 public record FeatureEditsResult(FeatureEditResult[] AddFeatureResults, FeatureEditResult[] UpdateFeatureResults, 
     FeatureEditResult[] DeleteFeatureResults, FeatureEditResult[] AddAttachmentResults, 
     FeatureEditResult[] UpdateAttachmentResults, FeatureEditResult[] DeleteAttachmentResults,
     EditedFeatureResult[]? EditedFeatureResults, long? EditMoment);
 
+/// <summary>
+///     FeatureEditResult represents the result of adding, updating or deleting a feature or an attachment.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html#FeatureEditResult">ArcGIS JS API</a>
+/// </summary>
+/// <param name="ObjectId">
+///     The objectId of the feature or the attachmentId of the attachment that was edited.
+/// </param>
+/// <param name="GlobalId">
+///     The globalId of the feature or the attachment that was edited.
+/// </param>
+/// <param name="Error">
+///     If the edit failed, the edit result includes an error.
+/// </param>
 public record FeatureEditResult(long? ObjectId, string? GlobalId, EditError? Error);
+
+/// <summary>
+///     The error object in a <see cref="FeatureEditResult"/>
+/// </summary>
+/// <param name="Name">
+///     Error name.
+/// </param>
+/// <param name="Message">
+///     Message describing the error.
+/// </param>
 public record EditError(string? Name, string? Message);
+
+/// <summary>
+///     Results returned from the applyEdits method if the returnServiceEditsOption parameter is set to original-and-current-features. It contains features that were added, deleted or updated in different feature layers of a feature service as a result of editing a single feature that participates in a composite relationship in a database. The results are organized by each layer affected by the edit. For example, if a feature is deleted and it is the origin in a composite relationship, the edited features as a result of this deletion are returned.
+///     The editedFeatures object returns full features including newly added features, the original features prior to delete, the original and current features for updates.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html#EditedFeatureResult">ArcGIS JS API</a>
+/// </summary>
+/// <param name="LayerId">
+///     The layerId of the feature layer where features were edited.
+/// </param>
+/// <param name="EditedFeatures">
+///     Object containing all edited features belonging to the specified layer.
+/// </param>
 public record EditedFeatureResult(long? LayerId, EditedFeatures? EditedFeatures);
 
+/// <summary>
+///     The edited features of an <see cref="EditedFeatureResult"/>
+/// </summary>
+/// <param name="Adds">
+///     Newly added features as a result of editing a feature that participates in a composite relationship.
+/// </param>
+/// <param name="Updates">
+///     Object containing original and updated features as a result of editing a feature that participates in a composite relationship.
+/// </param>
+/// <param name="Deletes">
+///     Deleted features as a result of editing a feature that participates in a composite relationship.
+/// </param>
+/// <param name="SpatialReference">
+///     Edited features are returned in the spatial reference of the feature service.
+/// </param>
 public record EditedFeatures(Graphic[] Adds, EditedFeatureUpdate[] Updates, Graphic[] Deletes,
     SpatialReference SpatialReference);
+
+/// <summary>
+///     The update object of a <see cref="EditedFeatures"/>.
+/// </summary>
+/// <param name="Original">
+///     Original feature before the update took place.
+/// </param>
+/// <param name="Current">
+///     Updated feature as a result of editing a feature that participates in a composite relationship.
+/// </param>
 public record EditedFeatureUpdate(Graphic[] Original, Graphic[] Current);

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/Field.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/Field.cs
@@ -9,10 +9,7 @@ namespace dymaptic.GeoBlazor.Core.Components.Layers;
 /// <summary>
 ///     Information about each field in a layer. Field objects must be constructed when creating a FeatureLayer from
 ///     client-side graphics. This class allows you to define the schema of each field in the FeatureLayer.
-///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-support-Field.html">
-///         ArcGIS
-///         JS API
-///     </a>
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-support-Field.html">ArcGIS JS API</a>
 /// </summary>
 public class Field : MapComponent
 {
@@ -133,8 +130,12 @@ public class Field : MapComponent
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public FieldValueType? ValueType { get; set; }
     
+    /// <summary>
+    ///     The domain associated with the field. Domains are used to constrain the values allowed in a field. There are two types of domains: RangeDomain and CodedValueDomain.
+    /// </summary>
     public Domain? Domain { get; set; }
 
+    /// <inheritdoc />
     public override async Task RegisterChildComponent(MapComponent child)
     {
         switch (child)
@@ -153,6 +154,7 @@ public class Field : MapComponent
         }
     }
     
+    /// <inheritdoc />
     public override async Task UnregisterChildComponent(MapComponent child)
     {
         switch (child)

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/Field.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/Field.cs
@@ -1,4 +1,5 @@
-﻿using dymaptic.GeoBlazor.Core.Serialization;
+﻿using dymaptic.GeoBlazor.Core.Components.Widgets;
+using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
 using System.Text.Json.Serialization;
 
@@ -131,6 +132,44 @@ public class Field : MapComponent
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public FieldValueType? ValueType { get; set; }
+    
+    public Domain? Domain { get; set; }
+
+    public override async Task RegisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case Domain domain:
+                if (!domain.Equals(Domain))
+                {
+                    Domain = domain;
+                }
+
+                break;
+            default:
+                await base.RegisterChildComponent(child);
+
+                break;
+        }
+    }
+    
+    public override async Task UnregisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case Domain domain:
+                if (domain.Equals(Domain))
+                {
+                    Domain = null;
+                }
+
+                break;
+            default:
+                await base.UnregisterChildComponent(child);
+
+                break;
+        }
+    }
 }
 
 /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
@@ -1987,6 +1987,24 @@ public partial class MapView : MapComponent
     }
 
     /// <summary>
+    ///     Returns the current cursor when hovering over the view.
+    /// </summary>
+    public async Task<string> GetCursor()
+    {
+        return await ViewJsModule!.InvokeAsync<string>("getCursor",
+            CancellationTokenSource.Token, Id);
+    }
+    
+    /// <summary>
+    ///     Sets the cursor for the view.
+    /// </summary>
+    public async Task SetCursor(string cursor)
+    {
+        await ViewJsModule!.InvokeVoidAsync("setCursor",
+            CancellationTokenSource.Token, cursor, Id);
+    }
+
+    /// <summary>
     ///     The callback method for returning a chunk of data from a Blazor Server hit test.
     /// </summary>
     /// <param name="eventId">

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/Domain.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/Domain.cs
@@ -1,0 +1,112 @@
+﻿using Microsoft.AspNetCore.Components;
+
+
+namespace dymaptic.GeoBlazor.Core.Components.Widgets;
+
+/// <summary>
+///     Domains define constraints on a layer field. There are two types of domains: coded values and range domains. This is an abstract class.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-support-Domain.html">ArcGIS JS API</a>
+/// </summary>
+public abstract class Domain : MapComponent
+{
+    /// <summary>
+    ///     The domain type.
+    /// </summary>
+    public abstract string Type { get; }
+    
+    /// <summary>
+    ///     The domain name.
+    /// </summary>
+    [Parameter]
+    public string? Name { get; set; }
+}
+
+/// <summary>
+///     Information about the coded values belonging to the domain. Coded value domains specify a valid set of values for a field. Each valid value is assigned a unique name. For example, in a layer for water mains, water main features may be buried under different types of surfaces as signified by a GroundSurfaceType field: pavement, gravel, sand, or none (for exposed water mains). The coded value domain includes both the actual value that is stored in the database (for example, 1 for pavement) and a more user-friendly description of what that value actually means.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-support-CodedValueDomain.html">ArcGIS JS API</a>
+/// </summary>
+public class CodedValueDomain : Domain
+{
+    /// <inheritdoc />
+    public override string Type => "coded-value";
+    
+    /// <summary>
+    ///     An array of the coded values in the domain.
+    /// </summary>
+    public HashSet<CodedValue>? CodedValues { get; set; }
+
+    /// <inheritdoc />
+    public override async Task RegisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case CodedValue codedValue:
+                CodedValues ??= new HashSet<CodedValue>();
+                
+                CodedValues.Add(codedValue);
+
+                break;
+            default:
+                await base.RegisterChildComponent(child);
+
+                break;
+        }
+    }
+    
+    /// <inheritdoc />
+    public override async Task UnregisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case CodedValue codedValue:
+                CodedValues?.Remove(codedValue);
+
+                break;
+            default:
+                await base.UnregisterChildComponent(child);
+
+                break;
+        }
+    }
+}
+
+/// <summary>
+///     The coded value in a domain.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-support-CodedValueDomain.html#CodedValue">ArcGIS JS API</a>
+/// </summary>
+public class CodedValue : MapComponent
+{
+    /// <summary>
+    ///     The name of the coded value.
+    /// </summary>
+    [Parameter]
+    public string? Name { get; set; }
+    
+    /// <summary>
+    ///     The value of the code.
+    /// </summary>
+    [Parameter]
+    public string? Code { get; set; }
+}
+
+/// <summary>
+///     Range domains specify a valid minimum and maximum valid value that can be stored in numeric and date fields.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-support-RangeDomain.html">ArcGIS JS API</a>
+/// </summary>
+public class RangeDomain : Domain
+{
+    /// <inheritdoc />
+    public override string Type => "range";
+    
+    /// <summary>
+    ///     The maximum valid value.
+    /// </summary>
+    [Parameter]
+    public double? MaxValue { get; set; }
+    
+    /// <summary>
+    ///     The minimum valid value.
+    /// </summary>
+    [Parameter]
+    public double? MinValue { get; set; }
+}

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/FormElement.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/FormElement.cs
@@ -1,0 +1,213 @@
+﻿using dymaptic.GeoBlazor.Core.Serialization;
+using Microsoft.AspNetCore.Components;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+
+namespace dymaptic.GeoBlazor.Core.Components.Widgets;
+[JsonConverter(typeof(FormElementConverter))]
+public abstract class FormElement: MapComponent
+{
+    /// <summary>
+    ///     The element's description providing the purpose behind it.
+    /// </summary>
+    [Parameter]
+    public string? Description { get; set; }
+    
+    /// <summary>
+    ///     A string value containing the field alias. This is not to Arcade expressions as the title is used instead.
+    /// </summary>
+    [Parameter]
+    public string? Label { get; set; }
+    
+    /// <summary>
+    ///     A reference to the name of an Arcade expression defined in the expressionInfos of the FormTemplate. The expression must follow the specification defined by the Form Constraint Profile. Expressions may reference field values using the $feature profile variable and must return either true or false.
+    /// </summary>
+    /// <remarks>
+    ///     When this expression evaluates to true, the element is displayed. When the expression evaluates to false the element is not displayed. If no expression is provided, the element is always displayed. Care must be taken when defining a visibility expression for a non-nullable field i.e. to make sure that such fields either have default values or are made visible to users so that they can provide a value before submitting the form.
+    ///     The referenced expression must be defined in the form template's expressionInfos. It cannot be set inline within the element object.
+    /// </remarks>
+    [Parameter]
+    public string? VisibilityExpression { get; set; }
+    
+    /// <summary>
+    ///     Indicates the type of form element.
+    /// </summary>
+    public abstract string Type { get; }
+}
+
+/// <summary>
+///     A FieldElement form element defines how a feature layer's field participates in the FeatureForm. This is the recommended approach to set field configurations within a feature form's or feature layer's formTemplate.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-form-elements-FieldElement.html">ArcGIS JS API</a>
+/// </summary>
+public class FieldElement : FormElement
+{
+    /// <inheritdoc />
+    public override string Type => "field";
+
+    /// <summary>
+    ///      A reference to the name of an Arcade expression defined in the expressionInfos of the FormTemplate. The expression must follow the specification defined in the Form Constraint Profile. Expressions may reference field values using the $feature global input and must return either true or false.
+    /// </summary>
+    /// <remarks>
+    ///     A reference to the name of an Arcade expression defined in the expressionInfos of the FormTemplate. The expression must follow the specification defined in the Form Constraint Profile. Expressions may reference field values using the $feature global input and must return either true or false.
+    ///     The referenced expression must be defined in the form template's expressionInfos. It cannot be set inline within the element object.
+    /// </remarks>
+    [Parameter]
+    public string? EditableExpression { get; set; }
+    
+    [Parameter]
+    public string? RequiredExpression { get; set; }
+    
+    /// <summary>
+    ///     The field name as defined by the feature layer. Set this property to indicate which field to edit.
+    /// </summary>
+    [Parameter]
+    public string? FieldName { get; set; }
+    
+    /// <summary>
+    ///     Contains a hint used to help editors while editing fields. Set this as a temporary placeholder for text/number inputs in either TextAreaInput or TextBoxInput.
+    /// </summary>
+    [Parameter]
+    public string? Hint { get; set; }
+    
+    /// <summary>
+    ///     A reference to the name of an Arcade expression defined in the expressionInfos of the FormTemplate. The expression must follow the specification defined in the Form Calculation Profile. This expression references field values within an individual feature or in other layers and must return either a date, number, or string value.
+    /// </summary>
+    /// <remarks>
+    ///     Once the expression evaluates, the form's field value updates to the expressions' result.
+    ///     It is required to set the view property when instantiating a FeatureForm widget and using expressions that use the $map variable.
+    ///     The referenced expression must be defined in the form template's expressionInfos. It cannot be set inline within the element object.
+    /// </remarks>
+    public string? ValueExpression { get; internal set; }
+    
+    /// <summary>
+    ///     The coded value domain or range domain of the field.
+    /// </summary>
+    public Domain? Domain { get; set; }
+    
+    /// <summary>
+    ///     The input to use for the element. The client application is responsible for defining the default user interface.
+    /// </summary>
+    public FormInput? Input { get; set; }
+
+    /// <inheritdoc />
+    public override async Task RegisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case Domain domain:
+                Domain = domain;
+
+                break;
+            case FormInput formInput:
+                Input = formInput;
+
+                break;
+            default:
+                await base.RegisterChildComponent(child);
+                
+                break;
+        }
+    }
+    
+    /// <inheritdoc />
+    public override async Task UnregisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case Domain _:
+                Domain = null;
+
+                break;
+            case FormInput _:
+                Input = null;
+
+                break;
+            default:
+                await base.UnregisterChildComponent(child);
+                
+                break;
+        }
+    }
+}
+
+public class GroupElement : FormElement
+{
+    /// <inheritdoc />
+    public override string Type => "group";
+    
+    public List<FieldElement>? Elements { get; set; }
+
+    /// <inheritdoc />
+    public override async Task RegisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case FieldElement fieldElement:
+                Elements ??= new List<FieldElement>();
+                Elements.Add(fieldElement);
+
+                break;
+            
+            default:
+                await base.RegisterChildComponent(child);
+
+                break;
+        }
+    }
+    
+    /// <inheritdoc />
+    public override async Task UnregisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case FieldElement fieldElement:
+                Elements?.Remove(fieldElement);
+
+                break;
+            
+            default:
+                await base.UnregisterChildComponent(child);
+
+                break;
+        }
+    }
+
+    /// <inheritdoc />
+    internal override void ValidateRequiredChildren()
+    {
+        if (Elements is not null)
+        {
+            foreach (FieldElement element in Elements)
+            {
+                element.ValidateRequiredChildren();
+            }
+        }
+        base.ValidateRequiredChildren();
+    }
+}
+
+/// <summary>
+///     Return types for Arcade expressions.
+/// </summary>
+[JsonConverter(typeof(EnumToKebabCaseStringConverter<ArcadeReturnType>))]
+public enum ArcadeReturnType
+{
+    Boolean,
+    Date,
+    Number,
+    String
+}
+
+internal class FormElementConverter : JsonConverter<FormElement>
+{
+    public override FormElement? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void Write(Utf8JsonWriter writer, FormElement value, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, (object)value, options);
+    }
+}

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/FormInput.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/FormInput.cs
@@ -1,0 +1,184 @@
+﻿using Microsoft.AspNetCore.Components;
+
+
+namespace dymaptic.GeoBlazor.Core.Components.Widgets;
+
+/// <summary>
+///     Abstract base class for Input fields in a form element.
+/// </summary>
+public abstract class FormInput : MapComponent
+{
+    /// <summary>
+    ///     The type of form element input.
+    /// </summary>
+    public abstract string Type { get; }
+}
+
+/// <summary>
+///     The TextBoxInput class defines the desired user interface as a single-line text box.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-form-elements-inputs-TextBoxInput.html">ArcGIS JS API</a>
+/// </summary>
+public class TextBoxInput : FormInput
+{
+    /// <inheritdoc />
+    public override string Type => "text-box";
+    
+    /// <summary>
+    ///     When set, defines the text input's maximum length.
+    /// </summary>
+    [Parameter]
+    public int? MaxLength { get; set; }
+    
+    /// <summary>
+    ///     When set, defines the text input's minimum length.
+    /// </summary>
+    [Parameter]
+    public int? MinLength { get; set; }
+}
+
+/// <summary>
+///     The TextAreaInput class defines the desired user interface as a multi-line text area.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-form-elements-inputs-TextAreaInput.html">ArcGIS JS API</a>
+/// </summary>
+public class TextAreaInput : FormInput
+{
+    /// <inheritdoc />
+    public override string Type => "text-area";
+    
+    /// <summary>
+    ///     When set, defines the text input's maximum length.
+    /// </summary>
+    [Parameter]
+    public int? MaxLength { get; set; }
+    
+    /// <summary>
+    ///     When set, defines the text input's minimum length.
+    /// </summary>
+    [Parameter]
+    public int? MinLength { get; set; }
+}
+
+/// <summary>
+///     The DateTimePickerInput class defines the desired user interface for editing date fields in a form.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-form-elements-inputs-DateTimePickerInput.html">ArcGIS JS API</a>
+/// </summary>
+public class DateTimePickerInput : FormInput
+{
+    /// <inheritdoc />
+    public override string Type => "datetime-picker";
+    
+    /// <summary>
+    ///     Indicates if the input should provide an option to select the time. If not provided, the default value is false.
+    /// </summary>
+    [Parameter]
+    public bool? IncludeTime { get; set; }
+    
+    /// <summary>
+    ///     The maximum date to allow. The number represents the number of milliseconds since epoch (January 1, 1970) in UTC.
+    /// </summary>
+    [Parameter]
+    public long? Max { get; set; }
+    
+    /// <summary>
+    ///     The minimum date to allow. The number represents the number of milliseconds since epoch (January 1, 1970) in UTC.
+    /// </summary>
+    [Parameter]
+    public long? Min { get; set; }
+}
+
+/// <summary>
+///     The BarcodeScannerInput class defines the desired user interface for a barcode or QR code scanner. This input type will default to the TextBoxInput type as the API does not currently support bar code scanning.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-form-elements-inputs-BarcodeScannerInput.html">ArcGIS JS API</a>
+/// </summary>
+public class BarcodeScannerInput : FormInput
+{
+    /// <inheritdoc />
+    public override string Type => "barcode-scanner";
+    
+    /// <summary>
+    ///     When set, defines the text input's maximum length.
+    /// </summary>
+    [Parameter]
+    public int? MaxLength { get; set; }
+    
+    /// <summary>
+    ///     When set, defines the text input's minimum length.
+    /// </summary>
+    [Parameter]
+    public int? MinLength { get; set; }
+}
+
+/// <summary>
+///     The ComboBoxInput class defines the desired user interface for a combo box group.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-form-elements-inputs-ComboBoxInput.html">ArcGIS JS API</a>
+/// </summary>
+/// <remarks>
+///     Coded-value domains are required when using this input type. Previously, fields containing values that weren't compatible with their associated coded-value domain(s) displayed the option and would remove it once a user updated the value. The ComboBoxInput will now display and keep the value but will disable it.
+/// </remarks>
+public class ComboBoxInput : FormInput
+{
+    /// <inheritdoc />
+    public override string Type => "combo-box";
+    
+    /// <summary>
+    ///     The text used to represent a null value.
+    /// </summary>
+    [Parameter]
+    public string? NoValueOptionLabel { get; set; }
+    
+    /// <summary>
+    ///     Determines whether a null value option is displayed. This only applies to fields that support null values.
+    /// </summary>
+    [Parameter]
+    public bool? ShowNoValueOption { get; set; }
+}
+
+/// <summary>
+///     https://developers.arcgis.com/javascript/latest/api-reference/esri-form-elements-inputs-RadioButtonsInput.html
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-form-elements-inputs-RadioButtonsInput.html">ArcGIS JS API</a>
+/// </summary>
+/// <remarks>
+///     Coded-value domains are required when using this input type. Previously, fields containing values that weren't compatible with their associated coded-value domain(s) displayed the option and would remove it once a user updated the value. The RadioButtonsInput will now keep the value, but it will not display an option in the user interface.
+/// </remarks>
+public class RadioButtonsInput : FormInput
+{
+    /// <inheritdoc />
+    public override string Type => "radio-buttons";
+    
+    /// <summary>
+    ///     The text used to represent a null value.
+    /// </summary>
+    [Parameter]
+    public string? NoValueOptionLabel { get; set; }
+    
+    /// <summary>
+    ///     Determines whether a null value option is displayed. This only applies to fields that support null values.
+    /// </summary>
+    [Parameter]
+    public bool? ShowNoValueOption { get; set; }
+}
+
+/// <summary>
+///     The SwitchInput class defines the desired user interface for a binary switch or toggle. This should be used when selecting between two options.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-form-elements-inputs-SwitchInput.html">ArcGIS JS API</a>
+/// </summary>
+/// <remarks>
+///     Coded-value domains are required when using this input type.
+/// </remarks>
+public class SwitchInput : FormInput
+{
+    /// <inheritdoc />
+    public override string Type => "switch";
+    
+    /// <summary>
+    ///     Coded value used when the switch state is turned off. Values that are parseable as numbers will be converted.
+    /// </summary>
+    [Parameter]
+    public string? OffValue { get; set; }
+    
+    /// <summary>
+    ///     Coded value used when the switch state is turned on. Values that are parseable as numbers will be converted.
+    /// </summary>
+    [Parameter]
+    public string? OnValue { get; set; }
+}

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/FormTemplate.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/FormTemplate.cs
@@ -1,0 +1,63 @@
+﻿using dymaptic.GeoBlazor.Core.Components.Popups;
+using Microsoft.AspNetCore.Components;
+
+
+namespace dymaptic.GeoBlazor.Core.Components.Widgets;
+
+public class FormTemplate : MapComponent
+{
+    [Parameter]
+    public string? Description { get; set; }
+    
+    [Parameter]
+    public bool? PreserveFieldValuesWhenHidden { get; set; }
+    
+    [Parameter]
+    public string? Title { get; set; }
+    
+    public HashSet<FormElement>? Elements { get; set; }
+    
+    public HashSet<ExpressionInfo>? ExpressionInfos { get; set; }
+
+    public override async Task RegisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case FormElement formElement:
+                Elements ??= new HashSet<FormElement>();
+                
+                Elements.Add(formElement);
+
+                break;
+            case ExpressionInfo expressionInfo:
+                ExpressionInfos ??= new HashSet<ExpressionInfo>();
+                
+                ExpressionInfos.Add(expressionInfo);
+
+                break;
+            default:
+                await base.RegisterChildComponent(child);
+
+                break;
+        }
+    }
+    
+    public override async Task UnregisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case FormElement formElement:
+                Elements?.Remove(formElement);
+
+                break;
+            case ExpressionInfo expressionInfo:
+                ExpressionInfos?.Remove(expressionInfo);
+
+                break;
+            default:
+                await base.UnregisterChildComponent(child);
+
+                break;
+        }
+    }
+}

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/FormTemplate.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/FormTemplate.cs
@@ -4,21 +4,46 @@ using Microsoft.AspNetCore.Components;
 
 namespace dymaptic.GeoBlazor.Core.Components.Widgets;
 
+/// <summary>
+///     A FormTemplate formats and defines the content of a FeatureForm for a specific Layer or Graphic. A FormTemplate allows the user to access values from feature attributes when a feature in the view is selected.
+///     The FormTemplate can be set directly on a FeatureLayer, a FeatureForm, or its view model. The template consists of various elements that display a specific type of form data.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-form-FormTemplate.html">ArcGIS JS API</a>
+/// </summary>
 public class FormTemplate : MapComponent
 {
+    /// <summary>
+    ///     The description of the form.
+    /// </summary>
     [Parameter]
     public string? Description { get; set; }
     
+    /// <summary>
+    ///     Indicates whether to retain or clear a form's field element values. Use this property when a field element initially displays as visible but then updates to not display as a result of an applied visibilityExpression.
+    /// </summary>
     [Parameter]
     public bool? PreserveFieldValuesWhenHidden { get; set; }
-    
+
+    /// <summary>
+    ///     The string template for defining how to format the title displayed at the top of a form.
+    /// </summary>
     [Parameter]
     public string? Title { get; set; }
     
+    /// <summary>
+    ///     An array of form element objects that represent an ordered list of form elements.
+    ///     Elements are designed to allow the form author the ability to define the layout for fields when collecting and/or editing data.
+    /// </summary>
+    /// <remarks>
+    ///     Nested group elements are not supported.
+    /// </remarks>
     public HashSet<FormElement>? Elements { get; set; }
     
+    /// <summary>
+    ///     An array of objects or ExpressionInfo[] that reference Arcade expressions following the specification defined by the Form Constraint Profile or the Form Calculation Profile. Form Constraint expressions must return either true or false. Form Calculation expressions must return a string, date, or a number.
+    /// </summary>
     public HashSet<ExpressionInfo>? ExpressionInfos { get; set; }
 
+    /// <inheritdoc />
     public override async Task RegisterChildComponent(MapComponent child)
     {
         switch (child)
@@ -42,6 +67,7 @@ public class FormTemplate : MapComponent
         }
     }
     
+    /// <inheritdoc />
     public override async Task UnregisterChildComponent(MapComponent child)
     {
         switch (child)

--- a/src/dymaptic.GeoBlazor.Core/Objects/Query.cs
+++ b/src/dymaptic.GeoBlazor.Core/Objects/Query.cs
@@ -158,7 +158,7 @@ public class Query
     ///     An array of ObjectIDs to be used to query for features in a layer.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public IEnumerable<int>? ObjectIds { get; set; }
+    public IEnumerable<long>? ObjectIds { get; set; }
 
     /// <summary>
     ///     One or more field names used to order the query results. Specify ASC (ascending) or DESC (descending) after the

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -2330,3 +2330,13 @@ export function getAuthenticationManager(dotNetRef: any, apiKey: string | null, 
     }
     return _authenticationManager;
 }
+
+export function getCursor(viewId: string): string {
+    let view = arcGisObjectRefs[viewId] as MapView;
+    return view.container.style.cursor;
+}
+
+export function setCursor(cursorType: string, viewId: string) {
+    let view = arcGisObjectRefs[viewId] as MapView;
+    view.container.style.cursor = cursorType;
+}

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -64,7 +64,7 @@ import {
 import {
     buildJsAttributes,
     buildJsExtent,
-    buildJsFields,
+    buildJsFields, buildJsFormTemplate,
     buildJsGeometry,
     buildJsGraphic,
     buildJsPoint,
@@ -1853,6 +1853,11 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
 
             copyValuesIfExists(layerObject, featureLayer, 'minScale', 'maxScale', 'orderBy', 'objectIdField',
                 'definitionExpression', 'labelingInfo', 'outFields');
+            
+            if (hasValue(layerObject.formTemplate)) {
+                featureLayer.formTemplate = buildJsFormTemplate(layerObject.formTemplate);
+                console.log('feature form: ' + JSON.stringify(featureLayer.formTemplate.toJSON()));
+            }
 
             if (hasValue(layerObject.popupTemplate)) {
                 featureLayer.popupTemplate = buildJsPopupTemplate(layerObject.popupTemplate, viewId ?? null);

--- a/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
@@ -465,3 +465,25 @@ export interface DotNetRelatedRecordsInfoFieldOrder {
     field: string;
     order: string;
 }
+
+export interface DotNetApplyEdits {
+    addFeatures: DotNetGraphic[];
+    updateFeatures: DotNetGraphic[];
+    deleteFeatures: DotNetGraphic[];
+    addAttachments: DotNetAttachmentsEdit[];
+    updateAttachments: DotNetAttachmentsEdit[];
+    deleteAttachments: string[];
+}
+
+export interface DotNetAttachmentsEdit {
+    feature: DotNetGraphic | number | string;
+    attachment: DotNetAttachment;
+}
+
+export interface DotNetAttachment {
+    globalId: string;
+    name: string;
+    contentType: string;
+    uploadId: string;
+    data: string;
+}

--- a/src/dymaptic.GeoBlazor.Core/Scripts/featureLayer.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/featureLayer.ts
@@ -3,6 +3,7 @@ import FeatureLayer from "@arcgis/core/layers/FeatureLayer";
 import Query from "@arcgis/core/rest/support/Query";
 import FeatureSet from "@arcgis/core/rest/support/FeatureSet";
 import {
+    DotNetApplyEdits,
     DotNetFeatureSet,
     DotNetGraphic,
     DotNetPopupTemplate,
@@ -10,7 +11,7 @@ import {
     DotNetRelationshipQuery,
     DotNetTopFeaturesQuery
 } from "./definitions";
-import {buildJsQuery, buildJsRelationshipQuery, buildJsTopFeaturesQuery} from "./jsBuilder";
+import {buildJsApplyEdits, buildJsQuery, buildJsRelationshipQuery, buildJsTopFeaturesQuery} from "./jsBuilder";
 import {
     buildDotNetExtent,
     buildDotNetGeometry,
@@ -224,5 +225,10 @@ export default class FeatureLayerWrapper {
             count: result.count,
             extent: buildDotNetExtent(result.extent)
         };
+    }
+    
+    applyEdits(edits: DotNetApplyEdits, options: any, viewId: string): Promise<any> {
+        let jsEdits = buildJsApplyEdits(edits, viewId);
+        return this.layer.applyEdits(jsEdits, options);
     }
 }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/featureLayer.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/featureLayer.ts
@@ -227,13 +227,13 @@ export default class FeatureLayerWrapper {
         };
     }
     
-    applyEdits(edits: DotNetApplyEdits, options: any, viewId: string): Promise<any> {
+    async applyEdits(edits: DotNetApplyEdits, options: any, viewId: string): Promise<any> {
         let jsEdits = buildJsApplyEdits(edits, viewId);
         let result;
         if (options !== null) {
-            result = this.layer.applyEdits(jsEdits, options);
+            result = await this.layer.applyEdits(jsEdits, options);
         } else {
-            result = this.layer.applyEdits(jsEdits);
+            result = await this.layer.applyEdits(jsEdits);
         }
         
         return result;

--- a/src/dymaptic.GeoBlazor.Core/Scripts/featureLayer.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/featureLayer.ts
@@ -229,6 +229,13 @@ export default class FeatureLayerWrapper {
     
     applyEdits(edits: DotNetApplyEdits, options: any, viewId: string): Promise<any> {
         let jsEdits = buildJsApplyEdits(edits, viewId);
-        return this.layer.applyEdits(jsEdits, options);
+        let result;
+        if (options !== null) {
+            result = this.layer.applyEdits(jsEdits, options);
+        } else {
+            result = this.layer.applyEdits(jsEdits);
+        }
+        
+        return result;
     }
 }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/featureLayerView.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/featureLayerView.ts
@@ -2,10 +2,11 @@
 import FeatureEffect from "@arcgis/core/layers/support/FeatureEffect";
 import Query from "@arcgis/core/rest/support/Query";
 import {DotNetFeatureSet, DotNetGraphic, DotNetQuery} from "./definitions";
-import {buildJsQuery} from "./jsBuilder";
+import {buildJsGraphic, buildJsQuery} from "./jsBuilder";
 import {blazorServer, dotNetRefs, graphicsRefs} from "./arcGisJsInterop";
 import Handle = __esri.Handle;
 import {buildDotNetGeometry, buildDotNetGraphic, buildDotNetSpatialReference} from "./dotNetBuilder";
+import Graphic from "@arcgis/core/Graphic";
 
 export default class FeatureLayerViewWrapper {
     private featureLayerView: FeatureLayerView;
@@ -41,7 +42,23 @@ export default class FeatureLayerViewWrapper {
     }
 
     highlight(target: any): Handle {
-        return this.featureLayerView.highlight(target);
+        let graphics: Graphic[] = [];
+        if (Array.isArray(target)) {
+            target.forEach(t => {
+                if (graphicsRefs.hasOwnProperty(t.id)) {
+                    graphics.push(graphicsRefs[t.id]);
+                } else {
+                    graphics.push(buildJsGraphic(t, null) as Graphic);
+                }
+            });
+        } else {
+            if (graphicsRefs.hasOwnProperty(target.id)) {
+                graphics.push(graphicsRefs[target.id]);
+            } else {
+                graphics.push(buildJsGraphic(target, null) as Graphic);
+            }
+        }
+        return this.featureLayerView.highlight(graphics);
     }
 
     async queryExtent(query: DotNetQuery, options: any): Promise<any> {

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -101,6 +101,7 @@ import BarcodeScannerInput from "@arcgis/core/form/elements/inputs/BarcodeScanne
 import ComboBoxInput from "@arcgis/core/form/elements/inputs/ComboBoxInput";
 import RadioButtonsInput from "@arcgis/core/form/elements/inputs/RadioButtonsInput";
 import SwitchInput from "@arcgis/core/form/elements/inputs/SwitchInput";
+import Domain from "@arcgis/core/layers/support/Domain";
 
 export function buildJsSpatialReference(dotNetSpatialReference: DotNetSpatialReference): SpatialReference {
     if (dotNetSpatialReference === undefined || dotNetSpatialReference === null) {
@@ -495,16 +496,65 @@ export function buildJsRenderer(dotNetRenderer: any): Renderer | null {
 export function buildJsFields(dotNetFields: any): Array<Field> {
     let fields: Array<Field> = [];
     dotNetFields.forEach(dnField => {
-        let field = new Field();
-        for (const prop in dnField) {
-            if (Object.prototype.hasOwnProperty.call(dnField, prop) && prop !== 'id') {
-                field[prop] = dnField[prop];
-            }
-        }
+        let field = buildJsField(dnField);
         fields.push(field);
     });
 
     return fields;
+}
+
+function buildJsField(dotNetField: any): Field {
+    let field = new Field();
+    if (hasValue(dotNetField.type)) {
+        field.type = dotNetField.type;
+    }
+    if (hasValue(dotNetField.alias)) {
+        field.alias = dotNetField.alias;
+    }
+    if (hasValue(dotNetField.name)) {
+        field.name = dotNetField.name;
+    }
+    if (hasValue(dotNetField.length)) {
+        field.length = dotNetField.length;
+    }
+    if (hasValue(dotNetField.nullable)) {
+        field.nullable = dotNetField.nullable;
+    }
+    if (hasValue(dotNetField.domain)) {
+        switch (dotNetField.domain.type) {
+            case "coded-value":
+                let codedValueDomain = new CodedValueDomain();
+                codedValueDomain.name = dotNetField.domain.name;
+                codedValueDomain.codedValues = dotNetField.domain.codedValues.map(cv => {
+                    return {
+                        name: cv.name,
+                        code: cv.code
+                    }
+                });
+                field.domain = codedValueDomain;
+                break;
+            case "range":
+                let rangeDomain = new RangeDomain();
+                rangeDomain.name = dotNetField.domain.name;
+                rangeDomain.minValue = dotNetField.domain.minValue;
+                rangeDomain.maxValue = dotNetField.domain.maxValue;
+                field.domain = rangeDomain;
+                break;
+        }
+    }
+    if (hasValue(dotNetField.defaultValue)) {
+        field.defaultValue = dotNetField.defaultValue;
+    }
+    if (hasValue(dotNetField.description)) {
+        field.description = dotNetField.description;
+    }
+    if (hasValue(dotNetField.editable)) {
+        field.editable = dotNetField.editable;
+    }
+    if (hasValue(dotNetField.valueType)) {
+        field.valueType = dotNetField.valueType;
+    }
+    return field;
 }
 
 export function buildJsViewClickEvent(dotNetClickEvent: any): ViewClickEvent {

--- a/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
+++ b/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
@@ -83,7 +83,7 @@
         <ExecAsync FilePath="pwsh" Arguments="./assetCopy.ps1" />
     </Target>
 
-    <Target Name="Copy Assets Release" AfterTargets="NPM Install" Condition="$(Configuration) == 'RELEASE' AND $(TargetFrameworks.StartsWith($(TargetFramework))) AND '$(OptOutFromCoreEsBuild)' != 'true'">
+    <Target Name="Copy Assets Release" AfterTargets="NPM Install" Condition="$(Configuration) == 'RELEASE' AND $(TargetFrameworks.StartsWith($(TargetFramework)))">
         <Message Importance="high" Text="Copying Asset files" />
         <Exec Command="pwsh ./assetCopy.ps1" />
     </Target>

--- a/src/dymaptic.GeoBlazor.Core/package-lock.json
+++ b/src/dymaptic.GeoBlazor.Core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.1",
       "license": "ISC",
       "dependencies": {
-        "@arcgis/core": "^4.26.5",
+        "@arcgis/core": "^4.27.6",
         "esbuild": "^0.17.5",
         "protobufjs": "^7.2.2",
         "protobufjs-cli": "^1.1.1"
@@ -19,16 +19,16 @@
       }
     },
     "node_modules/@arcgis/core": {
-      "version": "4.26.5",
-      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.26.5.tgz",
-      "integrity": "sha512-Z8KoJrTD1ZQwVVZAIpkdjAQVT/MjAaWAr5u0krifKd6Y1m0TrEb8/iK86KvyWX8yNNWEroEP9SiE19vH/JKquQ==",
+      "version": "4.27.6",
+      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.27.6.tgz",
+      "integrity": "sha512-Pdz8Y1hHpQm2LKkJUGNrag2o2pQ9Pe8KHjywWb+TOJcfqM8L2UQBLmtUGY26VmfMwT/FfnUfNJ7HhYzHi5ef0w==",
       "dependencies": {
         "@esri/arcgis-html-sanitizer": "~3.0.1",
         "@esri/calcite-colors": "~6.1.0",
-        "@esri/calcite-components": "~1.0.7",
-        "@popperjs/core": "~2.11.6",
-        "focus-trap": "~7.2.0",
-        "luxon": "~3.2.1",
+        "@esri/calcite-components": "^1.4.2",
+        "@popperjs/core": "~2.11.7",
+        "focus-trap": "~7.4.3",
+        "luxon": "~3.3.0",
         "sortablejs": "~1.15.0"
       }
     },
@@ -387,31 +387,33 @@
       "integrity": "sha512-wHQYWFtDa6c328EraXEVZvgOiaQyYr0yuaaZ0G3cB4C3lSkWefW34L/e5TLAhtuG3zJ/wR6pl5X1YYNfBc0/4Q=="
     },
     "node_modules/@esri/calcite-components": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.7.tgz",
-      "integrity": "sha512-Ucw0Ly+hvWl4RDMEcHAv2amMItgMYzCGfJS5M7gnIu9bEXcY2Areo+o0KaqvvdAcIjChsRY9fy05ke3ypw0tuA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.4.3.tgz",
+      "integrity": "sha512-3Yj0ZBOPBCIEp+YPJTM0C6cBmbxFXXsG9a6yv0DKxkaERj7te+hb3DQ1fVbG/lQsMLOdrQHiE70zdXSzMKvKCg==",
       "dependencies": {
-        "@floating-ui/dom": "1.1.0",
-        "@stencil/core": "2.20.0",
+        "@floating-ui/dom": "1.4.1",
+        "@stencil/core": "2.22.3",
         "@types/color": "3.0.3",
         "color": "4.2.3",
-        "focus-trap": "7.2.0",
+        "composed-offset-position": "0.0.4",
+        "dayjs": "1.11.8",
+        "focus-trap": "7.4.3",
         "form-request-submit-polyfill": "2.0.0",
         "lodash-es": "4.17.21",
         "sortablejs": "1.15.0"
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-LSqwPZkK3rYfD7GKoIeExXOyYx6Q1O4iqZWwIehDNuv3Dv425FIAE8PRwtAx1imEolFTHgBEcoFHm9MDnYgPCg=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g=="
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.0.tgz",
-      "integrity": "sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.1.tgz",
+      "integrity": "sha512-loCXUOLzIC3jp50RFOKXZ/kQjjz26ryr/23M+FWG9jrmAv8lRf3DUfC2AiVZ3+K316GOhB08CR+Povwz8e9mDw==",
       "dependencies": {
-        "@floating-ui/core": "^1.0.5"
+        "@floating-ui/core": "^1.3.1"
       }
     },
     "node_modules/@jsdoc/salty": {
@@ -426,9 +428,9 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -489,9 +491,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@stencil/core": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.20.0.tgz",
-      "integrity": "sha512-ka+eOW+dNteXIfLCRipNbbAlBEQjqJ2fkx3fxzlKgnNHEQMdZiuIjlWt63KzvOJStNeuADdQXo89BB1dC2VRUw==",
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
+      "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -669,6 +671,11 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
+    "node_modules/composed-offset-position": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.4.tgz",
+      "integrity": "sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -678,6 +685,11 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.8.tgz",
+      "integrity": "sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ=="
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -823,11 +835,11 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/focus-trap": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.2.0.tgz",
-      "integrity": "sha512-v4wY6HDDYvzkBy4735kW5BUEuw6Yz9ABqMYLuTNbzAFPcBOGiGHwwcNVMvUz4G0kgSYh13wa/7TG3XwTeT4O/A==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
+      "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
       "dependencies": {
-        "tabbable": "^6.0.1"
+        "tabbable": "^6.1.2"
       }
     },
     "node_modules/form-request-submit-polyfill": {
@@ -981,9 +993,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
       "engines": {
         "node": ">=12"
       }
@@ -1268,9 +1280,9 @@
       }
     },
     "node_modules/tabbable": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.1.tgz",
-      "integrity": "sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg=="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "node_modules/tmp": {
       "version": "0.2.1",
@@ -1356,16 +1368,16 @@
   },
   "dependencies": {
     "@arcgis/core": {
-      "version": "4.26.5",
-      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.26.5.tgz",
-      "integrity": "sha512-Z8KoJrTD1ZQwVVZAIpkdjAQVT/MjAaWAr5u0krifKd6Y1m0TrEb8/iK86KvyWX8yNNWEroEP9SiE19vH/JKquQ==",
+      "version": "4.27.6",
+      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.27.6.tgz",
+      "integrity": "sha512-Pdz8Y1hHpQm2LKkJUGNrag2o2pQ9Pe8KHjywWb+TOJcfqM8L2UQBLmtUGY26VmfMwT/FfnUfNJ7HhYzHi5ef0w==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "~3.0.1",
         "@esri/calcite-colors": "~6.1.0",
-        "@esri/calcite-components": "~1.0.7",
-        "@popperjs/core": "~2.11.6",
-        "focus-trap": "~7.2.0",
-        "luxon": "~3.2.1",
+        "@esri/calcite-components": "^1.4.2",
+        "@popperjs/core": "~2.11.7",
+        "focus-trap": "~7.4.3",
+        "luxon": "~3.3.0",
         "sortablejs": "~1.15.0"
       }
     },
@@ -1520,31 +1532,33 @@
       "integrity": "sha512-wHQYWFtDa6c328EraXEVZvgOiaQyYr0yuaaZ0G3cB4C3lSkWefW34L/e5TLAhtuG3zJ/wR6pl5X1YYNfBc0/4Q=="
     },
     "@esri/calcite-components": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.7.tgz",
-      "integrity": "sha512-Ucw0Ly+hvWl4RDMEcHAv2amMItgMYzCGfJS5M7gnIu9bEXcY2Areo+o0KaqvvdAcIjChsRY9fy05ke3ypw0tuA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.4.3.tgz",
+      "integrity": "sha512-3Yj0ZBOPBCIEp+YPJTM0C6cBmbxFXXsG9a6yv0DKxkaERj7te+hb3DQ1fVbG/lQsMLOdrQHiE70zdXSzMKvKCg==",
       "requires": {
-        "@floating-ui/dom": "1.1.0",
-        "@stencil/core": "2.20.0",
+        "@floating-ui/dom": "1.4.1",
+        "@stencil/core": "2.22.3",
         "@types/color": "3.0.3",
         "color": "4.2.3",
-        "focus-trap": "7.2.0",
+        "composed-offset-position": "0.0.4",
+        "dayjs": "1.11.8",
+        "focus-trap": "7.4.3",
         "form-request-submit-polyfill": "2.0.0",
         "lodash-es": "4.17.21",
         "sortablejs": "1.15.0"
       }
     },
     "@floating-ui/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-LSqwPZkK3rYfD7GKoIeExXOyYx6Q1O4iqZWwIehDNuv3Dv425FIAE8PRwtAx1imEolFTHgBEcoFHm9MDnYgPCg=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g=="
     },
     "@floating-ui/dom": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.0.tgz",
-      "integrity": "sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.1.tgz",
+      "integrity": "sha512-loCXUOLzIC3jp50RFOKXZ/kQjjz26ryr/23M+FWG9jrmAv8lRf3DUfC2AiVZ3+K316GOhB08CR+Povwz8e9mDw==",
       "requires": {
-        "@floating-ui/core": "^1.0.5"
+        "@floating-ui/core": "^1.3.1"
       }
     },
     "@jsdoc/salty": {
@@ -1556,9 +1570,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -1615,9 +1629,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@stencil/core": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.20.0.tgz",
-      "integrity": "sha512-ka+eOW+dNteXIfLCRipNbbAlBEQjqJ2fkx3fxzlKgnNHEQMdZiuIjlWt63KzvOJStNeuADdQXo89BB1dC2VRUw=="
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
+      "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng=="
     },
     "@types/color": {
       "version": "3.0.3",
@@ -1759,6 +1773,11 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
+    "composed-offset-position": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.4.tgz",
+      "integrity": "sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1768,6 +1787,11 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
+    },
+    "dayjs": {
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.8.tgz",
+      "integrity": "sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ=="
     },
     "deep-is": {
       "version": "0.1.4",
@@ -1868,11 +1892,11 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "focus-trap": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.2.0.tgz",
-      "integrity": "sha512-v4wY6HDDYvzkBy4735kW5BUEuw6Yz9ABqMYLuTNbzAFPcBOGiGHwwcNVMvUz4G0kgSYh13wa/7TG3XwTeT4O/A==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
+      "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
       "requires": {
-        "tabbable": "^6.0.1"
+        "tabbable": "^6.1.2"
       }
     },
     "form-request-submit-polyfill": {
@@ -2005,9 +2029,9 @@
       }
     },
     "luxon": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg=="
     },
     "markdown-it": {
       "version": "12.3.2",
@@ -2211,9 +2235,9 @@
       }
     },
     "tabbable": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.1.tgz",
-      "integrity": "sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg=="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "tmp": {
       "version": "0.2.1",

--- a/src/dymaptic.GeoBlazor.Core/package-lock.json
+++ b/src/dymaptic.GeoBlazor.Core/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@arcgis/core": "^4.27.6",
         "esbuild": "^0.17.5",
-        "protobufjs": "^7.2.2",
+        "protobufjs": "^7.2.4",
         "protobufjs-cli": "^1.1.1"
       },
       "devDependencies": {
@@ -1111,9 +1111,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-      "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -2111,9 +2111,9 @@
       "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
     },
     "protobufjs": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-      "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",

--- a/src/dymaptic.GeoBlazor.Core/package.json
+++ b/src/dymaptic.GeoBlazor.Core/package.json
@@ -12,9 +12,9 @@
   "author": "Tim Purdum",
   "license": "ISC",
   "dependencies": {
-    "@arcgis/core": "^4.26.5",
+    "@arcgis/core": "^4.27.6",
     "esbuild": "^0.17.5",
-    "protobufjs": "^7.2.2",
+    "protobufjs": "^7.2.4",
     "protobufjs-cli": "^1.1.1"
   },
   "devDependencies": {

--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.200"
+    "version": "7.0.200",
+    "rollForward": "latestMajor"
   }
 }

--- a/tests/dymaptic.GeoBlazor.Core.Test.Blazor/Components/GeometryEngineTests.cs
+++ b/tests/dymaptic.GeoBlazor.Core.Test.Blazor/Components/GeometryEngineTests.cs
@@ -175,7 +175,6 @@ public class GeometryEngineTests : TestRunnerBase
             }
         };
         var polyline = new PolyLine(mapPaths, new SpatialReference(102100));
-        PolyLine densifiedLine = (PolyLine)await GeometryEngine.Densify(polyline, 0.1, LinearUnit.Miles);
         Polygon buffer = await GeometryEngine.Buffer(polyline, 20, LinearUnit.Yards);
         Assert.IsNotNull(buffer);
     }
@@ -1318,7 +1317,7 @@ public class GeometryEngineTests : TestRunnerBase
                     }
                 }, new SpatialReference(102100));
 
-        Geometry? simplifiedGeometry = await GeometryEngine.Simplify(polygon);
+        Geometry simplifiedGeometry = await GeometryEngine.Simplify(polygon);
 
         Assert.IsNotNull(simplifiedGeometry);
         Assert.AreNotEqual(polygon, simplifiedGeometry);
@@ -1355,7 +1354,7 @@ public class GeometryEngineTests : TestRunnerBase
                     }
                 }, new SpatialReference(102100));
 
-        Geometry? symmetricDifference = await GeometryEngine.SymmetricDifference(polygon1, polygon2);
+        Geometry symmetricDifference = await GeometryEngine.SymmetricDifference(polygon1, polygon2);
 
         Assert.IsNotNull(symmetricDifference);
         Assert.AreNotEqual(polygon1, symmetricDifference);
@@ -1406,7 +1405,7 @@ public class GeometryEngineTests : TestRunnerBase
                     }
                 }, new SpatialReference(102100));
 
-        Geometry[]? symmetricDifferences =
+        Geometry[] symmetricDifferences =
             await GeometryEngine.SymmetricDifference(new Geometry[] { polygon1, polygon2 }, polygon3);
 
         Assert.IsNotNull(symmetricDifferences);
@@ -1522,7 +1521,7 @@ public class GeometryEngineTests : TestRunnerBase
                     }
                 }, new SpatialReference(102100));
 
-        Geometry? union = await GeometryEngine.Union(polygon1, polygon2);
+        Geometry union = await GeometryEngine.Union(polygon1, polygon2);
 
         Assert.IsNotNull(union);
         Assert.AreNotEqual(polygon1, union);
@@ -1600,11 +1599,6 @@ public class GeometryEngineTests : TestRunnerBase
 
         Assert.IsFalse(within);
     }
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        await base.OnAfterRenderAsync(firstRender);
-    }
-
+    
     private readonly Random _random = new();
 }


### PR DESCRIPTION
Closes #193 

- Adds support for Pro features
- new `FormTemplate` can be added to a `FeatureLayer`, including `FormElement`, `FormInput`, and `Domain`
- `FeatureLayer.ApplyEdits` - while the related widget is in Pro, this is available programmatically to all Core users
- Added `Domain` to `Field` to support form comboboxes
- Added cursor management to `MapView`
- Updated `Query.ObjectIds` to be `long` instead of `int`
- Prevent hosted/loaded `FeatureLayers` from updating in `arcGisJsInterop.updateLayer`
- Fixed `featureLayerView.highlight` typescript implementation
- Updated arcgis js reference to 4.27.6
- Updated protobufjs reference to 7.2.2
- Added "rollForward" to `global.json`. This should prevent breaking builds if you update your .NET SDK.