### PR TITLE
FeatureLayer Client-side Graphics method fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <CoreVersion>2.5.1</CoreVersion>
+        <CoreVersion>2.5.2</CoreVersion>
     </PropertyGroup>
 </Project>

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/Graphic.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/Graphic.cs
@@ -40,14 +40,18 @@ public class Graphic : LayerObject
     /// <param name="attributes">
     ///     Name-value pairs of fields and field values associated with the graphic.
     /// </param>
+    /// <param name="visible">
+    ///     Indicates the visibility of the graphic.
+    /// </param>
     public Graphic(Geometry? geometry = null, Symbol? symbol = null, PopupTemplate? popupTemplate = null,
-        AttributesDictionary? attributes = null)
+        AttributesDictionary? attributes = null, bool? visible = null)
     {
         AllowRender = false;
 #pragma warning disable BL0005
         Geometry = geometry;
         Symbol = symbol;
         PopupTemplate = popupTemplate;
+        Visible = visible;
 
         if (attributes is not null)
         {
@@ -68,6 +72,13 @@ public class Graphic : LayerObject
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public AttributesDictionary Attributes { get; set; } = new();
+    
+    /// <summary>
+    ///     Indicates the visibility of the graphic. Default value: true.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Visible { get; set; }
 
     /// <summary>
     ///     The geometry that defines the graphic's location.

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/ImageryLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/ImageryLayer.cs
@@ -336,7 +336,6 @@ public class ImageryLayer : Layer
     /// <summary>
     ///     A complete list of fields that consists of raster attribute table fields, item pixel value, service pixel value, service pixel value with various server defined function templates, and raster attribute table fields. 
     /// </summary>
-    [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IReadOnlyCollection<Field>? RasterFields { get; set; }
 
@@ -350,9 +349,8 @@ public class ImageryLayer : Layer
     /// <summary>
     ///    The spatial reference of the image service.
     /// </summary>
-    [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public SpatialReference? SpatialReference { get; set; }
+    public SpatialReference? SpatialReference { get; internal set; }
 
     /// <summary>
     ///    Determines if the layer will update its temporal data based on the view's timeExtent. 

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/Label.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/Label.cs
@@ -32,7 +32,7 @@ public class Label : LayerObject
     /// <param name="labelExpressionInfo">
     ///     Defines the labels for a <see cref="FeatureLayer" />.
     /// </param>
-    public Label(string? labelPlacement = null, string? labelExpression = null, 
+    public Label(LabelPlacement? labelPlacement = null, string? labelExpression = null, 
         LabelExpressionInfo? labelExpressionInfo = null)
     {
 #pragma warning disable BL0005 // Component parameter should not be set outside of its component.
@@ -58,7 +58,7 @@ public class Label : LayerObject
     /// </summary>
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? LabelPlacement { get; set; }
+    public LabelPlacement? LabelPlacement { get; set; }
 
     /// <summary>
     ///     Defines the labels for a MapImageLayer.

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/Label.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/Label.cs
@@ -206,3 +206,38 @@ public enum LabelPosition
     Parallel
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }
+
+/// <summary>
+///     The position of the <see cref="Label"/>. Possible values are based on the feature type. This property requires a value.
+/// </summary>
+[JsonConverter(typeof(LabelPlacementStringConverter))]
+public enum LabelPlacement
+{
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+    AboveCenter,
+    AboveLeft,
+    AboveRight,
+    BelowCenter,
+    BelowLeft,
+    BelowRight,
+    CenterCenter,
+    CenterLeft,
+    CenterRight,
+    AboveAfter,
+    AboveAlong,
+    AboveBefore,
+    AboveStart,
+    AboveEnd,
+    BelowAfter,
+    BelowAlong,
+    BelowBefore,
+    BelowStart,
+    BelowEnd,
+    CenterAfter,
+    CenterAlong,
+    CenterBefore,
+    CenterStart,
+    CenterEnd,
+    AlwaysHorizontal
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+}

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/Layer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/Layer.cs
@@ -157,23 +157,19 @@ public abstract class Layer : MapComponent
     /// </remarks>
     public async Task Load(CancellationToken cancellationToken = default)
     {
+        if (JsLayerReference is not null)
+        {
+            // this layer has already been loaded
+            return;
+        }
         AbortManager = new AbortManager(JsRuntime);
         IJSObjectReference abortSignal = await AbortManager!.CreateAbortSignal(cancellationToken);
         IJSObjectReference? arcGisPro = await JsModuleManager.GetArcGisJsPro(JsRuntime, cancellationToken);
         IJSObjectReference arcGisJsInterop = await JsModuleManager.GetArcGisJsCore(JsRuntime, arcGisPro, cancellationToken);
 
-        if (arcGisPro is not null)
-        {
-            JsLayerReference = await arcGisPro.InvokeAsync<IJSObjectReference>("createProLayer",
-                // ReSharper disable once RedundantCast
-                cancellationToken, (object)this, true, View?.Id);
-        }
-        else
-        {
-            JsLayerReference = await arcGisJsInterop.InvokeAsync<IJSObjectReference>("createLayer",
-                // ReSharper disable once RedundantCast
-                cancellationToken, (object)this, true, View?.Id);
-        }
+        JsLayerReference = await arcGisJsInterop.InvokeAsync<IJSObjectReference>("createLayer",
+            // ReSharper disable once RedundantCast
+            cancellationToken, (object)this, true, View?.Id);
 
         await JsLayerReference.InvokeVoidAsync("load", cancellationToken, abortSignal);
 

--- a/src/dymaptic.GeoBlazor.Core/JsModuleManager.cs
+++ b/src/dymaptic.GeoBlazor.Core/JsModuleManager.cs
@@ -3,8 +3,14 @@ using System.Security.Claims;
 
 namespace dymaptic.GeoBlazor.Core;
 
+/// <summary>
+///     Static class for managing the JavaScript modules used by GeoBlazor.
+/// </summary>
 public static class JsModuleManager
 {
+    /// <summary>
+    ///     Retrieves the main entry point for the GeoBlazor Core JavaScript module.
+    /// </summary>
     public static async Task<IJSObjectReference> GetArcGisJsCore(IJSRuntime jsRuntime, IJSObjectReference? proModule, CancellationToken cancellationToken)
     {
         Version? version = System.Reflection.Assembly.GetAssembly(typeof(JsModuleManager))!.GetName().Version;

--- a/src/dymaptic.GeoBlazor.Core/JsModuleManager.cs
+++ b/src/dymaptic.GeoBlazor.Core/JsModuleManager.cs
@@ -3,11 +3,11 @@ using System.Security.Claims;
 
 namespace dymaptic.GeoBlazor.Core;
 
-internal static class JsModuleManager
+public static class JsModuleManager
 {
     public static async Task<IJSObjectReference> GetArcGisJsCore(IJSRuntime jsRuntime, IJSObjectReference? proModule, CancellationToken cancellationToken)
     {
-        var version = System.Reflection.Assembly.GetAssembly(typeof(JsModuleManager))!.GetName().Version;
+        Version? version = System.Reflection.Assembly.GetAssembly(typeof(JsModuleManager))!.GetName().Version;
 
         if (proModule is null)
         {
@@ -24,7 +24,7 @@ internal static class JsModuleManager
     /// </summary>
     public static async Task<IJSObjectReference?> GetArcGisJsPro(IJSRuntime jsRuntime, CancellationToken cancellationToken)
     {
-        var version = System.Reflection.Assembly.GetAssembly(typeof(JsModuleManager))!.GetName().Version;
+        Version? version = System.Reflection.Assembly.GetAssembly(typeof(JsModuleManager))!.GetName().Version;
 
         LicenseType licenseType = Licensing.GetLicenseType();
 

--- a/src/dymaptic.GeoBlazor.Core/Objects/AttributesDictionary.cs
+++ b/src/dymaptic.GeoBlazor.Core/Objects/AttributesDictionary.cs
@@ -47,6 +47,10 @@ public class AttributesDictionary : IEquatable<AttributesDictionary>
                     JsonValueKind.String => jsonElement.ToString(),
                     _ => jsonElement
                 };
+                if (typedValue is string stringValue && Guid.TryParse(stringValue, out Guid guidValue))
+                {
+                    typedValue = guidValue;
+                }
                 _backingDictionary[kvp.Key] = (typedValue ?? default(object))!;
             }
 

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -2139,6 +2139,12 @@ export async function addLayer(layerObject: any, viewId: string, isBasemapLayer?
 }
 
 export async function createLayer(layerObject: any, wrap?: boolean | null, viewId?: string | null): Promise<Layer | null> {
+    if (arcGisObjectRefs.hasOwnProperty(layerObject.id)) {
+        if (wrap) {
+            return getObjectReference(arcGisObjectRefs[layerObject.id] as Layer);
+        }
+        return arcGisObjectRefs[layerObject.id] as Layer;
+    }
     let newLayer: Layer;
     switch (layerObject.type) {
         case 'graphics':
@@ -2184,7 +2190,8 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             let featureLayer = newLayer as FeatureLayer;
 
             copyValuesIfExists(layerObject, featureLayer, 'minScale', 'maxScale', 'orderBy', 'objectIdField',
-                'definitionExpression', 'outFields', 'legendEnabled', 'popupEnabled', 'apiKey', 'blendMode');
+                'definitionExpression', 'outFields', 'legendEnabled', 'popupEnabled', 'apiKey', 'blendMode',
+                'geometryType');
 
             if (hasValue(layerObject.formTemplate)) {
                 featureLayer.formTemplate = buildJsFormTemplate(layerObject.formTemplate);
@@ -2495,9 +2502,6 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             if (hasValue(layerObject.fields && layerObject.fields.length > 0)) {
                 imageryLayer.fields = buildJsFields(layerObject.fields);
             }
-            if (hasValue(layerObject.fieldsIndex)) {
-                imageryLayer.fieldsIndex = layerObject.fieldsIndex;
-            }
             if (hasValue(layerObject.mosaicRule)) {
                 imageryLayer.mosaicRule = layerObject.mosaicRule;
             }
@@ -2513,20 +2517,11 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             if (hasValue(layerObject.popupTemplate)) {
                 imageryLayer.popupTemplate = buildJsPopupTemplate(layerObject.popupTemplate, viewId ?? null) as PopupTemplate;
             }
-            if (hasValue(layerObject.rasterFields)) {
-                imageryLayer.rasterFields = layerObject.rasterFields;
-            }
             if (hasValue(layerObject.rasterFunction)) {
                 imageryLayer.rasterFunction = layerObject.rasterFunction;
             }
-            if (hasValue(layerObject.rasterFunctionInfos)) {
-                imageryLayer.rasterFunctionInfos = layerObject.rasterFunctionInfos;
-            }
             if (hasValue(layerObject.sourceJSON)) {
                 imageryLayer.sourceJSON = layerObject.sourceJSON;
-            }
-            if (hasValue(layerObject.spatialReference)) {
-                imageryLayer.spatialReference = buildJsSpatialReference(layerObject.spatialReference) as SpatialReference;
             }
             if (hasValue(layerObject.timeExtent)) {
                 imageryLayer.timeExtent = layerObject.timeExtent;

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -659,7 +659,7 @@ export async function hitTest(pointObject: any, eventId: string | null, viewId: 
     isEvent: boolean, options: DotNetHitTestOptions | null): Promise<DotNetHitTestResult | void> {
     let view = arcGisObjectRefs[viewId] as MapView;
     let result: HitTestResult;
-    let screenPoint = isEvent ? pointObject : { x: pointObject.x, y: pointObject.y };
+    let screenPoint = isEvent ? pointObject : view.toScreen(buildJsPoint(pointObject) as Point); 
 
     if (options !== null) {
         let hitOptions = buildHitTestOptions(options, view);
@@ -694,7 +694,7 @@ export function toMap(screenPoint: any, viewId: string): DotNetPoint | null {
 
 export function toScreen(mapPoint: any, viewId: string): ScreenPoint {
     let view = arcGisObjectRefs[viewId] as MapView;
-    return view.toScreen(mapPoint);
+    return view.toScreen(buildJsPoint(mapPoint) as Point);
 }
 
 export function disposeView(viewId: string): void {

--- a/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
@@ -606,8 +606,8 @@ export interface DotNetColorRamp {
 export interface DotNetAlgorithmicColorRamp {
     type: string;
     algorithm: string;
-    fromColor: color;
-    toColor: color;
+    fromColor: string;
+    toColor: string;
 }
 
 export interface DotNetMultiPartColorRamp {
@@ -617,19 +617,19 @@ export interface DotNetMultiPartColorRamp {
 
 export interface DotNetRasterColormapRenderer {
     type: string;
-    colormapInfos: DotNetColormapInfo;
+    colormapInfos: DotNetColormapInfo[];
 }
 
 export interface DotNetColormapInfo {
     value: number;
     type: string;
-    color: color;
+    color: string;
     label: string;
 }
 
 export interface DotNetFlowRenderer {
     authoringInfo: DotNetAuthoringInfo;
-    color: color;
+    color: string;
     type: string;
     flowRepresentation: string;
     density: number;

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -31,14 +31,12 @@ import RasterColormapRenderer from "@arcgis/core/renderers/RasterColormapRendere
 import VectorFieldRenderer from "@arcgis/core/renderers/VectorFieldRenderer.js";
 import FlowRenderer from "@arcgis/core/renderers/FlowRenderer.js";
 import ClassBreaksRenderer from "@arcgis/core/renderers/ClassBreaksRenderer.js";
-import AuthoringInfo from "@arcgis/core/renderers/support/AuthoringInfo.js";
 import ClassBreakInfo from "@arcgis/core/renderers/support/ClassBreakInfo.js";
 import UniqueValueRenderer from "@arcgis/core/renderers/UniqueValueRenderer.js";
 import ColormapInfo from "@arcgis/core/renderers/support/ColormapInfo.js";
 import MultidimensionalSubset from "@arcgis/core/layers/support/MultidimensionalSubset.js";
 import PolygonSymbol3D from "@arcgis/core/symbols/PolygonSymbol3D.js";
 import FieldsIndex from "@arcgis/core/layers/support/FieldsIndex.js";
-import AuthoringInfoVisualVariable from "@arcgis/core/renderers/support/AuthoringInfoVisualVariable.js";
 import UniqueValue from "@arcgis/core/renderers/support/UniqueValue.js";
 import UniqueValueInfo from "@arcgis/core/renderers/support/UniqueValueInfo.js";
 import UniqueValueClass from "@arcgis/core/renderers/support/UniqueValueClass.js";
@@ -610,7 +608,7 @@ export function buildJsRasterColormapRenderer(dotNetRasterColormapRenderer: DotN
     if (dotNetRasterColormapRenderer === undefined) return null;
     let rasterColormapRender = new RasterColormapRenderer();
     if (hasValue(dotNetRasterColormapRenderer.colormapInfos)) {
-        rasterColormapRender.colormapInfos = dotNetRasterColormapRenderer.colormapInfos;
+        rasterColormapRender.colormapInfos = dotNetRasterColormapRenderer.colormapInfos.map(buildJsColormapInfo) as ColormapInfo[];
     }
     return rasterColormapRender;
 }
@@ -620,7 +618,7 @@ export function buildJsColormapInfo(dotNetColormapInfo: DotNetColormapInfo): Col
     let colormapInfo = new ColormapInfo();
 
     if (hasValue(dotNetColormapInfo.color)) {
-        colormapInfo.color = dotNetColormapInfo.color;
+        colormapInfo.color = buildJsColor(dotNetColormapInfo.color);
     }
     if (hasValue(dotNetColormapInfo.label)) {
         colormapInfo.label = dotNetColormapInfo.label;
@@ -644,7 +642,7 @@ export function buildJsRasterShadedReliefRenderer(dnRasterShadedReliefRenderer: 
         rasterShadedReliefRenderer.colorRamp = buildJsColorRamp(dnRasterShadedReliefRenderer.colorRamp) as ColorRamp;
     }
     if (hasValue(dnRasterShadedReliefRenderer.hillshadeType)) {
-        rasterShadedReliefRenderer.hillshadeType = dnRasterShadedReliefRenderer.hillshadeType;
+        rasterShadedReliefRenderer.hillshadeType = dnRasterShadedReliefRenderer.hillshadeType as any;
     }
     if (hasValue(dnRasterShadedReliefRenderer.pixelSizeFactor)) {
         rasterShadedReliefRenderer.pixelSizeFactor = dnRasterShadedReliefRenderer.pixelSizeFactor;
@@ -656,7 +654,7 @@ export function buildJsRasterShadedReliefRenderer(dnRasterShadedReliefRenderer: 
         rasterShadedReliefRenderer.pixelSizePower = dnRasterShadedReliefRenderer.pixelSizePower;
     }
     if (hasValue(dnRasterShadedReliefRenderer.scalingType)) {
-        rasterShadedReliefRenderer.scalingType = dnRasterShadedReliefRenderer.scalingType;
+        rasterShadedReliefRenderer.scalingType = dnRasterShadedReliefRenderer.scalingType as any;
     }
     if (hasValue(dnRasterShadedReliefRenderer.zFactor)) {
         rasterShadedReliefRenderer.zFactor = dnRasterShadedReliefRenderer.zFactor;
@@ -669,7 +667,7 @@ export function buildJsUniqueValueRenderer(dnUniqueValueRenderer: DotNetUniqueVa
     let uniqueValueRenderer = new UniqueValueRenderer();
     if (hasValue(dnUniqueValueRenderer.backgroundFillSymbol)) {
         if (dnUniqueValueRenderer.backgroundFillSymbol.type == "FillSymbol") {
-            uniqueValueRenderer.backgroundFillSymbol = dnUniqueValueRenderer.backgroundFillSymbol as DotNetSimpleFillSymbol;
+            uniqueValueRenderer.backgroundFillSymbol = buildJsSymbol(dnUniqueValueRenderer.backgroundFillSymbol) as SimpleFillSymbol;
         }
         // Note: The PolygonSymbol3d is not currently supported
     }
@@ -677,7 +675,7 @@ export function buildJsUniqueValueRenderer(dnUniqueValueRenderer: DotNetUniqueVa
         uniqueValueRenderer.defaultLabel = dnUniqueValueRenderer.defaultLabel;
     }
     if (hasValue(dnUniqueValueRenderer.defaultSymbol)) {
-        uniqueValueRenderer.defaultSymbol = dnUniqueValueRenderer.defaultSymbol as DotNetSymbol;
+        uniqueValueRenderer.defaultSymbol = buildJsSymbol(dnUniqueValueRenderer.defaultSymbol) as Symbol;
     }
     if (hasValue(dnUniqueValueRenderer.field)) {
         uniqueValueRenderer.field = dnUniqueValueRenderer.field;
@@ -697,12 +695,6 @@ export function buildJsUniqueValueRenderer(dnUniqueValueRenderer: DotNetUniqueVa
     if (hasValue(dnUniqueValueRenderer.orderByClassesEnabled)) {
         uniqueValueRenderer.orderByClassesEnabled = dnUniqueValueRenderer.orderByClassesEnabled;
     }
-    if (hasValue(dnUniqueValueRenderer.uniqueValueGroups)) {
-        uniqueValueRenderer.uniqueValueGroups = dnUniqueValueRenderer.uniqueValueGroups;
-    }
-    if (hasValue(dnUniqueValueRenderer.uniqueValueInfos)) {
-        uniqueValueRenderer.uniqueValueInfos = dnUniqueValueRenderer.uniqueValueInfos;
-    }
     if (hasValue(dnUniqueValueRenderer.valueExpression)) {
         uniqueValueRenderer.valueExpression = dnUniqueValueRenderer.valueExpression;
     }
@@ -710,7 +702,7 @@ export function buildJsUniqueValueRenderer(dnUniqueValueRenderer: DotNetUniqueVa
         uniqueValueRenderer.valueExpressionTitle = dnUniqueValueRenderer.valueExpressionTitle;
     }
     if (hasValue(dnUniqueValueRenderer.visualVariables)) {
-        uniqueValueRenderer.visualVariables = dnUniqueValueRenderer.visualVariables;
+        uniqueValueRenderer.visualVariables = dnUniqueValueRenderer.visualVariables.map(buildJsVisualVariable) as VisualVariable[];
     }
     return uniqueValueRenderer;
 }
@@ -719,12 +711,6 @@ export function buildJsClassBreaksRenderer(dnClassBreaksRenderer: DotNetClassBre
     if (dnClassBreaksRenderer === undefined) return null;
     let classBreaksRenderer = new ClassBreaksRenderer();
     //Implements only the simple fill symbol PolygonSymbol3d is another option but can be implemented later
-    if (hasValue(dnClassBreaksRenderer.backgroundFillSymbol)) {
-        classBreaksRenderer.backgroundFillSymbol = dnClassBreaksRenderer.backgroundFillSymbol as DotNetSimpleFillSymbol;
-    }
-    if (hasValue(dnClassBreaksRenderer.classBreaksInfos)) {
-        classBreaksRenderer.classBreaksInfos = dnClassBreaksRenderer.classBreaksInfos;
-    }
     if (hasValue(dnClassBreaksRenderer.defaultLabel)) {
         classBreaksRenderer.defaultLabel = dnClassBreaksRenderer.defaultLabel;
     }
@@ -734,9 +720,6 @@ export function buildJsClassBreaksRenderer(dnClassBreaksRenderer: DotNetClassBre
     if (hasValue(dnClassBreaksRenderer.field)) {
         classBreaksRenderer.field = dnClassBreaksRenderer.field;
     }
-    if (hasValue(dnClassBreaksRenderer.legendOptions)) {
-        classBreaksRenderer.legendOptions = dnClassBreaksRenderer.legendOptions;
-    }
     if (hasValue(dnClassBreaksRenderer.normalizationField)) {
         classBreaksRenderer.normalizationField = dnClassBreaksRenderer.normalizationField;
     }
@@ -744,10 +727,7 @@ export function buildJsClassBreaksRenderer(dnClassBreaksRenderer: DotNetClassBre
         classBreaksRenderer.normalizationTotal = dnClassBreaksRenderer.normalizationTotal;
     }
     if (hasValue(dnClassBreaksRenderer.normalizationType)) {
-        classBreaksRenderer.normalizationType = dnClassBreaksRenderer.normalizationType;
-    }
-    if (hasValue(dnClassBreaksRenderer.type)) {
-        classBreaksRenderer.type = dnClassBreaksRenderer.type;
+        classBreaksRenderer.normalizationType = dnClassBreaksRenderer.normalizationType as any;
     }
     if (hasValue(dnClassBreaksRenderer.valueExpression)) {
         classBreaksRenderer.valueExpression = dnClassBreaksRenderer.valueExpression;
@@ -756,7 +736,7 @@ export function buildJsClassBreaksRenderer(dnClassBreaksRenderer: DotNetClassBre
         classBreaksRenderer.valueExpressionTitle = dnClassBreaksRenderer.valueExpressionTitle;
     }
     if (hasValue(dnClassBreaksRenderer.visualVariables)) {
-        classBreaksRenderer.visualVariables = dnClassBreaksRenderer.visualVariables;
+        classBreaksRenderer.visualVariables = dnClassBreaksRenderer.visualVariables.map(buildJsVisualVariable) as VisualVariable[];
     }
     return classBreaksRenderer;
 }
@@ -765,20 +745,17 @@ export function buildJsVectorFieldRenderer(dotNetVectorFieldRenderer: DotNetVect
     if (dotNetVectorFieldRenderer === undefined) return null;
     let vectorFieldRenderer = new VectorFieldRenderer();
 
-    if (hasValue(dotNetVectorFieldRenderer.attributeField)) {
-        vectorFieldRenderer.attributeField = dotNetVectorFieldRenderer.attributeField;
-    }
     if (hasValue(dotNetVectorFieldRenderer.flowRepresentation)) {
-        vectorFieldRenderer.flowRepresentation = dotNetVectorFieldRenderer.flowRepresentation;
+        vectorFieldRenderer.flowRepresentation = dotNetVectorFieldRenderer.flowRepresentation as any;
     }
     if (hasValue(dotNetVectorFieldRenderer.style)) {
-        vectorFieldRenderer.style = dotNetVectorFieldRenderer.style;
+        vectorFieldRenderer.style = dotNetVectorFieldRenderer.style as any;
     }
     if (hasValue(dotNetVectorFieldRenderer.symbolTileSize)) {
         vectorFieldRenderer.symbolTileSize = dotNetVectorFieldRenderer.symbolTileSize;
     }
     if (hasValue(dotNetVectorFieldRenderer.visualVariables)) {
-        vectorFieldRenderer.visualVariables = dotNetVectorFieldRenderer.visualVariables;
+        vectorFieldRenderer.visualVariables = dotNetVectorFieldRenderer.visualVariables.map(buildJsVisualVariable) as VisualVariable[];
     }
     return vectorFieldRenderer;
 }
@@ -810,37 +787,34 @@ export function buildJsFlowRenderer(dotNetFlowRenderer: DotNetFlowRenderer): Flo
     let flowRenderer = new FlowRenderer();
 
     if (hasValue(dotNetFlowRenderer.authoringInfo)) {
-        dotNetFlowRenderer.authoringInfo = flowRenderer.authoringInfo;
+        flowRenderer.authoringInfo = buildJsAuthoringInfo(dotNetFlowRenderer.authoringInfo);
     }
     if (hasValue(dotNetFlowRenderer.color)) {
-        dotNetFlowRenderer.color = flowRenderer.color;
+        flowRenderer.color = buildJsColor(dotNetFlowRenderer.color);
     }
     if (hasValue(dotNetFlowRenderer.density)) {
-        dotNetFlowRenderer.density = flowRenderer.density;
+        flowRenderer.density = dotNetFlowRenderer.density;
     }
     if (hasValue(dotNetFlowRenderer.flowRepresentation)) {
-        dotNetFlowRenderer.flowRepresentation = flowRenderer.flowRepresentation;
+        flowRenderer.flowRepresentation = dotNetFlowRenderer.flowRepresentation as any;
     }
     if (hasValue(dotNetFlowRenderer.flowSpeed)) {
-        dotNetFlowRenderer.flowSpeed = flowRenderer.flowSpeed;
-    }
-    if (hasValue(dotNetFlowRenderer.legendOptions)) {
-        dotNetFlowRenderer.legendOptions = flowRenderer.legendOptions;
+        flowRenderer.flowSpeed = dotNetFlowRenderer.flowSpeed;
     }
     if (hasValue(dotNetFlowRenderer.maxPathLength)) {
-        dotNetFlowRenderer.maxPathLength = flowRenderer.maxPathLength;
+        flowRenderer.maxPathLength = dotNetFlowRenderer.maxPathLength;
     }
     if (hasValue(dotNetFlowRenderer.trailCap)) {
-        dotNetFlowRenderer.trailCap = flowRenderer.trailCap;
+        flowRenderer.trailCap = dotNetFlowRenderer.trailCap as any;
     }
     if (hasValue(dotNetFlowRenderer.trailLength)) {
-        dotNetFlowRenderer.trailLength = flowRenderer.trailLength;
+        flowRenderer.trailLength = dotNetFlowRenderer.trailLength;
     }
     if (hasValue(dotNetFlowRenderer.trailWidth)) {
-        dotNetFlowRenderer.trailWidth = flowRenderer.trailWidth;
+        flowRenderer.trailWidth = dotNetFlowRenderer.trailWidth;
     }
     if (hasValue(dotNetFlowRenderer.visualVariables)) {
-        dotNetFlowRenderer.visualVariables = flowRenderer.visualVariables;
+        flowRenderer.visualVariables = dotNetFlowRenderer.visualVariables.map(buildJsVisualVariable) as VisualVariable[];
     }
     return flowRenderer;
 }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -213,6 +213,8 @@ export function buildJsGraphic(graphicObject: any, viewId: string | null)
     if (hasValue(graphicObject.popupTemplate)) {
         graphic.popupTemplate = buildJsPopupTemplate(graphicObject.popupTemplate, viewId) as PopupTemplate;
     }
+    
+    copyValuesIfExists(graphicObject, graphic, 'visible');
 
     return graphic;
 }

--- a/src/dymaptic.GeoBlazor.Core/Serialization/EnumToKebabCaseStringConverter.cs
+++ b/src/dymaptic.GeoBlazor.Core/Serialization/EnumToKebabCaseStringConverter.cs
@@ -1,4 +1,5 @@
-﻿using dymaptic.GeoBlazor.Core.Extensions;
+﻿using dymaptic.GeoBlazor.Core.Components.Layers;
+using dymaptic.GeoBlazor.Core.Extensions;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -66,6 +67,31 @@ public class TimeEnumToKebabCaseStringConverter<T> : EnumToKebabCaseStringConver
             Console.WriteLine(ex);
 
             return default(T)!;
+        }
+    }
+}
+
+/// <summary>
+///     Converts an enum to a kebab case string for serialization. Used with LabelPlacement which returns esriServerPointLabelPlacement from the ESRI JS.
+/// </summary>
+public class LabelPlacementStringConverter : EnumToKebabCaseStringConverter<LabelPlacement>
+{
+    /// <inheritdoc />
+    public override LabelPlacement Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString()
+            ?.Replace("-", string.Empty)
+            .Replace("esriServerPointLabelPlacement", string.Empty);
+
+        try
+        {
+            return value is not null ? (LabelPlacement)Enum.Parse(typeof(LabelPlacement), value, true) : default(LabelPlacement)!;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex);
+
+            return default(LabelPlacement);
         }
     }
 }

--- a/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
+++ b/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
@@ -56,7 +56,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     </ItemGroup>
-    <PropertyGroup Condition="$(Configuration) == 'RELEASE' AND $(TargetFrameworks.StartsWith($(TargetFramework)))">
+    <PropertyGroup Condition="$(Configuration) == 'RELEASE' AND $(TargetFrameworks.StartsWith($(TargetFramework))) AND '$(GenerateDocs)' == 'true'">
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <DefaultDocumentationFolder>Documentation</DefaultDocumentationFolder>
         <DefaultDocumentationGeneratedPages>Types</DefaultDocumentationGeneratedPages>
@@ -110,7 +110,7 @@
         <ExecAsync FilePath="pwsh" Arguments="./npmDebugBuild.ps1" />
     </Target>
 
-    <Target Name="NPM Release Build" AfterTargets="Copy Assets Release" Condition="$(Configuration) == 'RELEASE' AND $(TargetFrameworks.StartsWith($(TargetFramework))) AND '$(OptOutFromCoreEsBuild)' != 'true'">
+    <Target Name="NPM Release Build" AfterTargets="Copy Assets Release" Condition="$(Configuration) == 'RELEASE' AND $(TargetFrameworks.StartsWith($(TargetFramework)))">
         <!-- Runs synchronously to ensure all files are ready for nuget packaging in release mode -->
         <Exec Command="npm run releaseBuild" />
     </Target>

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerTests.razor
@@ -69,4 +69,49 @@
         Assert.IsNotNull(capabilities);
     }
 
+    [TestMethod]
+    public async Task TestCanAddFeatureWithApplyEdits(Action renderHandler)
+    {
+        FeatureLayer? layer = null;
+        AddMapRenderFragment(
+            @<MapView class="map-view" OnViewRendered="renderHandler">
+                <Map ArcGISDefaultBasemap="topo-vector">
+                    <FeatureLayer @ref="layer" Source="@([])" 
+                                  GeometryType="GeometryType.Point"
+                                  ObjectIdField="OBJECT_ID">
+                    </FeatureLayer>
+                </Map>
+            </MapView>);
+        await WaitForMapToRender();
+        await AssertJavaScript("assertLayerExists", args: "feature");
+        FeatureEdits edits = new() { 
+            AddFeatures = [
+                new Graphic(new Point(0, 0), 
+                    new SimpleMarkerSymbol(color: new MapColor("black")))
+            ] 
+        };
+        await layer!.ApplyEdits(edits);
+        await WaitForMapToRender();
+        await AssertJavaScript("assertGraphicExistsInLayer", args: new object[] { layer!.Id, "point", 1 });
+    }
+    
+    [TestMethod]
+    public async Task TestCannotAddFeaturesWithAddMethodAfterRender(Action renderHandler)
+    {
+        FeatureLayer? layer = null;
+        AddMapRenderFragment(
+            @<MapView class="map-view" OnViewRendered="renderHandler">
+                <Map ArcGISDefaultBasemap="topo-vector">
+                    <FeatureLayer @ref="layer" Source="@([])" 
+                                  GeometryType="GeometryType.Point"
+                                  ObjectIdField="OBJECT_ID">
+                    </FeatureLayer>
+                </Map>
+            </MapView>);
+        await WaitForMapToRender();
+        await AssertJavaScript("assertLayerExists", args: "feature");
+
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => layer!.Add(new Graphic(new Point(0, 0),
+            new SimpleMarkerSymbol(color: new MapColor("black")))));
+    }
 }

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/GraphicsTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/GraphicsTests.razor
@@ -66,4 +66,30 @@
         await WaitForMapToRender();
         await AssertJavaScript("assertGraphicExistsInView", args: new object[] { "point", 1 });
     }
+    
+    [TestMethod]
+    public async Task TestCanSerializeAndDeserializeGuidAttributes(Action renderHandler)
+    {
+        MapView? mapView = null;
+        AddMapRenderFragment( 
+            @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
+                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+            </MapView>);
+
+        await WaitForMapToRender();
+
+        Point point = new(0, 0, spatialReference: new SpatialReference(102100));
+        Guid testGuid = Guid.NewGuid();
+        Graphic testGraphic = new Graphic(point,
+            new SimpleMarkerSymbol(color: new MapColor("red"), size: 10),
+            attributes: new AttributesDictionary(new Dictionary<string, object>()
+            {
+                {"GUID_ID", testGuid}
+            }));
+        await mapView!.AddGraphic(testGraphic);
+        await WaitForMapToRender();
+        HitTestResult result = await mapView.HitTest(point);
+        GraphicHit graphicHit = (GraphicHit)result.Results[0];
+        Assert.AreEqual(testGuid, graphicHit.Graphic.Attributes["GUID_ID"]);
+    }
 }

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/TestRunnerBase.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/TestRunnerBase.razor
@@ -88,8 +88,15 @@
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await base.OnAfterRenderAsync(firstRender);
-        _jsObjectReference ??= await JsRuntime.InvokeAsync<IJSObjectReference>("import", 
-            "./_content/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/testRunner.js");
+
+        if (_jsObjectReference is null)
+        {
+            IJSObjectReference? proJs = await JsModuleManager.GetArcGisJsPro(JsRuntime, default);
+            IJSObjectReference coreJs = await JsModuleManager.GetArcGisJsCore(JsRuntime, proJs, default);
+            _jsObjectReference = await JsRuntime.InvokeAsync<IJSObjectReference>("import", 
+                "./_content/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/testRunner.js");
+            await _jsObjectReference.InvokeVoidAsync("initialize", coreJs);
+        }
     }
 
     protected void AddMapRenderFragment(RenderFragment fragment, [CallerMemberName] string methodName = "")

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/wwwroot/testRunner.js
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/wwwroot/testRunner.js
@@ -1,18 +1,12 @@
-﻿export let Core;
+﻿let Core;
 export let arcGisObjectRefs;
-export let Color;
+let Color;
 
-(async () => {
-
-    try {
-        let Pro = await import("../dymaptic.GeoBlazor.Pro/js/arcGisPro.js");
-        Core = await Pro.getCore();
-    } catch {
-        Core = await import("../dymaptic.GeoBlazor.Core/js/arcGisJsInterop.js");
-    }
+export function initialize(core) {
+    Core = core;
     arcGisObjectRefs = Core.arcGisObjectRefs;
     Color = Core.Color;
-})();
+}
 
 export function assertBasemapHasTwoLayers(methodName) {
     let view = getView(methodName);
@@ -37,9 +31,16 @@ export function assertGraphicExistsInView(methodName, geometryType, count) {
     }
 }
 
-export function assertGraphicExistsInLayer(methodName, layerId, geometryType, count) {
+export async function assertGraphicExistsInLayer(methodName, layerId, geometryType, count) {
     let layer = arcGisObjectRefs[layerId];
-    let graphics = layer.graphics.items.filter(g => g.geometry.type === geometryType);
+    let graphics;
+    if (layer.declaredClass === 'esri.layers.FeatureLayer') {
+        let featureSet = await layer.queryFeatures();
+        graphics = featureSet.features;
+    } else {
+        graphics = layer.graphics.items.filter(g => g.geometry.type === geometryType);
+    }
+    
     if (graphics.length !== count) {
         throw new Error(`Expected ${count} graphics of type ${geometryType} but found ${graphics.length}`);
     }


### PR DESCRIPTION
Closes #275 

- You can now define an empty `Source` parameter like below (C#12 syntax). This makes it possible to start with an empty layer and then add graphics later programmatically.

```html
<FeatureLayer Source="@([])">
```

- Discovered that an empty layer like above never calls `layerview-create`, and thus isn't "registered" in GeoBlazor with a JSObjectReference. Fixed `ApplyEdits` to also call `Load` first if the object ref isn't set.
- Added specific thrown exceptions to `FeatureLayer.Add(Graphic graphic)` and  `FeatureLayer.Remove(Graphic graphic)` methods if these are called after the layer is rendered, because ArcGIS Feature Layers do not support updating graphics this way.
- Did some cleanup on `ImageryLayer` and the related renderers to remove broken code that was either not converting correctly in TypeScript, or was trying to set read-only fields
- Changed `Label.LabelPlacement` to be an enum instead of a string. While this is technically a breaking change, I did discover a bug when the value would round-trip from ArcGIS, where ArcGIS returned values like `esriServerPointLabelPlacementAboveCenter`, so this also fixes that bug.
- Removed broken Pro code in `Layer.Load`
- Updated `testRunner.js` to use a better injection pattern for extending GeoBlazor.