### PR TITLE
cleanup, merge, and testing

### DIFF
--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Shared/NavMenu.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Shared/NavMenu.razor
@@ -39,8 +39,8 @@
 @code {
     private string? NavMenuCssClass => _collapseNavMenu ? "collapse" : null;
     private IEnumerable<PageLink> FilteredPages => string.IsNullOrWhiteSpace(_searchValue)
-        ? _pages
-        : _pages.Where(p => p.Title.Contains(_searchValue, StringComparison.OrdinalIgnoreCase));
+        ? Pages
+        : Pages.Where(p => p.Title.Contains(_searchValue, StringComparison.OrdinalIgnoreCase));
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -73,7 +73,7 @@
     private bool _collapseNavMenu = true;
     private ElementReference _searchField;
     private string _searchValue = string.Empty;
-    private readonly PageLink[] _pages =
+    public static readonly PageLink[] Pages =
     {
         new("", "Home", "oi-home"),
         new("navigation", "Navigation", "oi-compass"),
@@ -118,10 +118,8 @@
         new("marker-rotation", "Marker Rotation", "oi-loop-circular"),
         new("graphic-tracking", "Graphic Tracking", "oi-move"),
         new("geometry-methods", "Geometry Methods", "oi-task"),
-        new("search-multi-source", "Search Multiple Sources", "oi-magnifying-glass"),
-        new("tests", "Tests", "oi-check")
+        new("search-multi-source", "Search Multiple Sources", "oi-magnifying-glass")
     };
 
-    private record PageLink(string Href, string Title, string? IconClass, string? ImageFile = null);
-
+    public record PageLink(string Href, string Title, string? IconClass, string? ImageFile = null, bool Pro = false);
 }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayer.cs
@@ -4,6 +4,7 @@ using dymaptic.GeoBlazor.Core.Components.Renderers;
 using dymaptic.GeoBlazor.Core.Components.Widgets;
 using dymaptic.GeoBlazor.Core.Exceptions;
 using dymaptic.GeoBlazor.Core.Objects;
+using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using System.Text;
@@ -1350,16 +1351,68 @@ public record EditedFeatureUpdate(Graphic[] Original, Graphic[] Current);
 ///     They are used as a way to categorize your data. For example, the streets in a city streets feature layer
 ///     could be categorized into three feature types: local streets, collector streets, and arterial streets.
 /// </summary>
-public record FeatureType(object Id, string DeclaredCLass, string Name, FeatureTemplate[] Templates, Dictionary<string, Domain?> Domains);
+public record FeatureType(string Id, string Name, FeatureTemplate[] Templates, Dictionary<string, Domain?> Domains);
 
 /// <summary>
 ///     Feature templates define all the information required to create a new feature in
 ///     a feature layer. These include information such as the default attribute values with
 ///     which a feature will be created, and the default tool used to create that feature.
 /// </summary>
-public record FeatureTemplate(string DeclaredClass, string Name, string Description, string DrawingTool, Thumbnail Thumbnail, dynamic Prototype);
+/// <param name="Name">
+///     Name of the feature template.
+/// </param>
+/// <param name="Description">
+///     Description of the feature template.
+/// </param>
+/// <param name="DrawingTool">
+///     Name of the default drawing tool defined for the template to create a feature.
+/// </param>
+/// <param name="Thumbnail">
+///     An object used to create a thumbnail image that represents a feature type in the feature template.
+/// </param>
+/// <param name="Prototype">    
+///     An instance of the prototypical feature described by the feature template. It specifies default values for the attribute fields and does not contain geometry.
+/// </param>
+public record FeatureTemplate(string Name, string Description, DrawingTool DrawingTool, Thumbnail Thumbnail, Graphic Prototype);
 
 /// <summary>
 ///     An object used to create a thumbnail image that represents a feature type in the feature template.
 /// </summary>
+/// <param name="ContentType">
+///     The MIME type of the image.
+/// </param>
+/// <param name="ImageData">
+///     The base64EncodedImageData presenting the thumbnail image.
+/// </param>
+/// <param name="Height">
+///     The height of the thumbnail.
+/// </param>
+/// <param name="Width">
+///     The width of the thumbnail.
+/// </param>
 public record Thumbnail(string ContentType, string ImageData, double Height, double Width);
+
+/// <summary>
+///     Name of the default drawing tool defined for the template to create a feature.
+/// </summary>
+[JsonConverter(typeof(EnumToKebabCaseStringConverter<DrawingTool>))]
+public enum DrawingTool
+{
+#pragma warning disable CS1591
+    AutoCompletePolygon,
+    Circle,
+    Ellipse,
+    Freehand,
+    Line,
+    None,
+    Point,
+    Polygon,
+    Rectangle,
+    Arrow,
+    Triangle,
+    LeftArrow,
+    RightArrow,
+    UpArrow,
+    DownArrow
+#pragma warning restore CS1591
+}

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -497,7 +497,8 @@ function setEventListeners(view: __esri.View, dotNetRef: any, eventRateLimit: nu
         // find objectRef id by layer
         let layerGeoBlazorId = Object.keys(arcGisObjectRefs).find(key => arcGisObjectRefs[key] === evt.layer);
         let isBasemapLayer = false;
-        if (view.map.basemap.baseLayers.includes(evt.layer) || view.map.basemap.referenceLayers.includes(evt.layer)) {
+        if (hasValue(view.map.basemap) && 
+                (view.map.basemap.baseLayers?.includes(evt.layer) || view.map.basemap.referenceLayers?.includes(evt.layer))) {
             isBasemapLayer = true;
         }
         let layerRef;

--- a/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
@@ -38,6 +38,14 @@ export interface DotNetFeatureSet {
     spatialReference: DotNetSpatialReference | null;
 }
 
+export interface DotNetFeatureTemplate {
+    name: string;
+    description: string;
+    drawingTool: any;
+    thumbnail: any;
+    prototype: DotNetGraphic;
+}
+
 export interface DotNetGeometry {
     type: string;
     spatialReference: DotNetSpatialReference;

--- a/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
@@ -44,12 +44,13 @@ import {
     DotNetBookmark,
     DotNetViewpoint,
     DotNetField,
-    DotNetDomain, 
-    DotNetCodedValueDomain, 
-    DotNetCodedValue, 
-    DotNetInheritedDomain, 
-    DotNetRangeDomain, 
-    DotNetEffect
+    DotNetDomain,
+    DotNetCodedValueDomain,
+    DotNetCodedValue,
+    DotNetInheritedDomain,
+    DotNetRangeDomain,
+    DotNetEffect, 
+    DotNetFeatureTemplate
 } from "./definitions";
 import Point from "@arcgis/core/geometry/Point";
 import Polyline from "@arcgis/core/geometry/Polyline";
@@ -104,6 +105,9 @@ import SearchSource from "@arcgis/core/widgets/Search/SearchSource";
 import LocatorSearchSource from "@arcgis/core/widgets/Search/LocatorSearchSource";
 import SearchResult = __esri.SearchResult;
 import SuggestResult = __esri.SuggestResult;
+import FeatureType from "@arcgis/core/layers/support/FeatureType";
+import FeatureTemplate from "@arcgis/core/layers/support/FeatureTemplate";
+import FeatureTemplateThumbnail = __esri.FeatureTemplateThumbnail;
 
 
 export function buildDotNetGraphic(graphic: Graphic): DotNetGraphic {
@@ -764,7 +768,7 @@ export function buildDotNetTimeInterval(interval: any): any | null {
     } as any;
 }
 
-export function buildDotNetFeatureType(result: any) {
+export function buildDotNetFeatureType(result: FeatureType) {
 
     if (!hasValue(result)) {
         return null;
@@ -782,8 +786,19 @@ export function buildDotNetFeatureType(result: any) {
         domains: dotNetDomains,
         declaredClass: result.declaredClass,
         name: result.name,
-        templates: result.templates,
+        templates: result.templates?.map(buildDotNetFeatureTemplate)
     }
+}
+
+export function buildDotNetFeatureTemplate(jsFeatureTemplate: FeatureTemplate): DotNetFeatureTemplate | null {
+    if (!hasValue(jsFeatureTemplate)) return null;
+    return {
+        name: jsFeatureTemplate.name,
+        description: jsFeatureTemplate.description,
+        prototype: buildDotNetGraphic(jsFeatureTemplate.prototype),
+        drawingTool: jsFeatureTemplate.drawingTool,
+        thumbnail: jsFeatureTemplate.thumbnail,
+    } as DotNetFeatureTemplate
 }
 
 export function buildDotNetEffect(jsEffect: any): DotNetEffect | null {

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -64,7 +64,8 @@ import {
     DotNetFeatureFilter,
     DotNetRasterStretchRenderer,
     DotNetDimensionDefinition,
-    DotNetColorRamp
+    DotNetColorRamp,
+    DotNetFeatureTemplate
 } from "./definitions";
 import PictureMarkerSymbol from "@arcgis/core/symbols/PictureMarkerSymbol";
 import Popup from "@arcgis/core/widgets/Popup";
@@ -120,6 +121,7 @@ import SearchSource from "@arcgis/core/widgets/Search/SearchSource";
 import SearchSourceFilter = __esri.SearchSourceFilter;
 import SearchResult = __esri.SearchResult;
 import SuggestResult = __esri.SuggestResult;
+import FeatureTemplate from "@arcgis/core/layers/support/FeatureTemplate";
 
 
 export function buildJsSpatialReference(dotNetSpatialReference: DotNetSpatialReference): SpatialReference {
@@ -1277,6 +1279,16 @@ export function buildJsFeatureEffect(dnFeatureEffect: DotNetFeatureEffect): Feat
     }
 
     return featureEffect;
+}
+
+export function buildJsFeatureTemplate(dnFeatureTemplate: DotNetFeatureTemplate, viewId: string | null): FeatureTemplate {
+    return {
+        name: dnFeatureTemplate.name,
+        description: dnFeatureTemplate.description,
+        drawingTool: dnFeatureTemplate.drawingTool as any,
+        thumbnail: dnFeatureTemplate.thumbnail as any,
+        prototype: buildJsGraphic(dnFeatureTemplate.prototype, viewId)
+    } as FeatureTemplate
 }
 
 export function buildJsFeatureFilter(dnFeatureFilter: DotNetFeatureFilter): FeatureFilter | null {

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/LayerTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/LayerTests.razor
@@ -23,4 +23,52 @@
             </Map>);
         await WaitForMapToRender();
     }
+    
+    [TestMethod]
+    public async Task TestCanRenderFeatureLayer()
+    {
+        CreateViewRenderedHandler(async () =>
+        {
+            await AssertJavaScript("assertLayerExists", args: "feature");
+        });
+        AddMapRenderFragment(
+            @<Map>
+                <FeatureLayer Url="https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/TrailRuns/FeatureServer/0" />
+            </Map>);
+        await WaitForMapToRender();
+    }
+    
+    [TestMethod]
+    public async Task TestCanRunFeatureLayerMethods()
+    {
+        FeatureLayer? layer = null;
+        CreateViewRenderedHandler(async () =>
+        {
+            await AssertJavaScript("assertLayerExists", args: "feature");
+        });
+        AddMapRenderFragment(
+            @<Map>
+                <FeatureLayer @ref="layer">
+                    <PortalItem Id="449887ea7d60429fbf6f0c67881f2758" />
+                </FeatureLayer>
+            </Map>);
+        await WaitForMapToRender(cleanupFragment: false);
+        Query query = await layer!.CreateQuery();
+        Assert.IsNotNull(query);
+        query.Num = 5;
+        query.OutFields = new[] { "*" };
+        FeatureSet? featureSet = await layer!.QueryFeatures(query);
+        Assert.IsNotNull(featureSet);
+        foreach (Graphic feature in featureSet.Features!)
+        {
+            FeatureType? featureType = await layer!.GetFeatureType(feature);
+            Assert.IsNotNull(featureType);
+        }
+        var fieldName = "strinsur";
+        Field? field = await layer.GetField(fieldName);
+        Assert.IsNotNull(field);
+        Domain? domain = await layer.GetFieldDomain(fieldName);
+        Assert.IsNotNull(domain);
+        await CleanupFragment();
+    }
 }


### PR DESCRIPTION
Refactored `NavMenu.razor` to expose pages to Pro, so we don't have to maintain two lists of samples.

While testing Pro, found a few duplicated type declarations, refactored and combined. Added some `FeatureLayer` unit tests.