### PR TITLE
fix pro wasm bug, refactor JS module loading

### DIFF
--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/GraphicsLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/GraphicsLayer.cs
@@ -144,7 +144,7 @@ public class GraphicsLayer : Layer
 
                 ms.Seek(0, SeekOrigin.Begin);
 #if NET7_0_OR_GREATER
-                MapView.AddGraphicsSyncInterop(ms.ToArray(), View!.Id.ToString(), Id.ToString());
+                View.AddGraphicsSyncInterop(ms.ToArray(), View!.Id.ToString(), Id.ToString());
                 await ms.DisposeAsync();
                 await Task.Delay(1, cancellationToken);
 #else

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/Layer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/Layer.cs
@@ -159,11 +159,12 @@ public abstract class Layer : MapComponent
     {
         AbortManager = new AbortManager(JsRuntime);
         IJSObjectReference abortSignal = await AbortManager!.CreateAbortSignal(cancellationToken);
-        IJSObjectReference arcGisJsInterop = await GetArcGisJsInterop();
+        IJSObjectReference? arcGisPro = await JsModuleManager.GetArcGisJsPro(JsRuntime, cancellationToken);
+        IJSObjectReference arcGisJsInterop = await JsModuleManager.GetArcGisJsCore(JsRuntime, arcGisPro, cancellationToken);
 
-        if (GetType().Namespace!.Contains("Pro"))
+        if (arcGisPro is not null)
         {
-            JsLayerReference = await (await GetArcGisJsPro())!.InvokeAsync<IJSObjectReference>("createProLayer",
+            JsLayerReference = await arcGisPro.InvokeAsync<IJSObjectReference>("createProLayer",
                 // ReSharper disable once RedundantCast
                 cancellationToken, (object)this, true, View?.Id);
         }

--- a/src/dymaptic.GeoBlazor.Core/Components/MapComponent.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/MapComponent.razor.cs
@@ -327,46 +327,6 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable
         }
     }
 
-    /// <summary>
-    ///     Retrieves the main entry point for the JavaScript interop.
-    /// </summary>
-    protected async Task<IJSObjectReference> GetArcGisJsInterop()
-    {
-        LicenseType licenseType = Licensing.GetLicenseType();
-
-        switch ((int)licenseType)
-        {
-            case >= 100:
-                // this is here to support the pro extension library
-                IJSObjectReference proModule = await JsRuntime
-                    .InvokeAsync<IJSObjectReference>("import", CancellationTokenSource.Token,
-                        "./_content/dymaptic.GeoBlazor.Pro/js/arcGisPro.js");
-
-                return await proModule.InvokeAsync<IJSObjectReference>("getCore");
-            default:
-                return await JsRuntime
-                    .InvokeAsync<IJSObjectReference>("import", CancellationTokenSource.Token,
-                        "./_content/dymaptic.GeoBlazor.Core/js/arcGisJsInterop.js");
-        }
-    }
-
-    /// <summary>
-    ///     Retrieves the main entry point for the optional GeoBlazor Pro JavaScript module.
-    /// </summary>
-    protected async Task<IJSObjectReference?> GetArcGisJsPro()
-    {
-        LicenseType licenseType = Licensing.GetLicenseType();
-
-        switch ((int)licenseType)
-        {
-            case >= 100:
-                return await JsRuntime.InvokeAsync<IJSObjectReference>("import", CancellationTokenSource.Token,
-                    "./_content/dymaptic.GeoBlazor.Pro/js/arcGisPro.js");
-            default:
-                return null;
-        }
-    }
-
     private readonly Dictionary<string, (Delegate Handler, IJSObjectReference JsObjRef)> _watchers = new();
     private readonly Dictionary<string, (Delegate Handler, IJSObjectReference JsObjRef)> _listeners = new();
     private readonly Dictionary<string, (Delegate Handler, IJSObjectReference JsObjRef)> _waiters = new();

--- a/src/dymaptic.GeoBlazor.Core/JsModuleManager.cs
+++ b/src/dymaptic.GeoBlazor.Core/JsModuleManager.cs
@@ -1,33 +1,56 @@
 using Microsoft.JSInterop;
-
+#if NET7_0_OR_GREATER
+using System.Runtime.InteropServices.JavaScript;
+#endif
 
 namespace dymaptic.GeoBlazor.Core;
 
 internal static class JsModuleManager
 {
-    public static async Task<IJSObjectReference> GetJsModule(IJSRuntime jsRuntime)
+    public static async Task<IJSObjectReference> GetArcGisJsCore(IJSRuntime jsRuntime, IJSObjectReference? proModule, CancellationToken cancellationToken)
     {
         LicenseType licenseType = Licensing.GetLicenseType();
-        IJSObjectReference jsModule;
+
+        if (proModule is null)
+        {
+#if NET7_0_OR_GREATER
+            if (OperatingSystem.IsBrowser())
+            {
+#pragma warning disable CA1416
+                await JSHost.ImportAsync("arcGisJsInterop", "../_content/dymaptic.GeoBlazor.Core/js/arcGisJsInterop.js");
+#pragma warning restore CA1416
+            }
+#endif
+            return await jsRuntime
+                    .InvokeAsync<IJSObjectReference>("import", cancellationToken, "./_content/dymaptic.GeoBlazor.Core/js/arcGisJsInterop.js");
+        }
+
+        return await proModule.InvokeAsync<IJSObjectReference>("getCore");
+    }
+
+    /// <summary>
+    ///     Retrieves the main entry point for the optional GeoBlazor Pro JavaScript module.
+    /// </summary>
+    public static async Task<IJSObjectReference?> GetArcGisJsPro(IJSRuntime jsRuntime, CancellationToken cancellationToken)
+    {
+        LicenseType licenseType = Licensing.GetLicenseType();
 
         switch ((int)licenseType)
         {
             case >= 100:
-                // this is here to support the pro extension library
-                IJSObjectReference proModule = await jsRuntime
-                    .InvokeAsync<IJSObjectReference>("import",
-                        "./_content/dymaptic.GeoBlazor.Pro/js/arcGisPro.js");
-                jsModule = await proModule.InvokeAsync<IJSObjectReference>("getCore");
-
-                break;
+                
+#if NET7_0_OR_GREATER
+                if (OperatingSystem.IsBrowser())
+                {
+        #pragma warning disable CA1416
+                    await JSHost.ImportAsync("arcGisPro", "../_content/dymaptic.GeoBlazor.Pro/js/arcGisPro.js");
+        #pragma warning restore CA1416
+                }
+#endif
+                return await jsRuntime.InvokeAsync<IJSObjectReference>("import", cancellationToken,
+                    "./_content/dymaptic.GeoBlazor.Pro/js/arcGisPro.js");
             default:
-                jsModule = await jsRuntime
-                    .InvokeAsync<IJSObjectReference>("import",
-                        "./_content/dymaptic.GeoBlazor.Core/js/arcGisJsInterop.js");
-
-                break;
+                return null;
         }
-
-        return jsModule;
     }
 }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -1342,7 +1342,7 @@ export async function addGraphicsFromStream(streamRef: any, viewId: string, abor
     }
 }
 
-export function addGraphicsSyncInterop(graphicsArray: Uint8Array, viewId: string, layerId?: string | null): void {
+export function addGraphicsCoreSyncInterop(graphicsArray: Uint8Array, viewId: string, layerId?: string | null): void {
     try {
         let graphics = decodeProtobufGraphics(graphicsArray);
         let jsGraphics: Graphic[] = [];


### PR DESCRIPTION
- Moved all JS Module loading into `JsModuleManager` static class
- Changed the order of module loading so that Pro never gets loaded twice
- Fix the bug, closes #262 , where Pro was not loading the Core JS via the `Pro.getCore` method. I did this by loading the pro in the `JSHost`, and then having a duplicated implementation on the JS side of the synchronous method.