### PR TITLE
fix popup actions

### DIFF
--- a/src/dymaptic.GeoBlazor.Core.sln
+++ b/src/dymaptic.GeoBlazor.Core.sln
@@ -24,8 +24,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dymaptic.GeoBlazor.Core.Sam
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dymaptic.GeoBlazor.Core.Sample.ServerOAuth", "..\samples\dymaptic.GeoBlazor.Core.Sample.ServerOAuth\dymaptic.GeoBlazor.Core.Sample.ServerOAuth.csproj", "{3DED106E-5ED1-4506-87CA-50C40465D6A1}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dymaptic.GeoBlazor.Core.Test.Blazor", "..\tests\dymaptic.GeoBlazor.Core.Test.Blazor\dymaptic.GeoBlazor.Core.Test.Blazor.csproj", "{FACB8396-34A0-4BB0-98B0-463BC26BE349}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dymaptic.GeoBlazor.Core.Test.Blazor.Server", "..\test\dymaptic.GeoBlazor.Core.Test.Blazor.Server\dymaptic.GeoBlazor.Core.Test.Blazor.Server.csproj", "{915558F0-1755-42D9-81EC-805774ECEB42}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dymaptic.GeoBlazor.Core.Test.Blazor.Shared", "..\test\dymaptic.GeoBlazor.Core.Test.Blazor.Shared\dymaptic.GeoBlazor.Core.Test.Blazor.Shared.csproj", "{41CD66DB-1487-4F37-B2C6-3DB569116E89}"
@@ -72,10 +70,6 @@ Global
 		{3DED106E-5ED1-4506-87CA-50C40465D6A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3DED106E-5ED1-4506-87CA-50C40465D6A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3DED106E-5ED1-4506-87CA-50C40465D6A1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FACB8396-34A0-4BB0-98B0-463BC26BE349}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FACB8396-34A0-4BB0-98B0-463BC26BE349}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FACB8396-34A0-4BB0-98B0-463BC26BE349}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FACB8396-34A0-4BB0-98B0-463BC26BE349}.Release|Any CPU.Build.0 = Release|Any CPU
 		{915558F0-1755-42D9-81EC-805774ECEB42}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{915558F0-1755-42D9-81EC-805774ECEB42}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{915558F0-1755-42D9-81EC-805774ECEB42}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -110,6 +110,7 @@ import ComboBoxInput from "@arcgis/core/form/elements/inputs/ComboBoxInput";
 import RadioButtonsInput from "@arcgis/core/form/elements/inputs/RadioButtonsInput";
 import SwitchInput from "@arcgis/core/form/elements/inputs/SwitchInput";
 import Domain from "@arcgis/core/layers/support/Domain";
+import * as reactiveUtils from "@arcgis/core/core/reactiveUtils";
 
 
 export function buildJsSpatialReference(dotNetSpatialReference: DotNetSpatialReference): SpatialReference {
@@ -260,9 +261,12 @@ export function buildJsPopupTemplate(popupTemplateObject: DotNetPopupTemplate, v
                 if (hasValue(templateTriggerActionHandler)) {
                     templateTriggerActionHandler.remove();
                 }
-                templateTriggerActionHandler = view.popup.on("trigger-action", async (event: PopupTriggerActionEvent) => {
-                    await popupTemplateObject.dotNetPopupTemplateReference.invokeMethodAsync("OnTriggerAction", event.action.id);
-                });
+                reactiveUtils.once(() => view.popup.on !== undefined)
+                    .then(() => {
+                        templateTriggerActionHandler = view.popup.on("trigger-action", async (event: PopupTriggerActionEvent) => {
+                            await popupTemplateObject.dotNetPopupTemplateReference.invokeMethodAsync("OnTriggerAction", event.action.id);
+                        });
+                    })
             }
             catch (error) {
                 console.debug(error);
@@ -727,9 +731,9 @@ export function buildJsQuery(dotNetQuery: DotNetQuery): Query {
         where: dotNetQuery.where ?? "1=1",
         spatialRelationship: dotNetQuery.spatialRelationship as any ?? "intersects",
         distance: dotNetQuery.distance ?? undefined,
-        units: dotNetQuery.units as any ?? null,
+        units: dotNetQuery.units as any ?? undefined,
         returnGeometry: dotNetQuery.returnGeometry ?? false,
-        outFields: dotNetQuery.outFields ?? null,
+        outFields: dotNetQuery.outFields ?? undefined,
         orderByFields: dotNetQuery.orderByFields ?? undefined,
         outStatistics: dotNetQuery.outStatistics ?? undefined,
         groupByFieldsForStatistics: dotNetQuery.groupByFieldsForStatistics ?? undefined,
@@ -748,7 +752,7 @@ export function buildJsQuery(dotNetQuery: DotNetQuery): Query {
         having: dotNetQuery.having ?? undefined,
         historicMoment: dotNetQuery.historicMoment ?? undefined,
         maxRecordCountFactor: dotNetQuery.maxRecordCountFactor ?? 1,
-        text: dotNetQuery.text ?? null,
+        text: dotNetQuery.text ?? undefined,
         parameterValues: dotNetQuery.parameterValues ?? undefined,
         quantizationParameters: dotNetQuery.quantizationParameters ?? undefined,
         rangeValues: dotNetQuery.rangeValues ?? undefined,

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -261,6 +261,8 @@ export function buildJsPopupTemplate(popupTemplateObject: DotNetPopupTemplate, v
                 if (hasValue(templateTriggerActionHandler)) {
                     templateTriggerActionHandler.remove();
                 }
+                
+                // we need to wait for the popup to be initialized before we can add the trigger-action handler
                 reactiveUtils.once(() => view.popup.on !== undefined)
                     .then(() => {
                         templateTriggerActionHandler = view.popup.on("trigger-action", async (event: PopupTriggerActionEvent) => {

--- a/src/dymaptic.GeoBlazor.Core/assetCopy.ps1
+++ b/src/dymaptic.GeoBlazor.Core/assetCopy.ps1
@@ -1,4 +1,4 @@
-﻿$SourceFiles = "./node_modules/@arcgis/core/assets/*"
+﻿$SourceFiles = "./node_modules/@arcgis/core/assets"
 $OutputDir = "./wwwroot/assets"
 $packageJson = (Get-Content "package.json" -Raw) | ConvertFrom-Json
 # read the version from package.json

--- a/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
+++ b/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
@@ -9,8 +9,8 @@
         </Description>
         <Title>GeoBlazor</Title>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageVersion>2.2.1</PackageVersion>
-        <Version>2.2.1</Version>
+        <PackageVersion>2.3.0-beta-1</PackageVersion>
+        <Version>2.3.0-beta-1</Version>
         <Authors>Tim Purdum, Christopher Moravec, Mara Stoica, Tim Rawson</Authors>
         <Company>dymaptic</Company>
         <Copyright>©2023 by dymaptic</Copyright>
@@ -68,7 +68,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="wwwroot\assets" />
         <Content Remove="node_modules\**" />
     </ItemGroup>
 

--- a/src/dymaptic.GeoBlazor.Core/package-lock.json
+++ b/src/dymaptic.GeoBlazor.Core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dymaptic.GeoBlazor.Core",
-  "version": "2.2.1",
+  "version": "2.3.0-beta-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dymaptic.GeoBlazor.Core",
-      "version": "2.2.1",
+      "version": "2.3.0-beta-1",
       "license": "ISC",
       "dependencies": {
         "@arcgis/core": "^4.27.6",

--- a/src/dymaptic.GeoBlazor.Core/package.json
+++ b/src/dymaptic.GeoBlazor.Core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dymaptic.GeoBlazor.Core",
-  "version": "2.2.1",
+  "version": "2.3.0-beta-1",
   "description": "https://www.geoblazor.com",
   "main": "arcGisInterop.js",
   "scripts": {

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/PopupTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/PopupTests.razor
@@ -1,0 +1,43 @@
+﻿@inherits TestRunnerBase
+
+@{
+    base.BuildRenderTree(__builder);
+}
+
+@code {
+
+    [TestMethod]
+    public async Task TestCanActivatePopupAction()
+    {
+        bool callbackCalled = false;
+        CreateViewRenderedHandler(async () =>
+        {
+            await AssertJavaScript("assertPopupCallback");
+            Assert.IsTrue(callbackCalled);
+        });
+        
+        Task MeasureThis()
+        {
+            callbackCalled = true;
+            return Task.CompletedTask;
+        }
+        
+        AddMapRenderFragment(
+            @<Map>
+                 <Basemap>
+                     <PortalItem Id="f35ef07c9ed24020aadd65c8a65d3754" />
+                 </Basemap>
+                 <FeatureLayer Url="https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/TrailRuns/FeatureServer/0">
+                     <PopupTemplate Title="Trail Run" StringContent="{name}">
+                         <ActionButton Image="_content/dymaptic.GeoBlazor.Core.Sample.Shared/images/Measure_Distance16.png"
+                                       Title="Measure Length"
+                                       Id="measure-this"
+                                       CallbackFunction="MeasureThis" />
+                     </PopupTemplate>
+                 </FeatureLayer>
+            </Map>);
+
+        await WaitForMapToRender();
+        
+    }
+}

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/wwwroot/testRunner.js
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/wwwroot/testRunner.js
@@ -42,5 +42,10 @@ export async function assertPopupCallback(viewId, layerId) {
     view.popup.open({
         features: [ featureSet.features[0] ]
     });
-    view.popup.triggerAction(0);
+    let button = null;
+    while (button === null) {
+        await new Promise(resolve => setTimeout(resolve, 100));
+        button = document.querySelector('[title="Measure Length"]');
+    }
+    button.click();
 }

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/wwwroot/testRunner.js
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/wwwroot/testRunner.js
@@ -34,3 +34,13 @@ export function assertKmlLayerExists(viewId) {
 export function testThrow() {
     throw new Error("Test throw");
 }
+
+export async function assertPopupCallback(viewId, layerId) {
+    let view = arcGisObjectRefs[viewId];
+    let layer = view.map.layers.items[0];
+    let featureSet = await layer.queryFeatures();
+    view.popup.open({
+        features: [ featureSet.features[0] ]
+    });
+    view.popup.triggerAction(0);
+}


### PR DESCRIPTION
Closes #207 
The `view.popup.on` function is not available until the view is rendered. Rather than do some sort of re-registration of the `popupTemplate`, I realized we could use a `reactiveUtils.once` to register the handler after the popup is ready.

Also in this PR
- A few `undefined`s added to a `jsBuilder` to prevent null errors
- Had to update the `copyAssets.ps1`. Powershell's default behavior seems to have changed. Christopher and I saw this before, now my version matches what his Mac was doing 3 months ago...
- removed an old project reference from the solution file