### PR TITLE
Version/3 Reverse order of layers to match expected results

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <CoreVersion>2.5.3</CoreVersion>
+        <CoreVersion>3.0.0-beta-1</CoreVersion>
     </PropertyGroup>
 </Project>

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -364,13 +364,16 @@ export async function buildMapView(id: string, dotNetReference: any, long: numbe
         }
 
         if (hasValue(mapObject.layers)) {
-            for (const layerObject of mapObject.layers) {
+            // add layers in reverse order to match the expected order in the map
+            for (let i = mapObject.layers.length - 1; i >= 0; i--) {
+                const layerObject = mapObject.layers[i];
                 await addLayer(layerObject, id);
             }
         }
 
-        for (const l of basemapLayers) {
-            await addLayer(l, id, true);
+        for (let i = basemapLayers.length - 1; i >= 0; i--) {
+            const layerObject = basemapLayers[i];
+            await addLayer(layerObject, id, true);
         }
 
         for (const widget of widgets.filter(w => w.type !== 'popup')) {

--- a/templates/content/dymaptic.GeoBlazor.Template.Maui/dymaptic.GeoBlazor.Template.Maui.csproj
+++ b/templates/content/dymaptic.GeoBlazor.Template.Maui/dymaptic.GeoBlazor.Template.Maui.csproj
@@ -81,7 +81,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="dymaptic.GeoBlazor.Core" Version="2.5.3" />
+		<PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.0-beta-1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />

--- a/templates/content/dymaptic.GeoBlazor.Template.Server/dymaptic.GeoBlazor.Template.Server.csproj
+++ b/templates/content/dymaptic.GeoBlazor.Template.Server/dymaptic.GeoBlazor.Template.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dymaptic.GeoBlazor.Core" Version="2.5.3" />
+    <PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.0-beta-1" />
   </ItemGroup>
 
 </Project>

--- a/templates/content/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp.Client/dymaptic.GeoBlazor.Template.WebApp.Client.csproj
+++ b/templates/content/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp.Client/dymaptic.GeoBlazor.Template.WebApp.Client.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dymaptic.GeoBlazor.Core" Version="2.5.3" />
+    <PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.0-beta-1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
   </ItemGroup>
 

--- a/templates/content/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp.csproj
+++ b/templates/content/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\dymaptic.GeoBlazor.Template.WebApp.Client\dymaptic.GeoBlazor.Template.WebApp.Client.csproj" />
-		<PackageReference Include="dymaptic.GeoBlazor.Core" Version="2.5.3" />
+		<PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.0-beta-1" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.0" />
 	</ItemGroup>
 

--- a/templates/content/dymaptic.GeoBlazor.Template.WebAssembly/dymaptic.GeoBlazor.Template.WebAssembly.csproj
+++ b/templates/content/dymaptic.GeoBlazor.Template.WebAssembly/dymaptic.GeoBlazor.Template.WebAssembly.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dymaptic.GeoBlazor.Core" Version="2.5.3" />
+    <PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.0-beta-1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>

--- a/templates/dymaptic.GeoBlazor.Templates.csproj
+++ b/templates/dymaptic.GeoBlazor.Templates.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<PackageId>dymaptic.GeoBlazor.Templates</PackageId>
 		<Title>GeoBlazor Project Templates</Title>
-		<PackageVersion>2.5.3</PackageVersion>
+		<PackageVersion>3.0.0-beta-1</PackageVersion>
 		<Version>2.5.2</Version>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<Company>dymaptic</Company>


### PR DESCRIPTION
Based on an internal discussion, we realized that, currently, if you add layers in GeoBlazor markup, like:

```html
<Map>
    <FeatureLayer Title="Layer 1" />
    <FeatureLayer Title="Layer 2" />
    <FeatureLayer Title="Layer 3" />
    <FeatureLayer Title="Layer 4" />
</Map>
```

these layers will be added to ArcGIS in such a way as they will show in the `LayerListWidget` in reverse order, and more importantly, that Layer 4 will be layered "on top".

This breaks the visual expectation of the markup layout. However, _changing_ the behavior will break anyone who has already implemented stacked layers, so I will also create a dedicated page or section in the docs to explain how it works, and we need to make sure to highlight it in the release notes of V3.