### PR TITLE
adding/updating javascript file versioning

### DIFF
--- a/src/dymaptic.GeoBlazor.Core/JsModuleManager.cs
+++ b/src/dymaptic.GeoBlazor.Core/JsModuleManager.cs
@@ -1,4 +1,5 @@
 using Microsoft.JSInterop;
+using System.Security.Claims;
 
 namespace dymaptic.GeoBlazor.Core;
 
@@ -6,11 +7,13 @@ internal static class JsModuleManager
 {
     public static async Task<IJSObjectReference> GetArcGisJsCore(IJSRuntime jsRuntime, IJSObjectReference? proModule, CancellationToken cancellationToken)
     {
+        var version = System.Reflection.Assembly.GetAssembly(typeof(JsModuleManager))!.GetName().Version;
+
         if (proModule is null)
         {
             return await jsRuntime
                     .InvokeAsync<IJSObjectReference>("import", cancellationToken, 
-                        "./_content/dymaptic.GeoBlazor.Core/js/arcGisJsInterop.js");
+                        $"./_content/dymaptic.GeoBlazor.Core/js/arcGisJsInterop.js?v={version}");
         }
 
         return await proModule.InvokeAsync<IJSObjectReference>("getCore", cancellationToken);
@@ -21,6 +24,8 @@ internal static class JsModuleManager
     /// </summary>
     public static async Task<IJSObjectReference?> GetArcGisJsPro(IJSRuntime jsRuntime, CancellationToken cancellationToken)
     {
+        var version = System.Reflection.Assembly.GetAssembly(typeof(JsModuleManager))!.GetName().Version;
+
         LicenseType licenseType = Licensing.GetLicenseType();
 
         switch ((int)licenseType)
@@ -28,7 +33,7 @@ internal static class JsModuleManager
             case >= 100:
                 
                 return await jsRuntime.InvokeAsync<IJSObjectReference>("import", cancellationToken,
-                    "./_content/dymaptic.GeoBlazor.Pro/js/arcGisPro.js");
+                    $"./_content/dymaptic.GeoBlazor.Pro/js/arcGisPro.js?v={version}");
             default:
                 return null;
         }


### PR DESCRIPTION
closes #268

Adds a query parameter that is the current GeoBlazor version to the requests for the js interop file to prevent browser caching after an update.

Also combined duplicate interop request code to a single source.