### PR TITLE
Graphics Legend Widget

### DIFF
--- a/src/dymaptic.GeoBlazor.Core/Components/ActionBase.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/ActionBase.cs
@@ -45,13 +45,6 @@ public abstract class ActionBase : MapComponent
     public bool? Disabled { get; set; }
 
     /// <summary>
-    ///     Indicates if the action is visible.
-    /// </summary>
-    [Parameter]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public bool? Visible { get; set; }
-
-    /// <summary>
     ///     The action function to perform on click.
     /// </summary>
     [Parameter]

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/Graphic.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/Graphic.cs
@@ -43,8 +43,11 @@ public class Graphic : LayerObject
     /// <param name="visible">
     ///     Indicates the visibility of the graphic.
     /// </param>
+    /// <param name="legendLabel">
+    ///     Optional label override for this graphic in the GeoBlazor Pro GraphicsLegendWidget.
+    /// </param>
     public Graphic(Geometry? geometry = null, Symbol? symbol = null, PopupTemplate? popupTemplate = null,
-        AttributesDictionary? attributes = null, bool? visible = null)
+        AttributesDictionary? attributes = null, bool? visible = null, string? legendLabel = null)
     {
         AllowRender = false;
 #pragma warning disable BL0005
@@ -52,6 +55,7 @@ public class Graphic : LayerObject
         Symbol = symbol;
         PopupTemplate = popupTemplate;
         Visible = visible;
+        LegendLabel = legendLabel;
 
         if (attributes is not null)
         {
@@ -74,11 +78,12 @@ public class Graphic : LayerObject
     public AttributesDictionary Attributes { get; set; } = new();
     
     /// <summary>
-    ///     Indicates the visibility of the graphic. Default value: true.
+    ///     Legend label override for this graphic in the GeoBlazor Pro Graphics Legend Widget.
+    ///     Supports attribute substitution using the syntax {attributeName}.
     /// </summary>
     [Parameter]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public bool? Visible { get; set; }
+    [JsonIgnore]
+    public string? LegendLabel { get; set; }
 
     /// <summary>
     ///     The geometry that defines the graphic's location.

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/Layer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/Layer.cs
@@ -58,14 +58,6 @@ public abstract class Layer : MapComponent
     public ListMode? ListMode { get; set; }
 
     /// <summary>
-    ///     Indicates if the layer is visible in the View. When false, the layer may still be added to a Map instance that is
-    ///     referenced in a view, but its features will not be visible in the view.
-    /// </summary>
-    [Parameter]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public bool? Visible { get; set; }
-
-    /// <summary>
     ///     The full extent of the layer. By default, this is worldwide. This property may be used to set the extent of the
     ///     view to match a layer's extent so that its features appear to fill the view.
     /// </summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/MapComponent.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/MapComponent.razor.cs
@@ -66,6 +66,13 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable
     [CascadingParameter(Name = "View")]
     [JsonIgnore]
     public MapView? View { get; set; }
+    
+    /// <summary>
+    ///     Indicates the visibility of the component. Default value: true.
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Visible { get; set; }
 
     /// <summary>
     ///     A unique identifier, used to track components across .NET and JavaScript.
@@ -221,6 +228,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable
     public async Task SetVisibility(bool visible)
     {
         await JsModule!.InvokeVoidAsync("setVisibility", CancellationTokenSource.Token, Id, visible);
+        Visible = visible;
     }
 
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldInfo.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldInfo.cs
@@ -86,13 +86,6 @@ public class FieldInfo : MapComponent
     public string? Tooltip { get; set; } = string.Empty;
 
     /// <summary>
-    ///     Indicates whether the field is visible in the popup window.
-    /// </summary>
-    [Parameter]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public bool? Visible { get; set; }
-
-    /// <summary>
     ///     A string determining what type of input box editors see when editing the field.
     /// </summary>
     [Parameter]

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -2776,6 +2776,13 @@ export function setVisibility(componentId: string, visible: boolean): void {
     let component: any | undefined = arcGisObjectRefs[componentId];
     if (component !== undefined) {
         component.visible = visible;
+        return;
+    }
+    // check graphics too
+    let graphic = graphicsRefs[componentId];
+    if (graphic !== undefined) {
+        graphic.visible = visible;
+        return;
     }
 }
 


### PR DESCRIPTION
- Support for GeoBlazor Pro Issue 91, `GraphicsLegendWidget`
- Consolidates `Visible` as a property on `MapComponent`, and removes from some inherited classes.