### PR TITLE
Bug/214 sql filter

### DIFF
--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/Widget.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/Widget.cs
@@ -68,6 +68,13 @@ public abstract class Widget : MapComponent
     {
         JsObjectReference = jsObjectReference;
     }
+    
+    /// <inheritdoc />
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+        WidgetChanged = true;
+    }
 
     /// <inheritdoc />
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -79,7 +86,6 @@ public abstract class Widget : MapComponent
             await UpdateWidget();
         }
     }
-
     
     private async Task UpdateWidget()
     {

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -852,34 +852,34 @@ export async function updateLayer(layerObject: any, viewId: string): Promise<voi
                             featureLayer.portalItem.apiKey = layerObject.portalItem.apiKey;
                         }
                     }
-                } else if (hasValue(layerObject.url)) {
-                    if (layerObject.url !== featureLayer.url) {
-                        featureLayer.url = layerObject.url;
-                    }
+                } else if (hasValue(layerObject.url) && layerObject.url !== featureLayer.url) {
+                    featureLayer.url = layerObject.url;
                 } else {
-                    copyValuesIfExists(layerObject, featureLayer, 'minScale', 'maxScale', 'orderBy', 'objectIdField',
-                        'definitionExpression', 'labelingInfo', 'outFields');
-                    if (hasValue(layerObject.fullExtent) && layerObject.fullExtent !== currentLayer.fullExtent) {
-                        currentLayer.fullExtent = buildJsExtent(layerObject.fullExtent, view.spatialReference);
-                    }
-                    if (hasValue(layerObject.popupTemplate)) {
-                        featureLayer.popupTemplate = buildJsPopupTemplate(layerObject.popupTemplate, viewId);
-                    }
-                    // on first pass the renderer is often left blank, but it fills in when the round trip happens to the server
-                    if (hasValue(layerObject.renderer) && layerObject.renderer.type !== featureLayer.renderer.type) {
-                        let renderer = buildJsRenderer(layerObject.renderer);
-                        if (renderer !== null && featureLayer.renderer !== renderer) {
-                            featureLayer.renderer = renderer;
-                        }
-                    }
-                    if (hasValue(layerObject.fields) && layerObject.fields.length > 0) {
-                        featureLayer.fields = buildJsFields(layerObject.fields);
-                    }
                     if (hasValue(layerObject.spatialReference) &&
                         layerObject.spatialReference.wkid !== featureLayer.spatialReference.wkid) {
                         featureLayer.spatialReference = buildJsSpatialReference(layerObject.spatialReference);
                     }
                 }
+
+                if (hasValue(layerObject.fullExtent) && layerObject.fullExtent !== currentLayer.fullExtent) {
+                    currentLayer.fullExtent = buildJsExtent(layerObject.fullExtent, view.spatialReference);
+                }
+                if (hasValue(layerObject.popupTemplate)) {
+                    featureLayer.popupTemplate = buildJsPopupTemplate(layerObject.popupTemplate, viewId);
+                }
+                // on first pass the renderer is often left blank, but it fills in when the round trip happens to the server
+                if (hasValue(layerObject.renderer) && layerObject.renderer.type !== featureLayer.renderer.type) {
+                    let renderer = buildJsRenderer(layerObject.renderer);
+                    if (renderer !== null && featureLayer.renderer !== renderer) {
+                        featureLayer.renderer = renderer;
+                    }
+                }
+                if (hasValue(layerObject.fields) && layerObject.fields.length > 0) {
+                    featureLayer.fields = buildJsFields(layerObject.fields);
+                }
+
+                copyValuesIfExists(layerObject, featureLayer, 'minScale', 'maxScale', 'orderBy', 'objectIdField',
+                    'definitionExpression', 'labelingInfo', 'outFields');
 
                 break;
             case 'geo-json':

--- a/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
@@ -531,3 +531,39 @@ export interface DotNetFeatureFilter {
     units: string;
     where: string;
 }
+
+export interface DotNetField {
+    alias: string;
+    defaultValue: any;
+    description: string;
+    domain: DotNetDomain;
+    editable: boolean;
+    length: number;
+    name: string;
+    type: "small-integer"|"integer"|"single"|"double"|"long"|"string"|"date"|"oid"|"geometry"|"blob"|"raster"|"guid"|"global-id"|"xml";
+    valueType: string;
+}
+
+export interface DotNetDomain {
+    type: string;
+}
+
+export interface DotNetCodedValueDomain extends DotNetDomain {
+    codedValues: DotNetCodedValue[];
+    name: string;
+}
+
+export interface DotNetCodedValue {
+    name: string;
+    code: any;
+}
+
+export interface DotNetRangeDomain extends DotNetDomain {
+    maxValue: number;
+    minValue: number;
+    name: string;
+}
+
+export interface DotNetInheritedDomain extends DotNetDomain {
+    name: string;
+}

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -262,13 +262,19 @@ export function buildJsPopupTemplate(popupTemplateObject: DotNetPopupTemplate, v
                     templateTriggerActionHandler.remove();
                 }
                 
-                // we need to wait for the popup to be initialized before we can add the trigger-action handler
-                reactiveUtils.once(() => view.popup.on !== undefined)
-                    .then(() => {
-                        templateTriggerActionHandler = view.popup.on("trigger-action", async (event: PopupTriggerActionEvent) => {
-                            await popupTemplateObject.dotNetPopupTemplateReference.invokeMethodAsync("OnTriggerAction", event.action.id);
-                        });
-                    })
+                if (view.popup.on === undefined) {
+                    // we need to wait for the popup to be initialized before we can add the trigger-action handler
+                    reactiveUtils.once(() => view.popup.on !== undefined)
+                        .then(() => {
+                            templateTriggerActionHandler = view.popup.on("trigger-action", async (event: PopupTriggerActionEvent) => {
+                                await popupTemplateObject.dotNetPopupTemplateReference.invokeMethodAsync("OnTriggerAction", event.action.id);
+                            });
+                        })
+                } else {
+                    templateTriggerActionHandler = view.popup.on("trigger-action", async (event: PopupTriggerActionEvent) => {
+                        await popupTemplateObject.dotNetPopupTemplateReference.invokeMethodAsync("OnTriggerAction", event.action.id);
+                    });
+                }
             }
             catch (error) {
                 console.debug(error);


### PR DESCRIPTION
Closes #214 , fixing the sql filter page, by reverting some bad changes to `arcGisJsInterop.updateLayer`. Basically, FL's from the server (url or portal Id) were not getting some updates. I _think_ the original change was to avoid an issue with trying to jam a `SpatialReference` on a server feature layer, so I left that property client-side only for updates. I also tested with core and pro samples, and could not recreate the original problem after this reversion.

Also
- Fixed a Pro bug caused by the change in #208. We need to handle both the `view.popup.on` existing and not existing in `jsBuilder.buildJsPopupTemplate`
- While testing in Pro, on `ApplyEdits`, it tries to pass back the FeatureLayer, but it is apparently huge, even without graphics loaded. I noticed that `Fields` were being passed as-is from ArcGIS, and the `Renderer` I don't think needed to be passed.