### PR TITLE
Implemented and tested ApplyEdits changes via protobuf serialization

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <CoreVersion>2.5.2</CoreVersion>
+        <CoreVersion>2.5.3</CoreVersion>
     </PropertyGroup>
 </Project>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ManyGraphics.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ManyGraphics.razor
@@ -1,7 +1,7 @@
 ﻿@page "/many-graphics"
 
 <PageTitle>Many Graphics</PageTitle>
-<h1>Many Points</h1>
+<h1>Many Graphics</h1>
 <div class="links-div">
     <a class="btn btn-secondary" target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-Graphic.html">ArcGIS API for JavaScript</a>
 </div>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/dymaptic.GeoBlazor.Core.Sample.Shared.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/dymaptic.GeoBlazor.Core.Sample.Shared.csproj
@@ -18,12 +18,18 @@
         <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0"/>
     </ItemGroup>
 
-    <ItemGroup Condition="$(Configuration) == 'DEBUG' OR '$(UsePackageReferences)' != 'true'">
-        <ProjectReference Include="..\..\src\dymaptic.GeoBlazor.Core\dymaptic.GeoBlazor.Core.csproj"/>
-    </ItemGroup>
-    <ItemGroup Condition="$(Configuration) == 'RELEASE' AND '$(UsePackageReferences)' == 'true'">
-        <PackageReference Include="dymaptic.GeoBlazor.Core" Version="$(CoreVersion)" />
-    </ItemGroup>
+    <Choose>
+        <When Condition="$(Configuration) == 'RELEASE' AND '$(UsePackageReferences)' == 'true'">
+            <ItemGroup Condition="$(Configuration) == 'RELEASE'">
+                <PackageReference Include="dymaptic.GeoBlazor.Core"  Version="$(CoreVersion)" />
+            </ItemGroup>
+        </When>
+        <Otherwise>
+            <ItemGroup Condition="$(Configuration) == 'DEBUG'">
+                <ProjectReference Include="..\..\src\dymaptic.GeoBlazor.Core\dymaptic.GeoBlazor.Core.csproj"/>
+            </ItemGroup>
+        </Otherwise>
+    </Choose>
 
     <ItemGroup>
         <Content Update="wwwroot\images\dymaptic_logo.png">

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayer.cs
@@ -8,6 +8,7 @@ using dymaptic.GeoBlazor.Core.Objects;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
+using ProtoBuf;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -243,7 +244,7 @@ public class FeatureLayer : Layer, IFeatureReductionLayer
         get => _source;
         set
         {
-            if (value is not null)
+            if (value is not null && (_source is null || !_source!.Any()))
             {
                 _source = new HashSet<Graphic>(value);
             }
@@ -294,13 +295,18 @@ public class FeatureLayer : Layer, IFeatureReductionLayer
     /// <exception cref="InvalidOperationException">
     ///     If the layer is already loaded, you must use <see cref="ApplyEdits"/> to add graphics.
     /// </exception>
-    public Task Add(Graphic graphic)
+    public async Task Add(Graphic graphic)
     {
         if (JsLayerReference is not null)
         {
-            throw new InvalidOperationException("Cannot add graphics to a feature layer that is already loaded. Use ApplyEdits instead.");
+            await ApplyEdits(new FeatureEdits
+            {
+                AddFeatures = new []{graphic}
+            });
+
+            return;
         }
-        return RegisterChildComponent(graphic);
+        await RegisterChildComponent(graphic);
     }
 
     /// <summary>
@@ -316,7 +322,12 @@ public class FeatureLayer : Layer, IFeatureReductionLayer
     {
         if (JsLayerReference is not null)
         {
-            throw new InvalidOperationException("Cannot add graphics to a feature layer that is already loaded. Use ApplyEdits instead.");
+            await ApplyEdits(new FeatureEdits
+            {
+                AddFeatures = graphics
+            });
+
+            return;
         }
         foreach (Graphic graphic in graphics)
         {
@@ -361,17 +372,182 @@ public class FeatureLayer : Layer, IFeatureReductionLayer
     ///     Applies edits to features in a layer. New features can be created and existing features can be updated or deleted. Feature geometries and/or attributes may be modified. Only applicable to layers in a feature service and client-side features set through the FeatureLayer's source property. Attachments can also be added, updated or deleted.
     ///     If client-side features are added, removed or updated at runtime using applyEdits() then use FeatureLayer's queryFeatures() method to return updated features.
     /// </summary>
-    public async Task<FeatureEditsResult> ApplyEdits(FeatureEdits edits, FeatureEditOptions? options = null)
+    public async Task<FeatureEditsResult> ApplyEdits(FeatureEdits edits, FeatureEditOptions? options = null,
+        CancellationToken cancellationToken = default)
     {
         // Verify that the layer is loaded. Layers with no graphics are not rendered and therefore not loaded
         // as far as GeoBlazor is concerned
         if (JsModule is not null && JsLayerReference is null)
         {
-            await Load();
+            await Load(cancellationToken);
         }
         
-        return await JsLayerReference!.InvokeAsync<FeatureEditsResult>("applyEdits", edits, options,
-            View!.Id);
+        FeatureEditsResult emptyResult = new FeatureEditsResult(Array.Empty<FeatureEditResult>(), 
+            Array.Empty<FeatureEditResult>(),
+            Array.Empty<FeatureEditResult>(),
+            Array.Empty<FeatureEditResult>(),
+            Array.Empty<FeatureEditResult>(),
+            Array.Empty<FeatureEditResult>(),
+            Array.Empty<EditedFeatureResult>(),
+            null);
+
+        if (cancellationToken.IsCancellationRequested ||
+            CancellationTokenSource.Token.IsCancellationRequested)
+        {
+            return emptyResult;
+        }
+
+        Graphic[] addedFeatures = edits.AddFeatures?.ToArray() ?? Array.Empty<Graphic>();
+        Graphic[] updatedFeatures = edits.UpdateFeatures?.ToArray() ?? Array.Empty<Graphic>();
+        Graphic[] deletedFeatures = edits.DeleteFeatures?.ToArray() ?? Array.Empty<Graphic>();
+        long? editMoment = null;
+        int chunkSize = View!.GraphicSerializationChunkSize ?? (View.IsMaui ? 100 : 200);
+        AbortManager ??= new AbortManager(JsRuntime);
+        
+        // return await JsLayerReference!.InvokeAsync<FeatureEditsResult>("applyEdits", edits, options,
+        //     View!.Id);
+        FeatureEditsResult? addFeatureResults = null;
+        FeatureEditsResult? updateFeatureResults = null;
+        FeatureEditsResult? deleteFeatureResults = null;
+        List<EditedFeatureResult> editedFeatureResults = new();
+        IJSObjectReference abortSignal = await AbortManager!.CreateAbortSignal(cancellationToken);
+        for (var index = 0; index < addedFeatures.Length; index += chunkSize)
+        {
+            int skip = index;
+
+            addFeatureResults = 
+                await SendEdits(addedFeatures.Skip(skip).Take(chunkSize)
+                        .Select(g => g.ToSerializationRecord()).ToArray(), "add", 
+                    options, addFeatureResults, abortSignal, cancellationToken);
+            editMoment ??= addFeatureResults?.EditMoment;
+        }
+        for (var index = 0; index < updatedFeatures.Length; index += chunkSize)
+        {
+            int skip = index;
+
+            updateFeatureResults = 
+                await SendEdits(updatedFeatures.Skip(skip).Take(chunkSize)
+                        .Select(g => g.ToSerializationRecord()).ToArray(), "update", 
+                    options, updateFeatureResults, abortSignal, cancellationToken);
+            editMoment ??= updateFeatureResults?.EditMoment;
+        }
+        for (var index = 0; index < deletedFeatures.Length; index += chunkSize)
+        {
+            int skip = index;
+
+            deleteFeatureResults = 
+                await SendEdits(deletedFeatures.Skip(skip).Take(chunkSize)
+                        .Select(g => g.ToSerializationRecord()).ToArray(), "delete", 
+                    options, deleteFeatureResults, abortSignal, cancellationToken);
+            editMoment ??= deleteFeatureResults?.EditMoment;
+        }
+        
+        if (addFeatureResults?.EditedFeatureResults is not null)
+        {
+            editedFeatureResults.AddRange(addFeatureResults.EditedFeatureResults);
+        }
+        if (updateFeatureResults?.EditedFeatureResults is not null)
+        {
+            editedFeatureResults.AddRange(updateFeatureResults.EditedFeatureResults);
+        }
+        if (deleteFeatureResults?.EditedFeatureResults is not null)
+        {
+            editedFeatureResults.AddRange(deleteFeatureResults.EditedFeatureResults);
+        }
+
+        FeatureEditsResult? attachmentResults = null;
+        if (edits.AddAttachments?.Any() == true ||
+            edits.UpdateAttachments?.Any() == true ||
+            edits.DeleteAttachments?.Any() == true)
+        {
+            FeatureEdits attachmentEdits = new()
+            {
+                AddAttachments = edits.AddAttachments,
+                UpdateAttachments = edits.UpdateAttachments,
+                DeleteAttachments = edits.DeleteAttachments
+            };
+            attachmentResults = await JsLayerReference!.InvokeAsync<FeatureEditsResult>(
+                "applyAttachmentEdits", cancellationToken, attachmentEdits, options, View!.Id,
+                abortSignal);
+            editMoment ??= attachmentResults.EditMoment;
+            if (attachmentResults.EditedFeatureResults is not null)
+            {
+                editedFeatureResults.AddRange(attachmentResults.EditedFeatureResults);
+            }
+        }
+        
+        if (_source is not null)
+        {
+            // update the in-memory collections:
+            foreach (Graphic addedGraphic in addedFeatures)
+            {
+                _source!.Add(addedGraphic);
+            }
+            foreach (Graphic updatedGraphic in updatedFeatures)
+            {
+                _source!.Remove(updatedGraphic);
+                _source!.Add(updatedGraphic);
+            }
+            foreach (Graphic deletedGraphic in deletedFeatures)
+            {
+                _source!.Remove(deletedGraphic);
+            }
+        }
+
+        return new FeatureEditsResult
+        (
+            addFeatureResults?.AddFeatureResults ?? Array.Empty<FeatureEditResult>(), 
+            updateFeatureResults?.UpdateFeatureResults ?? Array.Empty<FeatureEditResult>(), 
+            deleteFeatureResults?.DeleteFeatureResults ?? Array.Empty<FeatureEditResult>(), 
+            attachmentResults?.AddAttachmentResults ?? Array.Empty<FeatureEditResult>(),
+            attachmentResults?.UpdateAttachmentResults ?? Array.Empty<FeatureEditResult>(),
+            attachmentResults?.DeleteAttachmentResults ?? Array.Empty<FeatureEditResult>(),
+            editedFeatureResults.ToArray(),
+            editMoment
+        );
+    }
+
+    private async Task<FeatureEditsResult?> SendEdits(GraphicSerializationRecord[] graphics, 
+        string editType, FeatureEditOptions? options, FeatureEditsResult? currentResults, 
+        IJSObjectReference abortSignal, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested ||
+            CancellationTokenSource.Token.IsCancellationRequested)
+        {
+            return null;
+        }
+        
+        ProtoGraphicCollection collection = new(graphics);
+        MemoryStream ms = new();
+        Serializer.Serialize(ms, collection);
+
+        if (cancellationToken.IsCancellationRequested ||
+            CancellationTokenSource.Token.IsCancellationRequested)
+        {
+            await ms.DisposeAsync();
+            return null;
+        }
+        
+        ms.Seek(0, SeekOrigin.Begin);
+
+        FeatureEditsResult result;
+        if (View!.IsWebAssembly)
+        {
+            result = await JsLayerReference!.InvokeAsync<FeatureEditsResult>(
+                "applyGraphicEditsSynchronously", cancellationToken, ms.ToArray(), editType, options, 
+                View!.Id, abortSignal);
+            await ms.DisposeAsync();
+            await Task.Delay(1, cancellationToken);
+        }
+        else
+        {
+            using DotNetStreamReference streamRef = new(ms);
+            result = await JsLayerReference!.InvokeAsync<FeatureEditsResult>(
+                "applyGraphicEditsFromStream", cancellationToken, streamRef, editType, options, 
+                View!.Id, abortSignal);
+        }
+
+        return result.Concat(currentResults);
     }
 
     /// <summary>
@@ -1178,7 +1354,8 @@ public class AttachmentEdit
     /// <summary>
     ///     The feature, objectId or globalId of feature associated with the attachment.
     /// </summary>
-    public Graphic Feature { get; set; } = default!;
+    [JsonConverter(typeof(GraphicToIdConverter))]
+    public Graphic? Feature { get; set; }
 
     /// <summary>
     ///     The attachment to be added, updated or deleted.
@@ -1335,10 +1512,32 @@ public class FeatureEditOptions
 /// <param name="EditMoment">
 ///     The time edits were applied to the feature service. This parameter is returned only when the returnEditMoment parameter of the applyEdits() method is set to true.
 /// </param>
-public record FeatureEditsResult(FeatureEditResult[] AddFeatureResults, FeatureEditResult[] UpdateFeatureResults,
-    FeatureEditResult[] DeleteFeatureResults, FeatureEditResult[] AddAttachmentResults,
-    FeatureEditResult[] UpdateAttachmentResults, FeatureEditResult[] DeleteAttachmentResults,
-    EditedFeatureResult[]? EditedFeatureResults, long? EditMoment);
+public record FeatureEditsResult(
+    FeatureEditResult[] AddFeatureResults,
+    FeatureEditResult[] UpdateFeatureResults,
+    FeatureEditResult[] DeleteFeatureResults,
+    FeatureEditResult[] AddAttachmentResults,
+    FeatureEditResult[] UpdateAttachmentResults,
+    FeatureEditResult[] DeleteAttachmentResults,
+    EditedFeatureResult[]? EditedFeatureResults,
+    long? EditMoment)
+{
+    public FeatureEditsResult Concat(FeatureEditsResult? other)
+    {
+        if (other is null) return this;
+        return this with
+        {
+            AddFeatureResults = AddFeatureResults.Concat(other.AddFeatureResults).ToArray(),
+            UpdateFeatureResults = UpdateFeatureResults.Concat(other.UpdateFeatureResults).ToArray(),
+            DeleteFeatureResults = DeleteFeatureResults.Concat(other.DeleteFeatureResults).ToArray(),
+            AddAttachmentResults = AddAttachmentResults.Concat(other.AddAttachmentResults).ToArray(),
+            UpdateAttachmentResults = UpdateAttachmentResults.Concat(other.UpdateAttachmentResults).ToArray(),
+            DeleteAttachmentResults = DeleteAttachmentResults.Concat(other.DeleteAttachmentResults).ToArray(),
+            EditedFeatureResults = (EditedFeatureResults ?? Array.Empty<EditedFeatureResult>())
+                .Concat(other.EditedFeatureResults ?? Array.Empty<EditedFeatureResult>()).ToArray()
+        };
+    }
+}
 
 /// <summary>
 ///     FeatureEditResult represents the result of adding, updating or deleting a feature or an attachment.
@@ -1477,4 +1676,20 @@ public enum DrawingTool
     UpArrow,
     DownArrow
 #pragma warning restore CS1591
+}
+
+/// <summary>
+///     One-directional converter to just send the component Id to JS
+/// </summary>
+internal class GraphicToIdConverter: JsonConverter<Graphic>
+{
+    public override Graphic? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void Write(Utf8JsonWriter writer, Graphic value, JsonSerializerOptions options)
+    {
+        writer.WriteRawValue(value.Id.ToString());
+    }
 }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
@@ -1145,3 +1145,44 @@ export function buildDotNetAuthoringInfo(jsAuthoringInfo: AuthoringInfo): any {
     
     return dnAuthoringInfo;
 }
+
+export function buildDotNetEditsResult(jsResult: __esri.EditsResult): any {
+    let dnResult: any = {
+        addFeatureResults: jsResult.addFeatureResults,
+        deleteFeatureResults: jsResult.deleteFeatureResults,
+        updateFeatureResults: jsResult.updateFeatureResults,
+        addAttachmentResults: jsResult.addAttachmentResults,
+        updateAttachmentResults: jsResult.updateAttachmentResults,
+        deleteAttachmentResults: jsResult.deleteAttachmentResults
+    };
+    
+    if (hasValue(jsResult.editedFeatureResults)) {
+        dnResult.editedFeatureResults = jsResult.editedFeatureResults!.map(r =>{
+            let dnEditedFeatureResult: any = {
+                layerId: r.layerId
+            };
+            if (hasValue(r.editedFeatures.adds)) {
+                dnEditedFeatureResult.adds = r.editedFeatures.adds!.map(buildDotNetFeature);
+            }
+            if (hasValue(r.editedFeatures.deletes)) {
+                dnEditedFeatureResult.deletes = r.editedFeatures.deletes!.map(buildDotNetFeature);
+            }
+            if (hasValue(r.editedFeatures.updates)) {
+                dnEditedFeatureResult.updates = [];
+                for (let i = 0; i < r.editedFeatures.updates!.length; i++) {
+                    let jsFeature = r.editedFeatures.updates![i];
+                    dnEditedFeatureResult.updates.push({
+                        original: jsFeature.original?.map(buildDotNetFeature),
+                        current: jsFeature.current?.map(buildDotNetFeature)
+                    });
+                }
+            }
+            if (hasValue(r.editedFeatures.spatialReference)) {
+                dnEditedFeatureResult.spatialReference = buildDotNetSpatialReference(r.editedFeatures.spatialReference!);
+            }
+            
+            return dnEditedFeatureResult;
+        });
+    }
+    return dnResult;
+}

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -1618,7 +1618,7 @@ function buildJsFormInput(dotNetFormInput: any): any {
     return undefined;
 }
 
-function buildJsAttachmentEdit(dotNetAttachmentEdit: DotNetAttachmentsEdit, viewId: string): AttachmentEdit {
+export function buildJsAttachmentEdit(dotNetAttachmentEdit: DotNetAttachmentsEdit, viewId: string): AttachmentEdit {
     return {
         feature: buildJsGraphic(dotNetAttachmentEdit.feature, viewId)!,
         attachment: dotNetAttachmentEdit.attachment

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerTests.razor
@@ -96,7 +96,7 @@
     }
     
     [TestMethod]
-    public async Task TestCannotAddFeaturesWithAddMethodAfterRender(Action renderHandler)
+    public async Task TestCanAddFeaturesWithAddMethodAfterRender(Action renderHandler)
     {
         FeatureLayer? layer = null;
         AddMapRenderFragment(
@@ -111,7 +111,137 @@
         await WaitForMapToRender();
         await AssertJavaScript("assertLayerExists", args: "feature");
 
-        await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => layer!.Add(new Graphic(new Point(0, 0),
-            new SimpleMarkerSymbol(color: new MapColor("black")))));
+        await layer!.Add(new Graphic(new Point(0, 0),
+            new SimpleMarkerSymbol(color: new MapColor("black"))));
+        await WaitForMapToRender();
+        await AssertJavaScript("assertGraphicExistsInLayer", args: new object[] { layer!.Id, "point", 1 });
+    }
+    
+    [TestMethod]
+    public async Task TestCanAddManyFeaturesWithApplyEdits(Action renderHandler)
+    {
+        FeatureLayer? layer = null;
+        AddMapRenderFragment(
+            @<MapView class="map-view" OnViewRendered="renderHandler">
+                <Map ArcGISDefaultBasemap="topo-vector">
+                    <FeatureLayer @ref="layer" Source="@([])" 
+                                  GeometryType="GeometryType.Point"
+                                  ObjectIdField="OBJECT_ID">
+                    </FeatureLayer>
+                </Map>
+            </MapView>);
+        await WaitForMapToRender();
+        await AssertJavaScript("assertLayerExists", args: "feature");
+
+        List<Graphic> graphics = [];
+        Random random = new();
+        for (var i = 0; i < 2000; i++)
+        {
+            Point point = new Point(random.Next(-180, 180), random.Next(-80, 80));
+            Graphic graphic = new(point);
+            graphics.Add(graphic);
+        }
+        FeatureEdits edits = new()
+        {
+            AddFeatures = graphics
+        };
+        FeatureEditsResult result = await layer!.ApplyEdits(edits);
+        await WaitForMapToRender();
+        await AssertJavaScript("assertGraphicExistsInLayer", args: new object[] { layer!.Id, "point", 2000 });
+        Assert.AreEqual(2000, result.AddFeatureResults.Length);
+        Assert.AreEqual(2000, layer.Source!.Count);
+    }
+
+    [TestMethod]
+    public async Task TestCanUpdateManyFeaturesWithApplyEdits(Action renderHandler)
+    {
+        FeatureLayer? layer = null;
+        AddMapRenderFragment(
+            @<MapView class="map-view" OnViewRendered="renderHandler">
+                <Map ArcGISDefaultBasemap="topo-vector">
+                    <FeatureLayer @ref="layer" Source="@([])" 
+                                  GeometryType="GeometryType.Point"
+                                  ObjectIdField="OBJECT_ID">
+                    </FeatureLayer>
+                </Map>
+            </MapView>);
+        await WaitForMapToRender();
+        await AssertJavaScript("assertLayerExists", args: "feature");
+
+        List<Graphic> graphics = [];
+        Random random = new();
+        for (var i = 0; i < 2000; i++)
+        {
+            Point point = new Point(random.Next(-180, 180), random.Next(-80, 80));
+            Graphic graphic = new(point);
+            graphics.Add(graphic);
+        }
+        FeatureEdits edits = new()
+        {
+            AddFeatures = graphics
+        };
+        FeatureEditsResult result = await layer!.ApplyEdits(edits);
+        await WaitForMapToRender();
+        await AssertJavaScript("assertGraphicExistsInLayer", args: new object[] { layer!.Id, "point", 2000 });
+        Assert.AreEqual(2000, result.AddFeatureResults.Length);
+        
+        foreach (Graphic graphic in graphics)
+        {
+            ((Point)graphic.Geometry!).X += 1;
+            ((Point)graphic.Geometry!).Y += 1;
+        }
+        
+        edits = new()
+        {
+            UpdateFeatures = graphics
+        };
+        result = await layer!.ApplyEdits(edits);
+        await WaitForMapToRender();
+        await AssertJavaScript("assertGraphicExistsInLayer", args: new object[] { layer!.Id, "point", 2000 });
+        Assert.AreEqual(2000, result.UpdateFeatureResults.Length);
+    }
+
+    [TestMethod]
+    public async Task TestCanDeleteManyFeaturesWithApplyEdits(Action renderHandler)
+    {
+        FeatureLayer? layer = null;
+        AddMapRenderFragment(
+            @<MapView class="map-view" OnViewRendered="renderHandler">
+                <Map ArcGISDefaultBasemap="topo-vector">
+                    <FeatureLayer @ref="layer" Source="@([])" 
+                                  GeometryType="GeometryType.Point"
+                                  ObjectIdField="OBJECT_ID">
+                    </FeatureLayer>
+                </Map>
+            </MapView>);
+        await WaitForMapToRender();
+        await AssertJavaScript("assertLayerExists", args: "feature");
+
+        List<Graphic> graphics = [];
+        Random random = new();
+        for (var i = 0; i < 2000; i++)
+        {
+            Point point = new Point(random.Next(-180, 180), random.Next(-80, 80));
+            Graphic graphic = new(point);
+            graphics.Add(graphic);
+        }
+        FeatureEdits edits = new()
+        {
+            AddFeatures = graphics
+        };
+        FeatureEditsResult result = await layer!.ApplyEdits(edits);
+        await WaitForMapToRender();
+        await AssertJavaScript("assertGraphicExistsInLayer", args: new object[] { layer!.Id, "point", 2000 });
+        Assert.AreEqual(2000, result.AddFeatureResults.Length);
+        
+        edits = new()
+        {
+            DeleteFeatures = graphics
+        };
+        result = await layer!.ApplyEdits(edits);
+        await WaitForMapToRender();
+        await Assert.ThrowsExceptionAsync<JSException>(async() =>
+            await AssertJavaScript("assertGraphicExistsInLayer", args: new object[] { layer!.Id, "point", 2000 }));
+        Assert.AreEqual(2000, result.DeleteFeatureResults.Length);
     }
 }

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/dymaptic.GeoBlazor.Core.Test.Blazor.Shared.csproj
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/dymaptic.GeoBlazor.Core.Test.Blazor.Shared.csproj
@@ -25,13 +25,19 @@
         <AdditionalFiles Include="Components\WidgetTests.razor"/>
     </ItemGroup>
 
-    <ItemGroup Condition="$(Configuration) == 'DEBUG'">
-        <ProjectReference Include="..\..\src\dymaptic.GeoBlazor.Core\dymaptic.GeoBlazor.Core.csproj"/>
-    </ItemGroup>
-    <ItemGroup Condition="$(Configuration) == 'RELEASE'">
-        <PackageReference Include="dymaptic.GeoBlazor.Core"  Version="$(CoreVersion)" />
-    </ItemGroup>
-
-
-
+    <Choose>
+        <When Condition="$(Configuration) == 'RELEASE' AND '$(UsePackageReferences)' == 'true'">
+            <ItemGroup Condition="$(Configuration) == 'RELEASE'">
+                <PackageReference Include="dymaptic.GeoBlazor.Core"  Version="$(CoreVersion)" />
+            </ItemGroup>
+        </When>
+        <Otherwise>
+            <ItemGroup Condition="$(Configuration) == 'DEBUG'">
+                <ProjectReference Include="..\..\src\dymaptic.GeoBlazor.Core\dymaptic.GeoBlazor.Core.csproj"/>
+            </ItemGroup>
+        </Otherwise>
+    </Choose>
+    
+    
+    
 </Project>


### PR DESCRIPTION
Closes #281 

- Implemented chunking and protobuf serialization of graphics in `FeatureLayer.ApplyEdits`
- Wrote unit tests for `ApplyEdits`
- Also re-implemented `FeatureLayer.Add` so that it uses `ApplyEdits` if the layer is already rendered.