### PR TITLE
Feature/232 search widget sources

### DIFF
--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/SearchMultipleSources.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/SearchMultipleSources.razor
@@ -1,0 +1,62 @@
+﻿@page "/search-multi-source"
+
+<PageTitle>Search with Multiple Sources</PageTitle>
+<h1>Search with Multiple Sources</h1>
+
+<div class="links-div">
+    <a class="btn btn-secondary" target="_blank" href="https://developers.arcgis.com/javascript/latest/sample-code/widgets-search-multiplesource/">ArcGIS API for JavaScript Reference</a>
+    <a class="btn btn-primary" target="_blank" href="https://www.arcgis.com/home/item.html?id=1970c1995b8f44749f4b9b6e81b5ba45">Dark Gray BaseMap</a>
+</div>
+<p class="instructions">
+    Demonstrates how to use the Search Widget with multiple sources.
+</p>
+
+<MapView Class="map-view"
+         Center="@(new Point(-97, 38))"
+         Scale="10000000">
+    <Map ArcGISDefaultBasemap="dark-gray-vector" />
+    <SearchWidget AllPlaceholder="District or Senator"
+                  IncludeDefaultSources="false"
+                  Position="OverlayPosition.TopRight">
+        <LayerSearchSource SearchFields="@(new [] {"DISTRICTID"})"
+                           DisplayField="DISTRICTID"
+                           ExactMatch="false"
+                           OutFields="@(new [] {"DISTRICTID", "NAME", "PARTY"})"
+                           Name="Congressional Districts"
+                           Placeholder="example: 3708">
+            <FeatureLayer Url="https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_117th_Congressional_Districts_all/FeatureServer/0">
+                <PopupTemplate Title="Congressional District {DISTRICTID} </br>{NAME}, ({PARTY})" OverwriteActions="true" />
+            </FeatureLayer>
+        </LayerSearchSource>
+        <LayerSearchSource SearchFields="@(new [] {"Name", "Party"})"
+                           SuggestionTemplate="{Name}, Party: {Party}"
+                           ExactMatch="false"
+                           OutFields="@(new [] {"*"})"
+                           Name="Senators"
+                           Placeholder="example: Casey"
+                           ZoomScale="500000">
+            <FeatureLayer Url="https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/US_Senators_2020/FeatureServer/0">
+                <PopupTemplate Title="<a href={Web_Page} target='_blank'> {Name}</a>, ({Party}-{State}) " OverwriteActions="true" />
+            </FeatureLayer>
+            <PictureMarkerSymbol Url="https://developers.arcgis.com/javascript/latest//sample-code/widgets-search-multiplesource/live/images/senate.png"
+                                 Height="36"
+                                 Width="36" />
+        </LayerSearchSource>
+        <LocatorSearchSource Name="ArcGIS World Geocoding Service"
+                             Placeholder="example: Nuuk, GRL"
+                             SingleLineFieldName="SingleLine"
+                             Url="https://geocode-api.arcgis.com/arcgis/rest/services/World/GeocodeServer" />
+    </SearchWidget>
+</MapView>
+
+@code {
+    private readonly FeatureLayer _districtsLayer = new(
+        "",
+        popupTemplate: new PopupTemplate("", 
+            overwriteActions: true));
+
+    private readonly FeatureLayer _senatorsLayer = new(
+        "https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/US_Senators_2020/FeatureServer/0",
+        popupTemplate: new PopupTemplate("<a href={Web_Page} target='_blank'> {Name}</a>, ({Party}-{State}) ", 
+            overwriteActions: true));
+}

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Shared/NavMenu.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Shared/NavMenu.razor
@@ -109,6 +109,7 @@
         new("marker-rotation", "Marker Rotation", "oi-loop-circular"),
         new("graphic-tracking", "Graphic Tracking", "oi-move"),
         new("geometry-methods", "Geometry Methods", "oi-task"),
+        new("search-multi-source", "Search Multiple Sources", "oi-magnifying-glass"),
         new("tests", "Tests", "oi-check")
     };
 

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/wwwroot/css/site.css
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/wwwroot/css/site.css
@@ -172,7 +172,7 @@ input[type=radio] {
     font-size: 1em
 }
 
-input[type="text"], input[type="number"] {
+input[type="text"]:not(.esri-search__input), input[type="number"]:not(.esri-search__input) {
     width: 8rem;
 }
 

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayer.cs
@@ -372,6 +372,7 @@ public class FeatureLayer : Layer
         base.Refresh();
     }
 
+    /// <inheritdoc />
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (_refreshRequired)

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayer.cs
@@ -78,17 +78,20 @@ public class FeatureLayer : Layer
     /// <param name="listMode">
     ///     Indicates how the layer should display in the LayerList widget. The possible values are listed below.
     /// </param>
+    /// <param name="popupTemplate">
+    ///     The <see cref="PopupTemplate" /> for the layer.
+    /// </param>
     public FeatureLayer(string? url = null, PortalItem? portalItem = null, IReadOnlyCollection<Graphic>? source = null,
         string[]? outFields = null, string? definitionExpression = null, double? minScale = null,
         double? maxScale = null, string? objectIdField = null, GeometryType? geometryType = null, string? title = null,
-        double? opacity = null, bool? visible = null, ListMode? listMode = null)
+        double? opacity = null, bool? visible = null, ListMode? listMode = null, PopupTemplate? popupTemplate = null)
     {
         if (url is null && portalItem is null && source is null)
         {
             throw new MissingRequiredOptionsChildElementException(nameof(FeatureLayer),
                 new[] { nameof(Url), nameof(PortalItem), nameof(Source) });
         }
-
+#pragma warning disable BL0005 // Component parameter should not be set outside of its component.
         Url = url;
         Source = source;
         PortalItem = portalItem;
@@ -102,6 +105,8 @@ public class FeatureLayer : Layer
         Opacity = opacity;
         Visible = visible;
         ListMode = listMode;
+        PopupTemplate = popupTemplate;
+#pragma warning restore BL0005 // Component parameter should not be set outside of its component.
     }
 
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
@@ -733,8 +733,7 @@ public partial class MapView : MapComponent
 
         if (center is not null)
         {
-            Latitude = center.Latitude;
-            Longitude = center.Longitude;
+            Center = center;
         }
 
         Zoom = zoom;

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/Domain.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/Domain.cs
@@ -98,6 +98,7 @@ public class CodedValue<T> : MapComponent
 /// </summary>
 public class InheritedDomain : Domain
 {
+    /// <inheritdoc />
     public override string Type => "inherited";
 }
 

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/GoToOverride.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/GoToOverride.cs
@@ -1,0 +1,155 @@
+﻿using dymaptic.GeoBlazor.Core.Components.Geometries;
+using dymaptic.GeoBlazor.Core.Components.Layers;
+
+
+namespace dymaptic.GeoBlazor.Core.Components.Widgets;
+
+/// <summary>
+///     The following properties define a goTo override function.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-support-widget.html#GoToOverride">ArcGIS JS API</a>
+/// </summary>
+/// <param name="ViewId">
+///     A reference Id to the MapView or SceneView where the navigation takes place.
+/// </param>
+/// <param name="Target">
+///     The target location/viewpoint/extent to animate to.
+/// </param>
+/// <param name="Options">
+///     Options defining the animation, duration, and easing of the navigation.
+/// </param>
+public record GoToOverrideParameters(Guid ViewId, GoToTarget Target, GoToOptions? Options);
+
+/// <summary>
+///     The target location/viewpoint to animate to in the goTo() method. A two or three-element array of numbers represents the [x,y,z] coordinates to center the view on. When using an object for the target, use the properties in this record.
+/// </summary>
+public record GoToTarget(object? Target, double[]? Center, double? Scale, double? Zoom, double? Heading, double? Tilt,
+    Point? Position)
+{
+    /// <summary>
+    ///     Constructor for when the target is a collection of coordinates.
+    /// </summary>
+    public GoToTarget(double[]? targetCoordinates, object? target, double[]? center, double? scale, double? zoom, 
+        double? heading, double? tilt, Point? position) : this(target, center, scale, zoom, heading, tilt, position)
+    {
+        TargetCoordinates = targetCoordinates;
+    }
+    
+    /// <summary>
+    ///     Constructor for when the target is a collection of Geometries.
+    /// </summary>
+    public GoToTarget(Geometry[]? targetGeometries, object? target, double[]? center, double? scale, double? zoom, 
+        double? heading, double? tilt, Point? position) : this(target, center, scale, zoom, heading, tilt, position)
+    {
+        TargetGeometries = targetGeometries;
+    }
+    
+    /// <summary>
+    ///     Constructor for when the target is a single Geometry.
+    /// </summary>
+    public GoToTarget(Geometry? targetGeometry, object? target, double[]? center, double? scale, double? zoom, 
+        double? heading, double? tilt, Point? position) : this(target, center, scale, zoom, heading, tilt, position)
+    {
+        TargetGeometry = targetGeometry;
+    }
+    
+    /// <summary>
+    ///     Constructor for when the target is a collection of Graphics.
+    /// </summary>
+    public GoToTarget(Graphic[]? targetGraphics, object? target, double[]? center, double? scale, double? zoom, 
+        double? heading, double? tilt, Point? position) : this(target, center, scale, zoom, heading, tilt, position)
+    {
+        TargetGraphics = targetGraphics;
+    }
+    
+    /// <summary>
+    ///     Constructor for when the target is a single Graphic.
+    /// </summary>
+    public GoToTarget(Graphic? targetGraphic, object? target, double[]? center, double? scale, double? zoom, 
+        double? heading, double? tilt, Point? position) : this(target, center, scale, zoom, heading, tilt, position)
+    {
+        TargetGraphic = targetGraphic;
+    }
+    
+    /// <summary>
+    ///     The target of the animation as [x,y] or [x,y,z] coordinates.
+    /// </summary>
+    public double[]? TargetCoordinates { get; set; }
+
+    /// <summary>
+    ///     The target of the animation as a collection of geometries.
+    /// </summary>
+    public Geometry[]? TargetGeometries { get; set; }
+
+    /// <summary>
+    ///     The target of the animation as a single geometry.
+    /// </summary>
+    public Geometry? TargetGeometry { get; set; }
+
+    /// <summary>
+    ///     The target of the animation as a collection of graphics.
+    /// </summary>
+    public Graphic[]? TargetGraphics { get; set; }
+    
+    /// <summary>
+    ///     The target of the animation as a single graphic.
+    /// </summary>
+    public Graphic? TargetGraphic { get; set; }
+    
+    /// <summary>
+    ///     The target of the animation.
+    /// </summary>
+    public object? Target { get; set; } = Target;
+
+    /// <summary>
+    ///     The View.Center to go to.
+    /// </summary>
+    public double[]? Center { get; private set; } = Center;
+
+    /// <summary>
+    ///     The View.Scale to go to.
+    /// </summary>
+    public double? Scale { get; private set; } = Scale;
+
+    /// <summary>
+    ///     The View.Zoom to go to.
+    /// </summary>
+    public double? Zoom { get; private set; } = Zoom;
+
+    /// <summary>
+    ///     The View.Heading to go to.
+    /// </summary>
+    public double? Heading { get; private set; } = Heading;
+
+    /// <summary>
+    ///     The View.Tilt to go to. 
+    /// </summary>
+    public double? Tilt { get; private set; } = Tilt;
+
+    /// <summary>
+    ///    The View.Position to go to. 
+    /// </summary>
+    public Point? Position { get; private set; } = Position;
+}
+
+/// <summary>
+///     Animation options for the goTo() method. See properties below for parameter specifications.
+/// </summary>
+/// <param name="Animate">
+///     Indicates if the transition to the new view should be animated. If set to false, speedFactor, duration, maxDuration, and easing properties are ignored.
+///     Default Value is True.
+/// </param>
+/// <param name="Duration">
+///     Set the exact duration (in milliseconds) of the animation. Note that by default, animation duration is calculated based on the time required to reach the target at a constant speed. Setting duration overrides the speedFactor option. Note that the resulting duration is still limited to the maxDuration.
+/// </param>
+/// <param name="Easing">
+///     The easing function to use for the animation. This may either be a preset (named) function, or a user specified function. Supported named presets are: linear, in-cubic, out-cubic, in-out-cubic, in-expo, out-expo, in-out-expo, in-out-coast-quadratic.
+/// </param>
+/// <param name="SpeedFactor">
+///     Increases or decreases the animation speed by the specified factor. A speedFactor of 2 will make the animation twice as fast, while a speedFactor of 0.5 will make the animation half as fast. Setting the speed factor will automatically adapt the default maxDuration accordingly.
+///     Default Value is 1.
+/// </param>
+/// <param name="MaxDuration">
+///     The maximum allowed duration (in milliseconds) of the animation. The default maxDuration value takes the specified speedFactor into account.
+///     Default Value is 8000.
+/// </param>
+public record GoToOptions(bool? Animate, double? Duration, string? Easing, double? SpeedFactor, double? MaxDuration);

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/LocateWidget.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/LocateWidget.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using System.Text.Json.Serialization;
 
 
@@ -22,12 +23,49 @@ public class LocateWidget : Widget
     ///     Indicates whether the widget will automatically rotate to user's direction.
     /// </summary>
     [Parameter]
+    [Obsolete("UseHeadingEnabled is deprecated. Use RotateEnabled instead.")]
     public bool UseHeadingEnabled { get; set; }
+    
+    /// <summary>
+    ///    Indicates whether the widget will automatically rotate to the device heading based on the Geolocation APIs GeolocationCoordinates.heading property. The map will not rotate if the speed is 0, or if the device is unable to provide heading information.
+    ///     Set to false to disable this behavior. Default Value:true
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? RotationEnabled { get; set; }
 
     /// <summary>
     ///     Indicates the scale to set on the view when navigating to the position of the geolocated result once a location is
     ///     returned from the track event.
     /// </summary>
     [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? Scale { get; set; } = 2500;
+    
+        
+    /// <summary>
+    ///     This function provides the ability to override either the MapView goTo() or SceneView goTo() methods with your own implementation.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore]
+    public Action<GoToOverrideParameters>? GoToOverride { get; set; }
+
+    /// <summary>
+    ///     Identifies whether a custom <see cref="GoToOverride" /> was registered.
+    /// </summary>
+    public bool HasGoToOverride => GoToOverride is not null;
+    
+    /// <summary>
+    ///     A .NET object reference for calling this class from JavaScript.
+    /// </summary>
+    public DotNetObjectReference<LocateWidget> LocateWidgetObjectReference => DotNetObjectReference.Create(this);
+    
+    /// <summary>
+    ///     JavaScript-invokable method for internal use
+    /// </summary>
+    [JSInvokable]
+    public void OnJavaScriptGoToOverride(GoToOverrideParameters goToOverrideParams)
+    {
+        GoToOverride?.Invoke(goToOverrideParams);
+    }
 }

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/PopupWidget.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/PopupWidget.cs
@@ -185,7 +185,7 @@ public class PopupWidget : Widget
     /// </summary>
     public async Task<Graphic> GetSelectedFeature()
     {
-        return await JsObjectReference!.InvokeAsync<Graphic>("getSelectedFeature",
+        return await JsWidgetReference!.InvokeAsync<Graphic>("getSelectedFeature",
             CancellationTokenSource.Token, View?.Id);
     }
 
@@ -194,7 +194,7 @@ public class PopupWidget : Widget
     /// </summary>
     public async Task SetContent(string stringContent)
     {
-        await JsObjectReference!.InvokeVoidAsync("setContent", CancellationTokenSource.Token, stringContent);
+        await JsWidgetReference!.InvokeVoidAsync("setContent", CancellationTokenSource.Token, stringContent);
     }
 
     /// <summary>
@@ -202,7 +202,7 @@ public class PopupWidget : Widget
     /// </summary>
     public async Task Clear()
     {
-        await JsObjectReference!.InvokeVoidAsync("clear", CancellationTokenSource.Token);
+        await JsWidgetReference!.InvokeVoidAsync("clear", CancellationTokenSource.Token);
     }
 
     /// <summary>
@@ -212,7 +212,7 @@ public class PopupWidget : Widget
     /// </summary>
     public async Task<Graphic[]> FetchFeatures()
     {
-        return await JsObjectReference!.InvokeAsync<Graphic[]>("fetchFeatures", CancellationTokenSource.Token);
+        return await JsWidgetReference!.InvokeAsync<Graphic[]>("fetchFeatures", CancellationTokenSource.Token);
     }
 
     /// <summary>
@@ -220,7 +220,7 @@ public class PopupWidget : Widget
     /// </summary>
     public async Task<int> GetFeatureCount()
     {
-        return await JsObjectReference!.InvokeAsync<int>("getFeatureCount", CancellationTokenSource.Token);
+        return await JsWidgetReference!.InvokeAsync<int>("getFeatureCount", CancellationTokenSource.Token);
     }
 
     /// <summary>
@@ -228,7 +228,7 @@ public class PopupWidget : Widget
     /// </summary>
     public async Task<int> GetSelectedFeatureIndex()
     {
-        return await JsObjectReference!.InvokeAsync<int>("getSelectedFeatureIndex", CancellationTokenSource.Token);
+        return await JsWidgetReference!.InvokeAsync<int>("getSelectedFeatureIndex", CancellationTokenSource.Token);
     }
 
     /// <summary>
@@ -236,7 +236,7 @@ public class PopupWidget : Widget
     /// </summary>
     public async Task<bool> GetVisibility()
     {
-        return await JsObjectReference!.InvokeAsync<bool>("getVisibility", CancellationTokenSource.Token);
+        return await JsWidgetReference!.InvokeAsync<bool>("getVisibility", CancellationTokenSource.Token);
     }
 
     /// <summary>
@@ -246,7 +246,7 @@ public class PopupWidget : Widget
     /// </summary>
     public async Task Open()
     {
-        await JsObjectReference!.InvokeVoidAsync("open", CancellationTokenSource.Token);
+        await JsWidgetReference!.InvokeVoidAsync("open", CancellationTokenSource.Token);
     }
 
     /// <summary>
@@ -255,7 +255,7 @@ public class PopupWidget : Widget
     /// </summary>
     public async Task Close()
     {
-        await JsObjectReference!.InvokeVoidAsync("close", CancellationTokenSource.Token);
+        await JsWidgetReference!.InvokeVoidAsync("close", CancellationTokenSource.Token);
     }
 
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/SearchSource.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/SearchSource.cs
@@ -1,0 +1,661 @@
+﻿using dymaptic.GeoBlazor.Core.Components.Geometries;
+using dymaptic.GeoBlazor.Core.Components.Layers;
+using dymaptic.GeoBlazor.Core.Components.Popups;
+using dymaptic.GeoBlazor.Core.Components.Symbols;
+using dymaptic.GeoBlazor.Core.Objects;
+using dymaptic.GeoBlazor.Core.Serialization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+
+namespace dymaptic.GeoBlazor.Core.Components.Widgets;
+
+/// <summary>
+///     The following properties define generic sources properties for use in the Search widget. Please see the subclasses that extend this class for more information about working with Search widget sources.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Search-SearchSource.html">ArcGIS JS API</a>
+/// </summary>
+[JsonConverter(typeof(SearchSourceConverter))]
+public class SearchSource : MapComponent
+{
+    /// <summary>
+    ///     The type of source.
+    /// </summary>
+    public virtual string Type => "";
+    
+    /// <summary>
+    ///     Indicates whether to automatically navigate to the selected result once selected.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? AutoNavigate { get; set; }
+    
+    /// <summary>
+    ///     Indicates the maximum number of search results to return. Default value is 6.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MaxResults { get; set; }
+    
+    /// <summary>
+    ///     Indicates the minimum number of characters required before querying for a suggestion. Default value is 1.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MinSuggestCharacters { get; set; }
+    
+    /// <summary>
+    ///     The name of the source for display.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Name { get; set; }
+    
+    /// <summary>
+    ///     Specifies the fields returned with the search results.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IEnumerable<string>? OutFields { get; set; }
+    
+    /// <summary>
+    ///     Used as a hint for the source input text.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Placeholder { get; set; }
+    
+    /// <summary>
+    ///     Indicates whether to display a Popup when a selected result is clicked.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? PopupEnabled { get; set; }
+    
+    /// <summary>
+    ///     Specify this to prefix the user's input of the search text.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Prefix { get; set; }
+    
+    /// <summary>
+    ///     Indicates whether to show a graphic on the map for the selected source using the resultSymbol.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? ResultGraphicEnabled { get; set; }
+    
+    /// <summary>
+    ///     A template string used to display multiple fields in a defined order when results are displayed.
+    /// </summary>
+    /// <remarks>
+    ///     Example: "{County}, {State}"
+    /// </remarks>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SearchTemplate { get; set; }
+    
+    /// <summary>
+    ///     Specify this to add a suffix to the user's input for the search value.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Suffix { get; set; }
+    
+    /// <summary>
+    ///     Indicates whether to display suggestions as the user enters input text in the widget. Default value is true.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? SuggestionsEnabled { get; set; }
+    
+    /// <summary>
+    ///     Indicates whether to constrain the search results to the view's extent. Default value is false.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? WithinViewEnabled { get; set; }
+    
+    /// <summary>
+    ///     The set zoom scale for the resulting search result. This scale is automatically honored. Default value is null.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? ZoomScale { get; set; }
+    
+    /// <summary>
+    ///     Function used to get search results. See GetResultsHandler for the function definition. When resolved, returns an object containing an array of search results.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore]
+    public Func<GetResultsParameters, Task<IList<SearchResult>>>? GetResultsHandler { get; set; }
+    
+    /// <summary>
+    ///     Function used to get search suggestions. See GetSuggestionsParameters for the function definition. When resolved, returns an object containing an array of suggest results.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore]
+    public Func<GetSuggestionsParameters, Task<IList<SuggestResult>>>? GetSuggestionsHandler { get; set; }
+    
+    /// <summary>
+    ///     The popup template used to display search results. If no popup is needed, set the source's popupTemplate to null.
+    /// </summary>
+    /// <remarks>
+    ///     This property should be set in instances where there is no existing PopupTemplate configured. For example, feature sources will default to any existing popupTemplate configured on the layer.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public PopupTemplate? PopupTemplate { get; set; }
+    
+    /// <summary>
+    ///     The symbol used to display the result.
+    /// </summary>
+    /// <remarks>
+    ///     This property only applies when the layer/locator/source is not part of the map.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Symbol? ResultSymbol { get; set; }
+    
+    /// <summary>
+    ///     The .NET object reference to this class for calling from JavaScript.
+    /// </summary>
+    public DotNetObjectReference<SearchSource> SearchSourceObjectReference => DotNetObjectReference.Create(this);
+    
+    /// <summary>
+    ///     Indicates for the JavaScript engine whether to set up the GetResults handler
+    /// </summary>
+    public bool HasGetResultsHandler => GetResultsHandler is not null;
+
+    /// <summary>
+    ///     Indicates for the JavaScript engine whether to set up the GetSuggestions handler
+    /// </summary>
+    public bool HasGetSuggestionsHandler => GetSuggestionsHandler is not null;
+    
+    /// <summary>
+    ///     JavaScript-invokable method for internal use.
+    /// </summary>
+    [JSInvokable]
+    public async Task<IList<SearchResult>> OnJavaScriptGetResults(GetResultsParameters resultsParams)
+    {
+        return await GetResultsHandler!.Invoke(resultsParams);
+    }
+    
+    /// <summary>
+    ///     JavaScript-invokable method for internal use.
+    /// </summary>
+    [JSInvokable]
+    public async Task<IList<SuggestResult>> OnJavaScriptGetSuggestions(GetSuggestionsParameters suggestionsParams)
+    {
+        return await GetSuggestionsHandler!.Invoke(suggestionsParams);
+    }
+    
+    /// <inheritdoc />
+    public override async Task RegisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case PopupTemplate popupTemplate:
+                if (!popupTemplate.Equals(PopupTemplate))
+                {
+                    PopupTemplate = popupTemplate;
+                }
+                break;
+            case Symbol symbol:
+                if (!symbol.Equals(ResultSymbol))
+                {
+                    ResultSymbol = symbol;
+                }
+
+                break;
+            default:
+                await base.RegisterChildComponent(child);
+
+                break;
+        }
+    }
+    
+    /// <inheritdoc />
+    public override async Task UnregisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case PopupTemplate _:
+                PopupTemplate = null;
+
+                break;
+            case Symbol:
+                ResultSymbol = null;
+
+                break;
+            default:
+                await base.UnregisterChildComponent(child);
+
+                break;
+        }
+    }
+
+    internal override void ValidateRequiredChildren()
+    {
+        PopupTemplate?.ValidateRequiredChildren();
+        ResultSymbol?.ValidateRequiredChildren();
+        base.ValidateRequiredChildren();
+    }
+}
+
+/// <summary>
+///     The following properties define a Layer-based source whose features may be searched by a Search widget instance.
+///     For string field searches, there is no leading wildcard. This effectively makes exactMatch true, which will remove unnecessary search results and suggestions.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Search-LayerSearchSource.html">ArcGIS JS API</a>
+/// </summary>
+/// <remarks>
+///     Layers created from client-side graphics are not supported.
+/// </remarks>
+public class LayerSearchSource : SearchSource
+{
+    /// <inheritdoc />
+    public override string Type => "layer";
+    
+    /// <summary>
+    ///     The results are displayed using this field. Defaults to the layer's displayField or the first string field.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayField { get; set; }
+    
+    /// <summary>
+    ///     Indicates to only return results that match the search value exactly. This property only applies to string field searches. exactMatch is always true when searching fields of type number. Default Value is false.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? ExactMatch { get; set; }
+
+    /// <summary>
+    ///     The Id for the layer queried in the search. This is required. The layer can be a map/feature service feature layer(s), SceneLayers with an associated feature layer, BuildingComponentSublayer with an associated feature layer, GeoJSONLayer, CSVLayer or OGCFeatureLayer. See the SceneLayer Guide page on how to publish SceneLayers with associated feature layers.
+    /// </summary>
+    /// <remarks>
+    ///     You may either specify a LayerId for an existing map layer, or nest a new <see cref="FeatureLayer"/> inside this Search Source.
+    ///     Feature layers created from client-side graphics are not supported.
+    /// </remarks>
+    [Parameter]
+    [RequiredProperty(nameof(Layer))]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Guid? LayerId { get; set; }
+    
+    /// <summary>
+    ///     One or more field names used to order the query results. Specfiy ASC (ascending) or DESC (descending) after the field name to control the order. The default order is ASC.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IEnumerable<string>? OrderByFields { get; set; }
+    
+    /// <summary>
+    ///     An array of string values representing the names of fields in the feature layer to search.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IEnumerable<string>? SearchFields { get; set; }
+    
+    /// <summary>
+    ///     A template string used to display multiple fields in a defined order when suggestions are displayed. This takes precedence over displayField. Field names in the template must have the following format: {FieldName}. An example suggestionTemplate could look something like: Name: {OWNER}, Parcel: {PARCEL_ID}.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SuggestionTemplate { get; set; }
+    
+    /// <summary>
+    ///     For filtering suggests or search results. Setting a value here takes precedence over withinViewEnabled. Please see the object specification table below for details.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public LayerSearchSourceFilter? Filter { get; set; }
+    
+    /// <summary>
+    ///     The layer queried in the search. This is required. The layer can be a map/feature service feature layer(s), SceneLayers with an associated feature layer, BuildingComponentSublayer with an associated feature layer, GeoJSONLayer, CSVLayer or OGCFeatureLayer. See the SceneLayer Guide page on how to publish SceneLayers with associated feature layers.
+    /// </summary>
+    /// <remarks>
+    ///     You may either specify a LayerId for an existing map layer, or nest a new <see cref="FeatureLayer"/> inside this Search Source.
+    ///     Feature layers created from client-side graphics are not supported.
+    /// </remarks>
+    [RequiredProperty(nameof(LayerId))]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Layer? Layer { get; set; }
+    
+    /// <inheritdoc />
+    public override async Task RegisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case LayerSearchSourceFilter filter:
+                if (!filter.Equals(Filter))
+                {
+                    Filter = filter;
+                }
+                break;
+            case Layer layer:
+                if (!layer.Equals(Layer))
+                {
+                    Layer = layer;
+                }
+
+                break;
+            default:
+                await base.RegisterChildComponent(child);
+
+                break;
+        }
+    }
+    
+    /// <inheritdoc />
+    public override async Task UnregisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case LayerSearchSourceFilter:
+                Filter = null;
+                break;
+            case Layer _:
+                Layer = null;
+                break;
+            default:
+                await base.UnregisterChildComponent(child);
+
+                break;
+        }
+    }
+
+    internal override void ValidateRequiredChildren()
+    {
+        Filter?.ValidateRequiredChildren();
+        Layer?.ValidateRequiredChildren();
+        base.ValidateRequiredChildren();
+    }
+}
+
+/// <summary>
+///     The following properties define a source pointing to a url that represents a locator service, which may be used to geocode locations with a Search widget instance.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Search-LocatorSearchSource.html">ArcGIS JS API</a>
+/// </summary>
+public class LocatorSearchSource : SearchSource
+{
+    /// <inheritdoc />
+    public override string Type => "locator";
+    
+    /// <summary>
+    ///     An authorization string used to access a resource or service. API keys are generated and managed in the ArcGIS Developer dashboard. An API key is tied explicitly to an ArcGIS account; it is also used to monitor service usage. Setting a fine-grained API key on a specific class overrides the global API key.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ApiKey { get; set; }    
+    
+    /// <summary>
+    ///     A string array which limits the results to one or more categories. For example, Populated Place or airport. Only applicable when using the World Geocode Service.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IEnumerable<string>? Categories { get; set; }
+    
+    /// <summary>
+    ///     Constricts search results to a specified country code. For example, US for United States or SE for Sweden. Only applies to the World Geocode Service.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CountryCode { get; set; }
+    
+    /// <summary>
+    ///     Sets the scale of the MapView or SceneView for the resulting search result, if the locator service doesn’t return an extent with a scale. An example of this is using the Use current location option in the Search bar.
+    ///     If you want to override the scale returned by the locator service, use zoomScale instead.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? DefaultZoomScale { get; set; }
+    
+    /// <summary>
+    ///     This property controls prioritization of Search widget result candidates depending on the view scale.
+    ///     When this property is false (the default value), the location parameter is included in the request when the scale of the MapView or SceneView is less than or equal to 300,000. This prioritizes result candidates based on their distance from a specified point (the center of the view).
+    ///     When this property is true, the location parameter is never included in the request, no matter the scale of the MapView or SceneView.
+    ///     Default value is False.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? LocalSearchDisabled { get; set; }
+    
+    /// <summary>
+    ///     Defines the type of location, either street or rooftop, of the point returned from the World Geocoding Service.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public LocatorSearchLocationType? LocationType { get; set; }
+    
+    /// <summary>
+    ///     The field name of the Single Line Address Field in the REST services directory for the locator service. Common values are SingleLine and SingleLineFieldName.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SingleLineFieldName { get; set; }
+
+    /// <summary>
+    ///     URL to the ArcGIS Server REST resource that represents a locator service. This is required.
+    /// </summary>
+    [Parameter]
+    [RequiredProperty]
+    [EditorRequired]
+    public string Url { get; set; } = default!;
+    
+    /// <summary>
+    ///     For filtering suggests or search results. Setting a value here takes precedence over withinViewEnabled.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public LocatorSearchSourceFilter? Filter { get; set; }
+    
+    /// <inheritdoc />
+    public override async Task RegisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case LocatorSearchSourceFilter filter:
+                if (!filter.Equals(Filter))
+                {
+                    Filter = filter;
+                }
+                break;
+            default:
+                await base.RegisterChildComponent(child);
+
+                break;
+        }
+    }
+    
+    /// <inheritdoc />
+    public override async Task UnregisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case LocatorSearchSourceFilter:
+                Filter = null;
+                break;
+            default:
+                await base.UnregisterChildComponent(child);
+
+                break;
+        }
+    }
+
+    internal override void ValidateRequiredChildren()
+    {
+        Filter?.ValidateRequiredChildren();
+        base.ValidateRequiredChildren();
+    }
+}
+
+/// <summary>
+///     For filtering suggests or search results. Setting a value here takes precedence over withinViewEnabled. Please see the object specification table below for details.
+/// </summary>
+public class LayerSearchSourceFilter : MapComponent
+{
+    /// <summary>
+    ///     The where clause specified for filtering suggests or search results.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Where { get; set; }
+    
+    /// <summary>
+    ///     The filter geometry for suggests or search results. Extent is the only supported geometry when working with locator sources. See <a target="_blank" href="https://developers.arcgis.com/rest/services-reference/enterprise/find-address-candidates.htm">Find Address Candidates</a> for additional information.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Geometry? Geometry { get; set; }
+}
+
+/// <summary>
+///     For filtering suggests or search results. Setting a value here takes precedence over withinViewEnabled. Please see the object specification table below for details.
+/// </summary>
+public class LocatorSearchSourceFilter : MapComponent
+{
+    /// <summary>
+    ///     The filter geometry for suggests or search results. Extent is the only supported geometry when working with locator sources. See <a target="_blank" href="https://developers.arcgis.com/rest/services-reference/enterprise/find-address-candidates.htm">Find Address Candidates</a> for additional information.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Geometry? Geometry { get; set; }
+}
+
+/// <summary>
+///     Defines the type of location, either street or rooftop, of the point returned from the World Geocoding Service.
+/// </summary>
+[JsonConverter(typeof(EnumToKebabCaseStringConverter<LocatorSearchLocationType>))]
+public enum LocatorSearchLocationType
+{
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+    Rooftop,
+    Street
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+}
+
+/// <summary>
+///     An object that is passed as a parameter to get search results.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Search-SearchSource.html#GetResultsHandler">ArcGIS JS API</a>
+/// </summary>
+/// <param name="ExactMatch">
+///     The key field used to find the result.
+/// </param>
+/// <param name="Location">
+///     The location value used by the Search.
+/// </param>
+/// <param name="MaxResults">
+///     Indicates the maximum number of search results to return.
+/// </param>
+/// <param name="SourceIndex">
+///     Indicates the index of the search source.
+/// </param>
+/// <param name="SpatialReference">
+///     Indicates the Spatial Reference defined by the source.
+/// </param>
+/// <param name="SuggestResult">
+///     Indicates the Suggest Result that triggered the search for a result.
+/// </param>
+/// <param name="ViewId">
+///     Indicates the Id for the MapView or SceneView provided to the Search Widget using the source.
+/// </param>
+public record GetResultsParameters(bool? ExactMatch, Point? Location, int? MaxResults, int? SourceIndex, 
+    SpatialReference? SpatialReference, SuggestResult SuggestResult, Guid? ViewId);
+    
+/// <summary>
+///     The result object returned from a suggest().
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Search.html#SuggestResult">ArcGIS JS API</a>
+/// </summary>
+/// <param name="Key">
+///     The key related to the suggest result.
+/// </param>
+/// <param name="Text">
+///     The key related to the suggest result.
+/// </param>
+/// <param name="SourceIndex">
+///     The key related to the suggest result.
+/// </param>
+public record SuggestResult(string Key, string Text, int SourceIndex);
+
+/// <summary>
+///     An object that is passed as a parameter to get search suggestions.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Search-SearchSource.html#GetSuggestionsParameters">ArcGIS JS API</a>
+/// </summary>
+/// <param name="MaxSuggestions">
+///     Indicates the maximum number of suggestions to return for the widget's input.
+/// </param>
+/// <param name="SourceIndex">
+///     Indicates the index of the search source.
+/// </param>
+/// <param name="SpatialReference">
+///     Indicates the Spatial Refeference defined by the source.
+/// </param>
+/// <param name="SuggestTerm">
+///     Indicates search term used to find a suggestion.
+/// </param>
+/// <param name="ViewId">
+///     Indicates the Id for the MapView or SceneView provided to the Search Widget using the source.
+/// </param>
+public record GetSuggestionsParameters(int? MaxSuggestions, int? SourceIndex, 
+    SpatialReference? SpatialReference, string? SuggestTerm, Guid? ViewId);
+
+internal class SearchSourceConverter : JsonConverter<SearchSource>
+{
+    public override SearchSource? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            return null;
+        }
+        
+        using var jsonDocument = JsonDocument.ParseValue(ref reader);
+        var rootElement = jsonDocument.RootElement;
+        var type = rootElement.GetProperty("type").GetString();
+        return type switch
+        {
+            "layer" => JsonSerializer.Deserialize<LayerSearchSource>(rootElement.GetRawText(), options),
+            "locator" => JsonSerializer.Deserialize<LocatorSearchSource>(rootElement.GetRawText(), options),
+            "" => MapFrom<BaseSearchSource, SearchSource>(JsonSerializer.Deserialize<BaseSearchSource>(rootElement.GetRawText(), options)),
+            _ => null
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, SearchSource value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case LocatorSearchSource locatorSearchSource:
+                JsonSerializer.Serialize(writer, locatorSearchSource, options);
+                break;
+            case LayerSearchSource layerSearchSource:
+                JsonSerializer.Serialize(writer, layerSearchSource, options);
+                break;
+            default:
+                JsonSerializer.Serialize(writer, 
+                    MapFrom<SearchSource, BaseSearchSource>(value)!, options);
+
+                break;
+        }
+    }
+    
+    // Copy properties from source object to new instance of target object, for instance using reflection.
+    private static TTarget? MapFrom<TSource, TTarget>(TSource? sourceObject) where TTarget : class, new()
+    {
+        if (sourceObject is null)
+            return null;
+
+        IEnumerable<PropertyInfo> sourceProperties = typeof(TSource).GetProperties().Where(prop => prop.CanRead);
+        PropertyInfo[] targetProperties = typeof(TTarget).GetProperties().Where(prop => prop.CanWrite).ToArray();
+
+        TTarget target = new TTarget();
+        foreach (PropertyInfo sourceProperty in sourceProperties)
+        {
+            PropertyInfo? targetProperty = targetProperties.FirstOrDefault(prop => prop.Name == sourceProperty.Name);
+            targetProperty?.SetValue(target, sourceProperty.GetValue(sourceObject));
+        }
+        return target;
+    }
+    
+    private class BaseSearchSource : SearchSource
+    {
+    }
+}

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/SearchWidget.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/SearchWidget.cs
@@ -306,17 +306,17 @@ public class SearchWidget : Widget
     /// <summary>
     ///     Retrieves the combined collection of defaultSources and sources. The defaultSources displays first in the Search UI.
     /// </summary>
-    public async Task<SearchSource> GetAllSources()
+    public async Task<IReadOnlyList<SearchSource>> GetAllSources()
     {
-        return await JsWidgetReference!.InvokeAsync<SearchSource>("getAllSources");
+        return await JsWidgetReference!.InvokeAsync<IReadOnlyList<SearchSource>>("getAllSources");
     }
 
     /// <summary>
     ///     Retrieves a Collection of LayerSearchSource and/or LocatorSearchSource. This may contain ArcGIS Portal locators and any web map or web scene configurable search sources. Web maps or web scenes may contain map/feature service feature layer(s), and/or table(s) as sources.
     /// </summary>
-    public async Task<SearchSource> GetDefaultSources()
+    public async Task<IReadOnlyList<SearchSource>> GetDefaultSources()
     {
-        return await JsWidgetReference!.InvokeAsync<SearchSource>("getDefaultSources");
+        return await JsWidgetReference!.InvokeAsync<IReadOnlyList<SearchSource>>("getDefaultSources");
     }
 
     /// <summary>
@@ -333,9 +333,9 @@ public class SearchWidget : Widget
     /// <summary>
     ///     Retrieves an array of objects, each containing a SearchResult from the search.
     /// </summary>
-    public async Task<SearchResultResponse> GetResults()
+    public async Task<IReadOnlyList<SearchResultResponse>> GetResults()
     {
-        return await JsWidgetReference!.InvokeAsync<SearchResultResponse>("getResults");
+        return await JsWidgetReference!.InvokeAsync<IReadOnlyList<SearchResultResponse>>("getResults");
     }
 
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/SearchWidget.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/SearchWidget.cs
@@ -2,6 +2,7 @@
 using dymaptic.GeoBlazor.Core.Components.Layers;
 using dymaptic.GeoBlazor.Core.Components.Popups;
 using dymaptic.GeoBlazor.Core.Components.Symbols;
+using dymaptic.GeoBlazor.Core.Exceptions;
 using dymaptic.GeoBlazor.Core.Objects;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
@@ -140,6 +141,9 @@ public class SearchWidget : Widget
     /// <summary>
     ///     The value of the search box input text string.
     /// </summary>
+    /// <remarks>
+    ///     Only use to set an initial value. Use SetSearchTerm() and GetSearchTerm() to update or read.
+    /// </remarks>
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? SearchTerm { get; set; }
@@ -194,6 +198,86 @@ public class SearchWidget : Widget
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Portal? Portal { get; set; }
+
+    /// <summary>
+    ///     Set the value of the search text box programmatically.
+    /// </summary>
+    public async Task SetSearchTerm(string searchTerm)
+    {
+#pragma warning disable BL0005
+        SearchTerm = searchTerm;
+#pragma warning restore BL0005
+        await JsWidgetReference!.InvokeVoidAsync("setSearchTerm", searchTerm);
+    }
+
+    /// <summary>
+    ///     Retrieves the current value of the search text box.
+    /// </summary>
+    public async Task<string> GetSearchTerm()
+    {
+#pragma warning disable BL0005
+        SearchTerm = await JsWidgetReference!.InvokeAsync<string>("getSearchTerm");
+#pragma warning restore BL0005
+        return SearchTerm;
+    }
+
+    /// <summary>
+    ///     Depending on the sources specified, search() queries the feature layer(s) and/or performs address matching using any specified locator(s) and returns any applicable results.
+    /// </summary>
+    /// <param name="searchTerm">
+    ///     The term to search for.
+    /// </param>
+    public async Task<SearchResponse> Search(string searchTerm)
+    {
+        return await JsWidgetReference!.InvokeAsync<SearchResponse>("search", searchTerm);
+    }
+    
+    /// <summary>
+    ///     Depending on the sources specified, search() queries the feature layer(s) and/or performs address matching using any specified locator(s) and returns any applicable results.
+    /// </summary>
+    /// <param name="searchTerm">
+    ///     The geometry to search for.
+    /// </param>
+    public async Task<SearchResponse> Search(Geometry searchTerm)
+    {
+        return await JsWidgetReference!.InvokeAsync<SearchResponse>("search", searchTerm);
+    }
+    
+    /// <summary>
+    ///     Depending on the sources specified, search() queries the feature layer(s) and/or performs address matching using any specified locator(s) and returns any applicable results.
+    /// </summary>
+    /// <param name="searchTerm">
+    ///     The <see cref="SuggestResult"/> to search for.
+    /// </param>
+    public async Task<SearchResponse> Search(SuggestResult searchTerm)
+    {
+        return await JsWidgetReference!.InvokeAsync<SearchResponse>("search", searchTerm);
+    }
+    
+    /// <summary>
+    ///     Depending on the sources specified, search() queries the feature layer(s) and/or performs address matching using any specified locator(s) and returns any applicable results.
+    /// </summary>
+    /// <param name="searchTerm">
+    ///     The array of long/lat coordinate pairs to search for.
+    /// </param>
+    public async Task<SearchResponse> Search(double[][] searchTerm)
+    {
+        return await JsWidgetReference!.InvokeAsync<SearchResponse>("search", searchTerm);
+    }
+    
+    /// <summary>
+    ///     Performs a suggest() request on the active Locator. It also uses the current value of the widget or one that is passed in.
+    /// </summary>
+    /// <remarks>
+    ///     Suggestions are available if working with a 10.3 or greater geocoding service that has suggest capability loaded or a 10.3 or greater feature layer that supports pagination, i.e. supportsPagination = true.
+    /// </remarks>
+    /// <param name="value">
+    ///     The string value used to suggest() on an active Locator or feature layer. If nothing is passed in, takes the current value of the widget.
+    /// </param>
+    public async Task<SuggestResponse> Suggest(string? value = null)
+    {
+        return await JsWidgetReference!.InvokeAsync<SuggestResponse>("suggest", value);
+    }
 
     /// <summary>
     ///     Retrieves the source object currently selected. Can be either a LayerSearchSource or a LocatorSearchSource.

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/SearchWidget.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/SearchWidget.cs
@@ -1,6 +1,12 @@
-﻿using dymaptic.GeoBlazor.Core.Objects;
+﻿using dymaptic.GeoBlazor.Core.Components.Geometries;
+using dymaptic.GeoBlazor.Core.Components.Layers;
+using dymaptic.GeoBlazor.Core.Components.Popups;
+using dymaptic.GeoBlazor.Core.Components.Symbols;
+using dymaptic.GeoBlazor.Core.Objects;
+using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using System.Reflection.Metadata;
 using System.Text.Json.Serialization;
 
 
@@ -23,13 +29,248 @@ public class SearchWidget : Widget
     public override string WidgetType => "search";
 
     /// <summary>
+    ///     Sets the current active menu of the Search widget. Default value is None.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public SearchMenu? ActiveMenu { get; set; }
+    
+    /// <summary>
+    ///     Sets the selected source's index. Default value is 0.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ActiveSourceIndex { get; set; }
+    
+    /// <summary>
+    ///     String value used as a hint for input text when searching on multiple sources. See the image below to view the location and style of this text in the context of the widget.
+    ///     Default Value: "Find address or place"
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AllPlaceholder { get; set; }
+    
+    /// <summary>
+    ///     Indicates whether to automatically select and zoom to the first geocoded result. If false, the findAddressCandidates operation will still geocode the input string, but the top result will not be selected. To work with the geocoded results, you can set up a search-complete event handler and get the results through the event object.
+    ///     Default value is True.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? AutoSelect { get; set; }
+    
+    /// <summary>
+    ///     When true, the widget is visually withdrawn and cannot be interacted with. Default value is False.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Disabled { get; set; }
+    
+    /// <summary>
+    ///     Indicates whether or not to include defaultSources in the Search UI.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? IncludeDefaultSources { get; set; }
+    
+    /// <summary>
+    ///     The widget's default label.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Label { get; set; }
+    
+    /// <summary>
+    ///     Enables location services within the widget. Default value is True.
+    /// </summary>
+    /// <remarks>
+    ///     The use of this property is only supported on secure origins. To use it, switch your application to a secure origin, such as HTTPS. Note that localhost is considered "potentially secure" and can be used for easy testing in browsers that supports Window.isSecureContext (currently Chrome and Firefox).
+    /// </remarks>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? LocationEnabled { get; set; }
+    
+    /// <summary>
+    ///     The maximum number of results returned by the widget if not specified by the source. Default value is 6.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MaxResults { get; set; }
+    
+    /// <summary>
+    ///     The maximum number of suggestions returned by the widget if not specified by the source.
+    ///     If working with the default ArcGIS Online Geocoding service, the default remains at 5.
+    ///     Default Value:6
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MaxSuggestions { get; set; }
+    
+    /// <summary>
+    ///     The minimum number of characters needed for the search if not specified by the source.
+    ///     Default Value:3
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MinSuggestCharacters { get; set; }
+    
+    /// <summary>
+    ///     Indicates whether to display the Popup on feature click. The graphic can be clicked to display a Popup.
+    ///     Default Value:true
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? PopupEnabled { get; set; }
+    
+    /// <summary>
+    ///     Indicates if the resultGraphic will display at the location of the selected feature.
+    ///     Default Value:true
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? ResultGraphicEnabled { get; set; }
+    
+    /// <summary>
+    ///     Indicates whether to display the option to search all sources. When true, the "All" option is displayed by default. When false, no option to search all sources at once is available.
+    ///     Default Value is True.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? SearchAllEnabled { get; set; }
+    
+    /// <summary>
+    ///     The value of the search box input text string.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SearchTerm { get; set; }
+    
+    /// <summary>
+    ///     Enable suggestions for the widget.
+    ///     This is only available if working with a 10.3 or greater geocoding service that has suggest capability loaded or a 10.3 or greater feature layer that supports pagination, i.e. supportsPagination = true.
+    ///     Default Value:true
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? SuggestionsEnabled { get; set; }
+    
+    /// <summary>
     ///     A delegate for a handler of search selection result events.
     ///     Function must take in a <see cref="SearchResult" /> parameter, and return a <see cref="Task" />
     /// </summary>
     [Parameter]
     [JsonIgnore]
     public EventCallback<SearchResult> OnSearchSelectResultEvent { get; set; }
+    
+    /// <summary>
+    ///     This function provides the ability to override either the MapView goTo() or SceneView goTo() methods with your own implementation.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore]
+    public Action<GoToOverrideParameters>? GoToOverride { get; set; }
 
+    /// <summary>
+    ///     Identifies whether a custom <see cref="GoToOverride" /> was registered.
+    /// </summary>
+    public bool HasGoToOverride => GoToOverride is not null;
+    
+    /// <summary>
+    ///     The Search widget may be used to search features in a map/feature service feature layer(s), SceneLayers with an associated feature layer, BuildingComponentSublayer with an associated feature layer, GeoJSONLayer, CSVLayer or OGCFeatureLayer, or table, or geocode locations with a locator. The sources property defines the sources from which to search for the view specified by the Search widget instance.
+    ///     There are two types of sources: <see cref="LayerSearchSource"/> and <see cref="LocatorSearchSource"/>. Any combination of these sources may be used together in the same instance of the Search widget. 
+    /// </summary>
+    /// <remarks>
+    ///     Feature layers created from client-side graphics are not supported.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public HashSet<SearchSource>? Sources { get; set; }
+    
+    /// <summary>
+    ///     A customized PopupTemplate for the selected feature. Note that any templates defined on allSources take precedence over those defined directly on the template.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public PopupTemplate? PopupTemplate { get; set; }
+    
+    /// <summary>
+    ///     It is possible to search a specified portal instance's locator services Use this property to set this ArcGIS Portal instance to search.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Portal? Portal { get; set; }
+
+    /// <summary>
+    ///     Retrieves the source object currently selected. Can be either a LayerSearchSource or a LocatorSearchSource.
+    /// </summary>
+    public async Task<SearchSource?> GetActiveSource()
+    {
+        return await JsWidgetReference!.InvokeAsync<SearchSource?>("getActiveSource");
+    }
+    
+    /// <summary>
+    ///     Retrieves the current active menu of the Search widget. Default value is None.
+    /// </summary>
+    public async Task<SearchMenu> GetActiveMenu()
+    {
+        return await JsWidgetReference!.InvokeAsync<SearchMenu>("getActiveMenu");
+    }
+
+    /// <summary>
+    ///     Retrieves the index of the currently selected source. This value is -1 when all sources are selected.
+    /// </summary>
+    public async Task<int> GetActiveSourceIndex()
+    {
+        return await JsWidgetReference!.InvokeAsync<int>("getActiveSourceIndex");
+    }
+
+    /// <summary>
+    ///     Retrieves the combined collection of defaultSources and sources. The defaultSources displays first in the Search UI.
+    /// </summary>
+    public async Task<SearchSource> GetAllSources()
+    {
+        return await JsWidgetReference!.InvokeAsync<SearchSource>("getAllSources");
+    }
+
+    /// <summary>
+    ///     Retrieves a Collection of LayerSearchSource and/or LocatorSearchSource. This may contain ArcGIS Portal locators and any web map or web scene configurable search sources. Web maps or web scenes may contain map/feature service feature layer(s), and/or table(s) as sources.
+    /// </summary>
+    public async Task<SearchSource> GetDefaultSources()
+    {
+        return await JsWidgetReference!.InvokeAsync<SearchSource>("getDefaultSources");
+    }
+
+    /// <summary>
+    ///     The graphic used to highlight the resulting feature or location.
+    /// </summary>
+    /// <remarks>
+    ///     A graphic will be placed in the View's graphics for layer views that do not support the highlight method.
+    /// </remarks>
+    public async Task<Graphic> GetResultGraphic()
+    {
+        return await JsWidgetReference!.InvokeAsync<Graphic>("getResultGraphic");
+    }
+
+    /// <summary>
+    ///     Retrieves an array of objects, each containing a SearchResult from the search.
+    /// </summary>
+    public async Task<SearchResultResponse> GetResults()
+    {
+        return await JsWidgetReference!.InvokeAsync<SearchResultResponse>("getResults");
+    }
+
+    /// <summary>
+    ///    Retrieves the result selected from a search.
+    /// </summary>
+    public async Task<SearchResult> GetSelectedResult()
+    {
+        return await JsWidgetReference!.InvokeAsync<SearchResult>("getSelectedResult");
+    }
+
+    /// <summary>
+    ///     Retrieves an array of results from the suggest method.
+    ///     This is available if working with a 10.3 or greater geocoding service that has suggest capability loaded or a 10.3 or greater feature layer that supports pagination, i.e. supportsPagination = true.
+    /// </summary>
+    public async Task<SuggestResult[]> GetSuggestions()
+    {
+        return await JsWidgetReference!.InvokeAsync<SuggestResult[]>("getSuggestions");
+    }
+    
     /// <summary>
     ///     A .NET object reference for calling this class from JavaScript.
     /// </summary>
@@ -46,4 +287,97 @@ public class SearchWidget : Widget
     {
         await OnSearchSelectResultEvent.InvokeAsync();
     }
+    
+    /// <summary>
+    ///     JavaScript-invokable method for internal use
+    /// </summary>
+    [JSInvokable]
+    public void OnJavaScriptGoToOverride(GoToOverrideParameters goToOverrideParams)
+    {
+        GoToOverride?.Invoke(goToOverrideParams);
+    }
+    
+    /// <inheritdoc />
+    public override async Task RegisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case SearchSource source:
+                Sources ??= new HashSet<SearchSource>();
+                Sources.Add(source);
+                WidgetChanged = true;
+                break;
+            case PopupTemplate popupTemplate:
+                if (!popupTemplate.Equals(PopupTemplate))
+                {
+                    PopupTemplate = popupTemplate;
+                    WidgetChanged = true;
+                }
+
+                break;
+            case Portal portal:
+                if (!portal.Equals(Portal))
+                {
+                    Portal = portal;
+                    WidgetChanged = true;
+                }
+
+                break;
+            default:
+                await base.RegisterChildComponent(child);
+
+                break;
+        }
+    }
+    
+    /// <inheritdoc />
+    public override async Task UnregisterChildComponent(MapComponent child)
+    {
+        switch (child)
+        {
+            case SearchSource source:
+                Sources?.Remove(source);
+                break;
+            case PopupTemplate _:
+                PopupTemplate = null;
+
+                break;
+            case Portal _:
+                Portal = null;
+
+                break;
+            default:
+                await base.UnregisterChildComponent(child);
+
+                break;
+        }
+    }
+    
+    internal override void ValidateRequiredChildren()
+    {
+        if (Sources is not null)
+        {
+            foreach (SearchSource source in Sources)
+            {
+                source.ValidateRequiredChildren();
+            }
+        }
+        PopupTemplate?.ValidateRequiredChildren();
+        Portal?.ValidateRequiredChildren();
+        base.ValidateRequiredChildren();
+    }
+}
+
+/// <summary>
+///     The active menu of the search widget.
+/// </summary>
+[JsonConverter(typeof(EnumToKebabCaseStringConverter<SearchMenu>))]
+public enum SearchMenu
+{
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+    None,
+    Suggestion,
+    Source,
+    Warning
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/Widget.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/Widget.cs
@@ -66,7 +66,7 @@ public abstract class Widget : MapComponent
     [JSInvokable]
     public void OnWidgetCreated(IJSObjectReference jsObjectReference)
     {
-        JsObjectReference = jsObjectReference;
+        JsWidgetReference = jsObjectReference;
     }
     
     /// <inheritdoc />
@@ -106,7 +106,7 @@ public abstract class Widget : MapComponent
     /// <summary>
     ///     JS Object Reference to the widget
     /// </summary>
-    protected IJSObjectReference? JsObjectReference;
+    protected IJSObjectReference? JsWidgetReference;
 }
 
 internal class WidgetConverter : JsonConverter<Widget>

--- a/src/dymaptic.GeoBlazor.Core/Objects/SearchResult.cs
+++ b/src/dymaptic.GeoBlazor.Core/Objects/SearchResult.cs
@@ -1,6 +1,7 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Geometries;
 using dymaptic.GeoBlazor.Core.Components.Layers;
 using dymaptic.GeoBlazor.Core.Components.Widgets;
+using dymaptic.GeoBlazor.Core.Exceptions;
 using System.Text.Json.Serialization;
 
 
@@ -53,3 +54,24 @@ public class SearchResult
 ///     The index of the source
 /// </param>
 public record SearchResultResponse(SearchResult[] Results, SearchSource Source, int SourceIndex);
+
+/// <summary>
+///     When resolved, returns this response after calling search.
+/// </summary>
+/// <param name="ActiveSourceIndex">
+///     The index of the source from which the search result was obtained.
+/// </param>
+/// <param name="Errors">
+///     An array of error objects returned from the search results.
+/// </param>
+/// <param name="NumResults">
+///     The number of search results.
+/// </param>
+/// <param name="SearchTerm">
+///     The searched expression.
+/// </param>
+/// <param name="Results">
+///     An array of objects representing the results of the search.
+/// </param>
+public record SearchResponse(int ActiveSourceIndex, JavascriptError[] Errors, int NumResults, string SearchTerm, 
+    SearchResultResponse[] Results);

--- a/src/dymaptic.GeoBlazor.Core/Objects/SearchResult.cs
+++ b/src/dymaptic.GeoBlazor.Core/Objects/SearchResult.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Geometries;
 using dymaptic.GeoBlazor.Core.Components.Layers;
+using dymaptic.GeoBlazor.Core.Components.Widgets;
 using System.Text.Json.Serialization;
 
 
@@ -32,4 +33,23 @@ public class SearchResult
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Name { get; set; }
+    
+    /// <summary>
+    ///     The target of the result, which is a Graphic used for either MapView goTo() or SceneView goTo() navigation.
+    /// </summary>
+    public Graphic? Target { get; set; }
 }
+
+/// <summary>
+///     A collection of <see cref="SearchResult"/>s for each <see cref="SearchSource"/>
+/// </summary>
+/// <param name="Results">
+///     The results of the search
+/// </param>
+/// <param name="Source">
+///     The source of the search
+/// </param>
+/// <param name="SourceIndex">
+///     The index of the source
+/// </param>
+public record SearchResultResponse(SearchResult[] Results, SearchSource Source, int SourceIndex);

--- a/src/dymaptic.GeoBlazor.Core/Objects/SuggestResult.cs
+++ b/src/dymaptic.GeoBlazor.Core/Objects/SuggestResult.cs
@@ -1,0 +1,55 @@
+﻿using dymaptic.GeoBlazor.Core.Components.Widgets;
+using dymaptic.GeoBlazor.Core.Exceptions;
+
+
+namespace dymaptic.GeoBlazor.Core.Objects;
+
+/// <summary>
+///     The result object returned from a suggest().
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Search.html#SuggestResult">ArcGIS JS API</a>
+/// </summary>
+/// <param name="Key">
+///     The key related to the suggest result.
+/// </param>
+/// <param name="Text">
+///     The key related to the suggest result.
+/// </param>
+/// <param name="SourceIndex">
+///     The key related to the suggest result.
+/// </param>
+public record SuggestResult(string Key, string Text, int SourceIndex);
+
+/// <summary>
+///     A collection of <see cref="SuggestResult"/>s
+/// </summary>
+/// <param name="Results">
+///     The results of the suggest
+/// </param>
+/// <param name="Source">
+///     The source of the suggest
+/// </param>
+/// <param name="SourceIndex">
+///     The index of the source
+/// </param>
+public record SuggestResultResponse(SuggestResult[] Results, SearchSource Source, int SourceIndex);
+
+/// <summary>
+///     When resolved, returns this response after calling suggest.
+/// </summary>
+/// <param name="ActiveSourceIndex">
+///     The index of the source from which the suggest result was obtained.
+/// </param>
+/// <param name="Errors">
+///     An array of error objects returned from the suggest results.
+/// </param>
+/// <param name="NumResults">
+///     The number of suggest results.
+/// </param>
+/// <param name="SuggestTerm">
+///     The suggested expression.
+/// </param>
+/// <param name="Results">
+///     An array of objects representing the results of the suggest.
+/// </param>
+public record SuggestResponse(int ActiveSourceIndex, JavascriptError[] Errors, int NumResults, string SuggestTerm, 
+    SuggestResultResponse[] Results);

--- a/src/dymaptic.GeoBlazor.Core/Objects/SuggestResult.cs
+++ b/src/dymaptic.GeoBlazor.Core/Objects/SuggestResult.cs
@@ -17,7 +17,7 @@ namespace dymaptic.GeoBlazor.Core.Objects;
 /// <param name="SourceIndex">
 ///     The key related to the suggest result.
 /// </param>
-public record SuggestResult(string Key, string Text, int SourceIndex);
+public record SuggestResult(string? Key, string? Text, int? SourceIndex);
 
 /// <summary>
 ///     A collection of <see cref="SuggestResult"/>s

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -64,7 +64,7 @@ import {
     buildDotNetPopupTemplate,
     buildDotNetSpatialReference,
     buildViewExtentUpdate,
-    buildDotNetBookmark
+    buildDotNetBookmark, buildDotNetGoToOverrideParameters
 } from "./dotNetBuilder";
 
 import {
@@ -88,7 +88,8 @@ import {
     buildJsColorRamp,
     buildJsAlgorithmicColorRamp,
     buildJsMultipartColorRamp,
-    buildJsRasterStretchRenderer
+    buildJsRasterStretchRenderer,
+    buildJsSearchSource
 } from "./jsBuilder";
 import {
     DotNetExtent,
@@ -124,6 +125,9 @@ import ColorRamp from "@arcgis/core/rest/support/ColorRamp";
 import MultipartColorRamp from "@arcgis/core/rest/support/MultipartColorRamp";
 import AlgorithmicColorRamp from "@arcgis/core/rest/support/AlgorithmicColorRamp";
 import Renderer from "@arcgis/core/renderers/Renderer";
+import SearchWidgetWrapper from "./searchWidgetWrapper";
+import Geometry from "@arcgis/core/geometry/Geometry";
+import SearchSource from "@arcgis/core/widgets/Search/SearchSource";
 
 export let arcGisObjectRefs: Record<string, Accessor> = {};
 export let graphicsRefs: Record<string, Graphic> = {};
@@ -162,6 +166,9 @@ export function getObjectReference(id: string): any {
     }
     if (objectRef instanceof Popup) {
         return new PopupWidgetWrapper(objectRef);
+    }
+    if (objectRef instanceof Search) {
+        return new SearchWidgetWrapper(objectRef);
     }
     return objectRef;
 }
@@ -1019,6 +1026,27 @@ export async function updateWidget(widgetObject: any, viewId: string): Promise<v
                     bookmarks.bookmarks = widgetObject.bookmarks.map(buildJsBookmark);
                 }
                 break;
+            case 'search':
+                let search = currentWidget as Search;
+                if (hasValue(widgetObject.sources)) {
+                    let sources: SearchSource[] = [];
+                    for (const source of widgetObject.sources) {
+                        let jsSource = await buildJsSearchSource(source, viewId);
+                        sources.push(jsSource);
+                    }
+                    search.sources.removeAll();
+                    search.sources.addMany(sources);
+                }
+
+                if (hasValue(widgetObject.popupTemplate)) {
+                    search.popupTemplate = buildJsPopupTemplate(widgetObject.popupTemplate, viewId);
+                }
+
+                if (hasValue(widgetObject.portal)) {
+                    search.portal = new Portal({
+                        url: widgetObject.portal.url
+                    });
+                }
         }
         unsetWaitCursor(viewId);
     } catch (error) {
@@ -1560,14 +1588,20 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
     let newWidget: Widget;
     switch (widget.type) {
         case 'locate':
-            newWidget = new Locate({
+            const locate = new Locate({
                 view: view,
                 useHeadingEnabled: widget.useHeadingEnabled,
-                goToOverride: function (view, options) {
-                    options.target.scale = widget.scale;
-                    return view.goTo(options.target);
-                }
+                rotationEnabled: widget.rotationEnabled ?? undefined,
+                scale: widget.scale ?? undefined
             });
+            newWidget = locate;
+
+            if (widget.hasGoToOverride) {
+                locate.goToOverride = async (view, parameters) => {
+                    let dnParams = buildDotNetGoToOverrideParameters(parameters, viewId);
+                    await widget.locateWidgetObjectReference.invokeMethodAsync('OnJavaScriptGoToOverride', dnParams);
+                }
+            }
 
             break;
         case 'search':
@@ -1576,6 +1610,32 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
             });
             newWidget = search;
 
+            if (hasValue(widget.sources)) {
+                let sources: SearchSource[] = [];
+                for (const source of widget.sources) {
+                    let jsSource = await buildJsSearchSource(source, viewId);
+                    sources.push(jsSource);
+                }
+                search.sources.addMany(sources);
+            }
+            
+            if (hasValue(widget.popupTemplate)) {
+                search.popupTemplate = buildJsPopupTemplate(widget.popupTemplate, viewId);
+            }
+            
+            if (hasValue(widget.portal)) {
+                search.portal = new Portal({
+                    url: widget.portal.url
+                });
+            }
+            
+            if (widget.hasGoToOverride) {
+                search.goToOverride = async (view, parameters) => {
+                    let dnParams = buildDotNetGoToOverrideParameters(parameters, viewId);
+                    await widget.searchWidgetObjectReference.invokeMethodAsync('OnJavaScriptGoToOverride', dnParams);
+                }
+            }
+
             search.on('select-result', (evt) => {
                 widget.searchWidgetObjectReference.invokeMethodAsync('OnJavaScriptSearchSelectResult', {
                     extent: buildDotNetExtent(evt.result.extent),
@@ -1583,6 +1643,11 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
                     name: evt.result.name
                 });
             });
+            
+            copyValuesIfExists(widget, search, 'activeMenu', 'activeSourceIndex', 'allPlaceholder',
+                'autoSelect', 'disabled', 'includeDefaultSources', 'label', 'locationEnabled', 'maxResults',
+                'maxSuggestions', 'minSuggestCharacters', 'popupEnabled', 'resultGraphicEnabled', 'searchAllEnabled',
+                'searchTerm', 'suggestionsEnabled');
             break;
         case 'basemapToggle':
             // the esri definition file is missing basemapToggle.nextBasemap, but it is in the docs.
@@ -2293,7 +2358,7 @@ function waitForRender(viewId: string, dotNetRef: any): void {
     })
 }
 
-function hasValue(prop: any): boolean {
+export function hasValue(prop: any): boolean {
     return prop !== undefined && prop !== null;
 }
 

--- a/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
@@ -796,8 +796,8 @@ export function buildDotNetSearchSource(jsSource: LayerSearchSource | LocatorSea
         dnSource.searchFields = jsSource.searchFields;
         dnSource.suggestionTemplate = jsSource.suggestionTemplate;
         dnSource.filter = {
-            where: jsSource.filter.where,
-            geometry: buildDotNetGeometry(jsSource.filter.geometry ?? null),
+            where: jsSource.filter?.where,
+            geometry: buildDotNetGeometry(jsSource.filter?.geometry ?? null),
         }
     } else {
         dnSource.type = 'locator';
@@ -810,7 +810,7 @@ export function buildDotNetSearchSource(jsSource: LayerSearchSource | LocatorSea
         dnSource.singleLineFieldName = jsSource.singleLineFieldName;
         dnSource.url = jsSource.url;
         dnSource.filter = {
-            geometry: buildDotNetGeometry(jsSource.filter.geometry ?? null)
+            geometry: buildDotNetGeometry(jsSource.filter?.geometry ?? null)
         }
     }
 

--- a/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
@@ -73,7 +73,7 @@ import ExpressionContent from "@arcgis/core/popup/content/ExpressionContent";
 import ElementExpressionInfo from "@arcgis/core/popup/ElementExpressionInfo";
 import FeatureLayer from "@arcgis/core/layers/FeatureLayer";
 import GraphicsLayer from "@arcgis/core/layers/GraphicsLayer";
-import { arcGisObjectRefs } from "./arcGisJsInterop";
+import {arcGisObjectRefs, hasValue} from "./arcGisJsInterop";
 import SimpleMarkerSymbol from "@arcgis/core/symbols/SimpleMarkerSymbol";
 import Symbol from "@arcgis/core/symbols/Symbol";
 import Graphic from "@arcgis/core/Graphic";
@@ -92,6 +92,11 @@ import Domain from "@arcgis/core/layers/support/Domain";
 import CodedValueDomain from "@arcgis/core/layers/support/CodedValueDomain";
 import InheritedDomain from "@arcgis/core/layers/support/InheritedDomain";
 import RangeDomain from "@arcgis/core/layers/support/RangeDomain";
+import LayerSearchSource from "@arcgis/core/widgets/Search/LayerSearchSource";
+import SearchSource from "@arcgis/core/widgets/Search/SearchSource";
+import LocatorSearchSource from "@arcgis/core/widgets/Search/LocatorSearchSource";
+import SearchResult = __esri.SearchResult;
+import SuggestResult = __esri.SuggestResult;
 
 
 export function buildDotNetGraphic(graphic: Graphic): DotNetGraphic {
@@ -129,7 +134,7 @@ export function buildDotNetGraphic(graphic: Graphic): DotNetGraphic {
     return dotNetGraphic;
 }
 
-function buildDotNetSymbol(symbol: Symbol): DotNetSymbol {
+export function buildDotNetSymbol(symbol: Symbol): DotNetSymbol {
     if (symbol instanceof SimpleMarkerSymbol) {
         let dnMarkerSymbol = {
             type: 'simple-marker',
@@ -748,4 +753,122 @@ export function buildDotNetTimeInterval(interval: any): any | null {
         unit: interval.unit,
         value: interval.value
     } as any;
+}
+
+export function buildDotNetSearchSource(jsSource: LayerSearchSource | LocatorSearchSource): any {
+    let dnSource: any =  {
+        autoNavigate: jsSource.autoNavigate,
+        maxResults: jsSource.maxResults,
+        minSuggestCharacters: jsSource.minSuggestCharacters,
+        name: jsSource.name,
+        outFields: jsSource.outFields,
+        placeholder: jsSource.placeholder,
+        popupEnabled: jsSource.popupEnabled,
+        prefix: jsSource.prefix,
+        resultGraphicEnabled: jsSource.resultGraphicEnabled,
+        searchTemplate: jsSource.searchTemplate,
+        suffix: jsSource.suffix,
+        suggestionsEnabled: jsSource.suggestionsEnabled,
+        withinViewEnabled: jsSource.withinViewEnabled,
+        zoomScale: jsSource.zoomScale,
+    }
+
+    if (hasValue(jsSource.popupTemplate)) {
+        dnSource.popupTemplate = buildDotNetPopupTemplate(jsSource.popupTemplate);
+    }
+
+    if (hasValue(jsSource.resultSymbol)) {
+        dnSource.resultSymbol = buildDotNetSymbol(jsSource.resultSymbol);
+    }
+
+    if (jsSource instanceof LayerSearchSource) {
+        dnSource.type = 'layer';
+        dnSource.displayField = jsSource.displayField;
+        dnSource.exactMatch = jsSource.exactMatch;
+        dnSource.layer = buildDotNetLayer(jsSource.layer);
+        for (let key in arcGisObjectRefs) {
+            if (arcGisObjectRefs[key] === jsSource.layer) {
+                dnSource.layerId = key;
+                break;
+            }
+        }
+        dnSource.orderByFields = jsSource.orderByFields;
+        dnSource.searchFields = jsSource.searchFields;
+        dnSource.suggestionTemplate = jsSource.suggestionTemplate;
+        dnSource.filter = {
+            where: jsSource.filter.where,
+            geometry: buildDotNetGeometry(jsSource.filter.geometry ?? null),
+        }
+    } else {
+        dnSource.type = 'locator';
+        dnSource.apiKey = jsSource.apiKey;
+        dnSource.categories = jsSource.categories;
+        dnSource.countryCode = jsSource.countryCode;
+        dnSource.defaultZoomScale = jsSource.defaultZoomScale;
+        dnSource.localSearchDisabled = jsSource.localSearchDisabled;
+        dnSource.locationType = jsSource.locationType;
+        dnSource.singleLineFieldName = jsSource.singleLineFieldName;
+        dnSource.url = jsSource.url;
+        dnSource.filter = {
+            geometry: buildDotNetGeometry(jsSource.filter.geometry ?? null)
+        }
+    }
+
+    return dnSource;
+}
+
+export function buildDotNetGoToOverrideParameters(parameters: any, viewId: string): any {
+    let dnParams: any = {
+        viewId: viewId
+    }
+    if (hasValue(parameters.target)) {
+        let target: any = {
+            target: parameters.target.target,
+            center: parameters.target.center,
+            scale: parameters.target.scale,
+            zoom: parameters.target.zoom,
+            heading: parameters.target.heading,
+            tilt: parameters.target.tilt,
+            position: buildDotNetPoint(parameters.target.position)
+        };
+        if (Array.isArray(parameters.target.target) && parameters.target.target.length > 0) {
+            let firstObject = parameters.target.target[0];
+            if (firstObject instanceof Graphic) {
+                target.targetGraphics = [];
+                for (let g: Graphic in parameters.target.target as Graphic[]) {
+                    target.targetGraphics.push(buildDotNetGraphic(g));
+                }
+            } else if (firstObject instanceof Geometry) {
+                target.targetGeometries = [];
+                for (let g: Geometry in parameters.target.target as Geometry[]) {
+                    target.targetGeometries.push(buildDotNetGeometry(g));
+                }
+            } else {
+                target.targetCoordinates = parameters.target.target;
+            }
+        } else if (parameters.target.target instanceof Graphic) {
+            target.targetGraphic = buildDotNetGraphic(parameters.target.target);
+        } else if (parameters.target.target instanceof Geometry) {
+            target.targetGeometry = buildDotNetGeometry(parameters.target.target);
+        }
+    }
+}
+
+export function buildDotNetSearchResult(jsSearchResult: SearchResult) {
+    let dnSearchResult: any = {
+        extent: buildDotNetExtent(jsSearchResult.extent),
+        feature: buildDotNetGraphic(jsSearchResult.feature),
+        name: jsSearchResult.name,
+        target: buildDotNetGraphic(jsSearchResult.target)
+    }
+
+    return dnSearchResult;
+}
+
+export function buildDotNetSuggestResult(jsSuggestResult: SuggestResult) {
+    return {
+        text: jsSuggestResult.text,
+        key: jsSuggestResult.key,
+        sourceIndex: jsSuggestResult.sourceIndex
+    }
 }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -2,7 +2,7 @@
 import Extent from "@arcgis/core/geometry/Extent";
 import Graphic from "@arcgis/core/Graphic";
 import PopupTemplate from "@arcgis/core/PopupTemplate";
-import {arcGisObjectRefs, dotNetRefs, triggerActionHandler} from "./arcGisJsInterop";
+import {arcGisObjectRefs, createLayer, dotNetRefs, triggerActionHandler} from "./arcGisJsInterop";
 import Geometry from "@arcgis/core/geometry/Geometry";
 import Point from "@arcgis/core/geometry/Point";
 import Polyline from "@arcgis/core/geometry/Polyline";
@@ -94,7 +94,7 @@ import SimpleLineSymbol from "@arcgis/core/symbols/SimpleLineSymbol";
 import ElementExpressionInfo from "@arcgis/core/popup/ElementExpressionInfo";
 import ChartMediaInfoValueSeries from "@arcgis/core/popup/content/support/ChartMediaInfoValueSeries";
 import View from "@arcgis/core/views/View";
-import { buildDotNetGraphic } from "./dotNetBuilder";
+import {buildDotNetGraphic, buildDotNetPoint, buildDotNetSpatialReference} from "./dotNetBuilder";
 import ViewClickEvent = __esri.ViewClickEvent;
 import PopupOpenOptions = __esri.PopupOpenOptions;
 import PopupDockOptions = __esri.PopupDockOptions;
@@ -116,6 +116,10 @@ import ComboBoxInput from "@arcgis/core/form/elements/inputs/ComboBoxInput";
 import RadioButtonsInput from "@arcgis/core/form/elements/inputs/RadioButtonsInput";
 import SwitchInput from "@arcgis/core/form/elements/inputs/SwitchInput";
 import * as reactiveUtils from "@arcgis/core/core/reactiveUtils";
+import SearchSource from "@arcgis/core/widgets/Search/SearchSource";
+import SearchSourceFilter = __esri.SearchSourceFilter;
+import SearchResult = __esri.SearchResult;
+import SuggestResult = __esri.SuggestResult;
 
 
 export function buildJsSpatialReference(dotNetSpatialReference: DotNetSpatialReference): SpatialReference {
@@ -1315,4 +1319,151 @@ export function buildJsTickConfigs(dotNetTickConfig: any): any {
         labelFormatFunction: labelFormatFunction ?? undefined
     }
     return tickConfig;
+}
+
+export async function buildJsSearchSource(dotNetSource: any, viewId: string): Promise<SearchSource> {
+    let source: any = {
+        autoNavigate: dotNetSource.autoNavigate ?? undefined,
+        filter: buildJsSearchSourceFilter(dotNetSource.filter) ?? undefined,
+        maxResults: dotNetSource.maxResults ?? undefined,
+        minSuggestCharacters: dotNetSource.minSuggestCharacters ?? undefined,
+        name: dotNetSource.name ?? undefined,
+        outFields: dotNetSource.outFields ?? undefined,
+        placeholder: dotNetSource.placeholder ?? undefined,
+        popupEnabled: dotNetSource.popupEnabled ?? undefined,
+        prefix: dotNetSource.prefix ?? undefined,
+        resultGraphicEnabled: dotNetSource.resultGraphicEnabled ?? undefined,
+        searchTemplate: dotNetSource.searchTemplate ?? undefined,
+        suffix: dotNetSource.suffix ?? undefined,
+        suggestionsEnabled: dotNetSource.suggestionsEnabled ?? undefined,
+        zoomScale: dotNetSource.zoomScale ?? undefined
+    };
+    
+    if (hasValue(dotNetSource.popupTemplate)) {
+        source.popupTemplate = buildJsPopupTemplate(dotNetSource.popupTemplate, viewId);
+    }
+    
+    if (hasValue(dotNetSource.resultSymbol)) {
+        source.resultSymbol = buildJsSymbol(dotNetSource.resultSymbol);
+    }
+    
+    if (dotNetSource.hasGetResultsHandler) {
+        source.getResults = async (params: any) => {
+            let viewId: string | null = null;
+            
+            for (let key in arcGisObjectRefs) {
+                if (arcGisObjectRefs[key] === params.view) {
+                    viewId = key;
+                    break;
+                }
+            }
+            
+            let dnParams = {
+                exactMatch: params.exactMatch,
+                location: buildDotNetPoint(params.location),
+                maxResults: params.maxResults,
+                sourceIndex: params.sourceIndex,
+                spatialReference: buildDotNetSpatialReference(params.spatialReference),
+                suggestResult: {
+                    key: params.suggestResult.key,
+                    text: params.suggestResult.text,
+                    sourceIndex: params.suggestResult.sourceIndex
+                },
+                viewId: viewId
+            }
+            let dnResults = await dotNetSource.searchSourceObjectReference.invokeMethodAsync('OnJavaScriptGetResults', dnParams);
+            
+            let results: SearchResult[] = [];
+            
+            for (let dnResult of dnResults) {
+                let result: any = {
+                    extent: buildJsExtent(dnResult.extent, null) ?? undefined,
+                    name: dnResult.name ?? undefined,
+                };
+                if (hasValue(dnResult.feature)) {
+                    result.feature = buildJsGraphic(dnResult.feature, viewId) as Graphic;
+                }
+                results.push(result);
+            }
+            
+            return results;
+        }
+    }
+
+    if (dotNetSource.hasGetSuggestionsHandler) {
+        source.getSuggestions = async (params: any) => {
+            let viewId: string | null = null;
+
+            for (let key in arcGisObjectRefs) {
+                if (arcGisObjectRefs[key] === params.view) {
+                    viewId = key;
+                    break;
+                }
+            }
+
+            let dnParams = {
+                maxSuggestions: params.maxSuggestions,
+                sourceIndex: params.sourceIndex,
+                spatialReference: buildDotNetSpatialReference(params.spatialReference),
+                suggestTerm: params.suggestTerm,
+                viewId: viewId
+            }
+            let dnResults = await dotNetSource.searchSourceObjectReference.invokeMethodAsync('OnJavaScriptGetSuggestions', dnParams);
+
+            let results: SuggestResult[] = [];
+
+            for (let dnResult of dnResults) {
+                results.push({
+                    key: dnResult.key,
+                    text: dnResult.text,
+                    sourceIndex: dnResult.sourceIndex
+                })
+            }
+
+            return results;
+        }
+    }
+    
+    switch (dotNetSource.type) {
+        case "layer":
+            let layer: Layer | null = null;
+            if (hasValue(dotNetSource.layerId)) {
+                layer = arcGisObjectRefs[dotNetSource.layerId] as Layer;
+            }
+            if (!hasValue(layer) && hasValue(dotNetSource.layer)) {
+                layer = await createLayer(dotNetSource.layer, false, viewId);
+            }
+            source.layer = layer;
+            source.displayField = dotNetSource.displayField ?? undefined;
+            source.exactMatch = dotNetSource.exactMatch ?? undefined;
+            source.orderByFields = dotNetSource.orderByFields ?? undefined;
+            source.searchFields = dotNetSource.searchFields ?? undefined;
+            source.suggestionTemplate = dotNetSource.suggestionTemplate ?? undefined;
+            
+            break;
+        case "locator":
+            source.apiKey = dotNetSource.apiKey ?? undefined;
+            source.categories = dotNetSource.categories ?? undefined;
+            source.countryCode = dotNetSource.countryCode ?? undefined;
+            source.defaultZoomScale = dotNetSource.defaultZoomScale ?? undefined;
+            source.localSearchDisabled = dotNetSource.localSearchDisabled ?? undefined;
+            source.locationType = dotNetSource.locationType ?? undefined;
+            source.singleLineFieldName = dotNetSource.singleLineFieldName ?? undefined;
+            source.url = dotNetSource.url ?? undefined;
+            
+            break;
+    }
+    
+    return source as SearchSource;
+}
+
+function buildJsSearchSourceFilter(dotNetFilter: any): SearchSourceFilter | null {
+    if (!hasValue(dotNetFilter)) return null;
+
+    let filter: SearchSourceFilter = {
+        where: dotNetFilter.where ?? undefined,
+        geometry: buildJsGeometry(dotNetFilter.geometry) ?? undefined
+    };
+
+    return filter;
 }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/searchWidgetWrapper.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/searchWidgetWrapper.ts
@@ -1,0 +1,92 @@
+﻿import Search from "@arcgis/core/widgets/Search";
+import {
+    buildDotNetGraphic,
+    buildDotNetSearchResult,
+    buildDotNetSearchSource,
+    buildDotNetSuggestResult
+} from "./dotNetBuilder";
+
+
+export default class SearchWidgetWrapper {
+    private search: Search;
+
+    constructor(search: Search) {
+        this.search = search;
+        // set all properties from graphic
+        for (let prop in search) {
+            if (prop.hasOwnProperty(prop)) {
+                this[prop] = search[prop];
+            }
+        }
+    }
+
+    getActiveSource() {
+        let jsSource = this.search.activeSource;
+        return buildDotNetSearchSource(jsSource);
+    }
+    
+    getActiveMenu() {
+        return this.search.activeMenu;
+    }
+    
+    getActiveSourceIndex(): number {
+        return this.search.activeSourceIndex;
+    }
+    
+    getAllSources() {
+        let jsSources = this.search.allSources;
+        let dotNetSources: any[] = [];
+        for (let jsSource of jsSources) {
+            dotNetSources.push(buildDotNetSearchSource(jsSource));
+        }
+        
+        return dotNetSources;
+    }
+    
+    getDefaultSources() {
+        let jsSources = this.search.defaultSources;
+        let dotNetSources: any[] = [];
+        for (let jsSource of jsSources) {
+            dotNetSources.push(buildDotNetSearchSource(jsSource));
+        }
+        
+        return dotNetSources;
+    }
+    
+    getResultGraphic() {
+        return buildDotNetGraphic(this.search.resultGraphic);
+    }
+    
+    getResults() {
+        let jsResults = this.search.results;
+        let dnResults: any[] = [];
+        for (let jsResult of jsResults) {
+            let searchResults: any[] = [];
+            for (let jsSearchResult of jsResult.results) {
+                searchResults.push(buildDotNetSearchResult(jsSearchResult));
+            }
+            let dnResult = {
+                results: searchResults,
+                source: buildDotNetSearchSource(jsResult.source),
+                sourceIndex: jsResult.sourceIndex
+            }
+            dnResults.push(dnResult);
+        }
+        
+        return dnResults;
+    }
+    
+    getSelectedResult() {
+        return buildDotNetSearchResult(this.search.selectedResult);
+    }
+    
+    getSuggestions() {
+        let jsSuggestions = this.search.suggestions;
+        let dnSuggestions: any[] = [];
+        for (let jsSuggestion of jsSuggestions) {
+            dnSuggestions.push(buildDotNetSuggestResult(jsSuggestion));
+        }
+        
+        return dnSuggestions;
+    }
+}

--- a/src/dymaptic.GeoBlazor.Core/Scripts/searchWidgetWrapper.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/searchWidgetWrapper.ts
@@ -5,13 +5,14 @@ import {
     buildDotNetSearchSource,
     buildDotNetSuggestResult
 } from "./dotNetBuilder";
+import {buildJsGeometry} from "./jsBuilder";
 
 
 export default class SearchWidgetWrapper {
-    private search: Search;
+    private searchWidget: Search;
 
     constructor(search: Search) {
-        this.search = search;
+        this.searchWidget = search;
         // set all properties from graphic
         for (let prop in search) {
             if (prop.hasOwnProperty(prop)) {
@@ -21,20 +22,20 @@ export default class SearchWidgetWrapper {
     }
 
     getActiveSource() {
-        let jsSource = this.search.activeSource;
+        let jsSource = this.searchWidget.activeSource;
         return buildDotNetSearchSource(jsSource);
     }
     
     getActiveMenu() {
-        return this.search.activeMenu;
+        return this.searchWidget.activeMenu;
     }
     
     getActiveSourceIndex(): number {
-        return this.search.activeSourceIndex;
+        return this.searchWidget.activeSourceIndex;
     }
     
     getAllSources() {
-        let jsSources = this.search.allSources;
+        let jsSources = this.searchWidget.allSources;
         let dotNetSources: any[] = [];
         for (let jsSource of jsSources) {
             dotNetSources.push(buildDotNetSearchSource(jsSource));
@@ -44,7 +45,7 @@ export default class SearchWidgetWrapper {
     }
     
     getDefaultSources() {
-        let jsSources = this.search.defaultSources;
+        let jsSources = this.searchWidget.defaultSources;
         let dotNetSources: any[] = [];
         for (let jsSource of jsSources) {
             dotNetSources.push(buildDotNetSearchSource(jsSource));
@@ -54,11 +55,11 @@ export default class SearchWidgetWrapper {
     }
     
     getResultGraphic() {
-        return buildDotNetGraphic(this.search.resultGraphic);
+        return buildDotNetGraphic(this.searchWidget.resultGraphic);
     }
     
     getResults() {
-        let jsResults = this.search.results;
+        let jsResults = this.searchWidget.results;
         let dnResults: any[] = [];
         for (let jsResult of jsResults) {
             let searchResults: any[] = [];
@@ -77,16 +78,36 @@ export default class SearchWidgetWrapper {
     }
     
     getSelectedResult() {
-        return buildDotNetSearchResult(this.search.selectedResult);
+        return buildDotNetSearchResult(this.searchWidget.selectedResult);
     }
     
     getSuggestions() {
-        let jsSuggestions = this.search.suggestions;
+        let jsSuggestions = this.searchWidget.suggestions;
         let dnSuggestions: any[] = [];
         for (let jsSuggestion of jsSuggestions) {
             dnSuggestions.push(buildDotNetSuggestResult(jsSuggestion));
         }
         
         return dnSuggestions;
+    }
+    
+    setSearchTerm(term: string) {
+        this.searchWidget.searchTerm = term;
+    }
+    
+    getSearchTerm() {
+        return this.searchWidget.searchTerm;
+    }
+    
+    search(term: any) {
+        if (term.hasOwnProperty('id') && term.hasOwnProperty('type')) {
+            // if there's an id, this is probably a geometry, we should convert it
+            term = buildJsGeometry(term);
+        }
+        return this.searchWidget.search(term);
+    }
+    
+    suggest(term: string) {
+        return this.searchWidget.suggest(term);
     }
 }

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/TestRunnerBase.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/TestRunnerBase.razor
@@ -185,6 +185,7 @@
         catch (Exception ex)
         {
             _failed[methodInfo.Name] = $"{ResultBuilder}{Environment.NewLine}{ex.StackTrace}";
+            await CleanupFragment(methodInfo.Name);
             ResultBuilder.AppendLine($"<p style=\"color: red; font-weight: bold\">{ex.Message.Replace(Environment.NewLine, "<br/>")}<br/>{ex.StackTrace?.Replace(Environment.NewLine, "<br/>")}</p>");
         }
 
@@ -196,7 +197,7 @@
         });
     }
 
-    private void OnRenderError(ErrorEventArgs arg)
+    private async Task OnRenderError(ErrorEventArgs arg)
     {
         _mapRenderingExceptions[arg.MethodName] = arg.Exception;
     }

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/WidgetTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/WidgetTests.razor
@@ -237,11 +237,10 @@
     }
 
     [TestMethod]
-    public async Task TestSearchWidgetMethods()
+    public async Task TestSearchWidgetGetResultsHandler()
     {
         SearchWidget? widget = null;
         var resultsHandlerWasCalled = false;
-        var suggestionsHandlerWasCalled = false;
 
         Task<IList<SearchResult>> GetResultsHandler(GetResultsParameters parameters)
         {
@@ -249,6 +248,31 @@
             resultsHandlerWasCalled = true;
             return Task.FromResult<IList<SearchResult>>(new List<SearchResult>());
         }
+        
+        CreateViewRenderedHandler(async () =>
+        {
+            await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Search");
+        });
+        
+        AddMapRenderFragment(
+            @<div>
+                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <SearchWidget @ref="widget">
+                    <SearchSource GetResultsHandler="GetResultsHandler" />
+                </SearchWidget>
+            </div>);
+        
+        await WaitForMapToRender(cleanupFragment: false);
+        await widget!.Search("test");
+        await WaitForMapToRender();
+        Assert.IsTrue(resultsHandlerWasCalled);
+    }
+
+    [TestMethod]
+    public async Task TestSearchWidgetGetSuggestionsHandler()
+    {
+        SearchWidget? widget = null;
+        var suggestionsHandlerWasCalled = false;
         
         Task<IList<SuggestResult>> GetSuggestionsHandler(GetSuggestionsParameters parameters)
         {
@@ -258,24 +282,73 @@
         }
         
         CreateViewRenderedHandler(async () =>
-            await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Search"));
+        {
+            await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Search");
+            await AssertJavaScript("triggerSearchHandlers");
+        });
         
         AddMapRenderFragment(
             @<div>
                 <Map ArcGISDefaultBasemap="arcgis-imagery" />
                 <SearchWidget @ref="widget">
-                    <SearchSource GetResultsHandler="GetResultsHandler"
-                                  GetSuggestionsHandler="GetSuggestionsHandler" />
+                    <SearchSource GetSuggestionsHandler="GetSuggestionsHandler" />
                 </SearchWidget>
             </div>);
         
         await WaitForMapToRender(cleanupFragment: false);
-        await widget!.Search("test");
-        await widget.SetSearchTerm("test1");
-        Assert.AreEqual("test1", widget.SearchTerm);
-        await WaitForMapToRender();
-        Assert.IsTrue(resultsHandlerWasCalled);
+
+        var tries = 50;
+        while (!suggestionsHandlerWasCalled && tries > 0)
+        {
+            await Task.Delay(100);
+            tries--;
+        }
+        await CleanupFragment();
         Assert.IsTrue(suggestionsHandlerWasCalled);
     }
-
+    
+    [TestMethod]
+    public async Task TestSearchWidgetMethods()
+    {
+        SearchWidget? widget = null;
+        
+        CreateViewRenderedHandler(async () =>
+        {
+            await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Search");
+        });
+        
+        AddMapRenderFragment(
+            @<div>
+                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <SearchWidget @ref="widget" />
+            </div>);
+        
+        await WaitForMapToRender(cleanupFragment: false);
+        await widget!.SetSearchTerm("testSearchTerm");
+        string searchTerm = await widget.GetSearchTerm();
+        Assert.AreEqual("testSearchTerm", searchTerm);
+        SuggestResponse suggestResponse = await widget!.Suggest("test");
+        Assert.IsNotNull(suggestResponse);
+        SearchResponse searchResponse = await widget!.Search("test");
+        Assert.IsNotNull(searchResponse);
+        IReadOnlyList<SearchResultResponse> searchResultResponse = await widget.GetResults();
+        Assert.IsNotNull(searchResultResponse);
+        SuggestResult[] suggestResults = await widget.GetSuggestions();
+        Assert.IsNotNull(suggestResults);
+        SearchMenu activeMenu = await widget.GetActiveMenu();
+        Assert.IsNotNull(activeMenu);
+        SearchSource? activeSource = await widget.GetActiveSource();
+        Assert.IsNotNull(activeSource);
+        int activeSourceIndex = await widget.GetActiveSourceIndex();
+        Assert.AreEqual(0, activeSourceIndex);
+        IReadOnlyList<SearchSource>? allSources = await widget.GetAllSources();
+        Assert.AreEqual(1, allSources.Count);
+        IReadOnlyList<SearchSource>? defaultSources = await widget.GetDefaultSources();
+        Assert.AreEqual(1, defaultSources.Count);
+        Graphic resultGraphic = await widget.GetResultGraphic();
+        Assert.IsNotNull(resultGraphic);
+        SearchResult selectedResult = await widget.GetSelectedResult();
+        Assert.IsNotNull(selectedResult);
+        await CleanupFragment();
+    }
 }

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/WidgetTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/WidgetTests.razor
@@ -236,4 +236,46 @@
         await WaitForMapToRender();
     }
 
+    [TestMethod]
+    public async Task TestSearchWidgetMethods()
+    {
+        SearchWidget? widget = null;
+        var resultsHandlerWasCalled = false;
+        var suggestionsHandlerWasCalled = false;
+
+        Task<IList<SearchResult>> GetResultsHandler(GetResultsParameters parameters)
+        {
+            Assert.IsNotNull(parameters);
+            resultsHandlerWasCalled = true;
+            return Task.FromResult<IList<SearchResult>>(new List<SearchResult>());
+        }
+        
+        Task<IList<SuggestResult>> GetSuggestionsHandler(GetSuggestionsParameters parameters)
+        {
+            Assert.IsNotNull(parameters);
+            suggestionsHandlerWasCalled = true;
+            return Task.FromResult<IList<SuggestResult>>(new List<SuggestResult>());
+        }
+        
+        CreateViewRenderedHandler(async () =>
+            await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Search"));
+        
+        AddMapRenderFragment(
+            @<div>
+                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <SearchWidget @ref="widget">
+                    <SearchSource GetResultsHandler="GetResultsHandler"
+                                  GetSuggestionsHandler="GetSuggestionsHandler" />
+                </SearchWidget>
+            </div>);
+        
+        await WaitForMapToRender(cleanupFragment: false);
+        await widget!.Search("test");
+        await widget.SetSearchTerm("test1");
+        Assert.AreEqual("test1", widget.SearchTerm);
+        await WaitForMapToRender();
+        Assert.IsTrue(resultsHandlerWasCalled);
+        Assert.IsTrue(suggestionsHandlerWasCalled);
+    }
+
 }

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/wwwroot/testRunner.js
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/wwwroot/testRunner.js
@@ -57,3 +57,12 @@ export async function assertPopupCallback(viewId, layerId) {
     }
     button.click();
 }
+
+export async function triggerSearchHandlers() {
+    let searchInput = document.querySelector('.esri-search__input');
+    searchInput.value = 'testFromJavascript';
+    searchInput.dispatchEvent(new Event('input'));
+    await new Promise(resolve => setTimeout(resolve, 100));
+    searchInput.value = 'testFromJavascript1';
+    searchInput.dispatchEvent(new Event('input'));
+}


### PR DESCRIPTION
Closes #232 

- Adds all missing methods to `SearchWidget`
- Adds support for custom and multiple `SearchSource`s
- Added unit tests for `SearchWidget` callbacks and methods
- Small improvements to unit test runner cleanup
- Fixed some bugs with `geometryEngine.ts` not converting properly back to .NET types