### PR TITLE
Version/3 Basemap Styles

### DIFF
--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Basemaps.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Basemaps.razor
@@ -9,12 +9,21 @@
 <div class="flex-column">
     <div class="toggle-row">
         <label class="radio-container">
-            From Static Default
+            From Style
             <input type="radio" checked
                    name="basemap-type" @onclick="@(() => SetBasemap(0))" />
             <div class="radio-box" />
         </label>
-        <a class="btn btn-primary" target="_blank" href="https://www.arcgis.com/home/item.html?id=67372ff42cd145319639a99152b15bc3">Topographic BaseMap</a>
+        @if (_basemapType == 0)
+        {
+            <select @onchange="SelectStyleMapChanged">
+                @foreach (BasemapStyleName style in Enum.GetValues(typeof(BasemapStyleName)))
+                {
+                    <option value="@style">@style</option>
+                }
+            </select>
+        }
+        <a class="btn btn-primary" target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-support-BasemapStyle.html">Basemap Style Service</a>
     </div>
     <div class="toggle-row">
         <label class="radio-container">
@@ -23,23 +32,23 @@
                    name="basemap-type" @onclick="@(() => SetBasemap(1))" />
             <div class="radio-box" />
         </label>
-        <a class="btn btn-primary" target="_blank" href="https://www.arcgis.com/home/group.html?id=702026e41f6641fb85da88efe79dc166&view=list#content">ArcGIS Online BaseMaps</a>
+        @if (_basemapType == 1)
+        {
+            <select @onchange="SelectPortalMapChanged">
+                <option value="55ebf90799fa4a3fa57562700a68c405">Default-Street</option>
+                <option value="da10cf4ba254469caf8016cd66369157">Satellite</option>
+                <option value="86265e5a4bbb4187a59719cf134e0018">Hybrid</option>
+                <option value="f33a34de3a294590ab48f246e99958c9">National Geographic</option>
+                <option value="67372ff42cd145319639a99152b15bc3">Topographic</option>
+                <option value="979c6cc89af9449cbeb5342a439c6a76">Gray</option>
+                <option value="1a386c5dfd864bfda3f03ab428e57640">Dark Gray</option>
+                <option value="fae788aa91e54244b161b59725dcbb2a">Open Street Map</option>
+                <option value="9053b6cd38d54e65bb0967f355a232df">Streets Night</option>
+                <option value="c50de463235e4161b206d000587af18b">Streets Navigation</option>
+            </select>
+        }
+        <a class="btn btn-primary" target="_blank" href="https://www.arcgis.com/home/group.html?id=702026e41f6641fb85da88efe79dc166&view=list#content">ArcGIS Online Basemaps</a>
     </div>
-    @if (_basemapType == 1)
-    {
-        <select @onchange="SelectMapChanged">
-            <option value="55ebf90799fa4a3fa57562700a68c405">Default-Street</option>
-            <option value="da10cf4ba254469caf8016cd66369157">Satellite</option>
-            <option value="86265e5a4bbb4187a59719cf134e0018">Hybrid</option>
-            <option value="f33a34de3a294590ab48f246e99958c9">National Geographic</option>
-            <option value="67372ff42cd145319639a99152b15bc3">Topographic</option>
-            <option value="979c6cc89af9449cbeb5342a439c6a76">Gray</option>
-            <option value="1a386c5dfd864bfda3f03ab428e57640">Dark Gray</option>
-            <option value="fae788aa91e54244b161b59725dcbb2a">Open Street Map</option>
-            <option value="9053b6cd38d54e65bb0967f355a232df">Streets Night</option>
-            <option value="c50de463235e4161b206d000587af18b">Streets Navigation</option>
-        </select>
-    }
     <div class="toggle-row">
         <label class="radio-container">
             From Tile Layers
@@ -55,8 +64,12 @@
 @switch (_basemapType)
 {
     case 0:
-        <MapView Class="map-view" Zoom="11" Latitude="_latitude" Longitude="_longitude">
-            <Map ArcGISDefaultBasemap="arcgis-topographic" />
+        <MapView @ref="_mapView1" Class="map-view" Zoom="11" Latitude="_latitude" Longitude="_longitude">
+            <Map>
+                <Basemap>
+                    <BasemapStyle Name="_basemapStyleName" />
+                </Basemap>
+            </Map>
         </MapView>
         break;
     case 1:
@@ -90,19 +103,25 @@
     {
         _basemapType = val;
     }
-
-    private void SelectMapChanged(ChangeEventArgs obj)
+    
+    private void SelectStyleMapChanged(ChangeEventArgs obj)
     {
-        _basemapId = obj.Value?.ToString() ?? "55ebf90799fa4a3fa57562700a68c405";
-        _mapView2!.Refresh();
+        _basemapStyleName = (BasemapStyleName)Enum.Parse(typeof(BasemapStyleName), obj.Value!.ToString()!);
+        _mapView1?.Refresh();
     }
 
+    private void SelectPortalMapChanged(ChangeEventArgs obj)
+    {
+        _basemapId = obj.Value?.ToString() ?? "55ebf90799fa4a3fa57562700a68c405";
+        _mapView2?.Refresh();
+    }
+
+    private MapView? _mapView1;
     private MapView? _mapView2;
     private int _basemapType;
     private readonly double _latitude = 34.027;
     private readonly double _longitude = -118.805;
     private string _basemapId = "55ebf90799fa4a3fa57562700a68c405";
-
-
+    private BasemapStyleName _basemapStyleName = BasemapStyleName.ArcgisNova;
 
 }

--- a/src/dymaptic.GeoBlazor.Core/Components/Basemap.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Basemap.cs
@@ -1,4 +1,9 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Layers;
+using Microsoft.AspNetCore.Components;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 
 namespace dymaptic.GeoBlazor.Core.Components;
@@ -20,6 +25,18 @@ public class Basemap : MapComponent
     ///     A collection of tile layers that make of the basemap's features.
     /// </summary>
     public HashSet<Layer> Layers { get; set; } = new();
+    
+    /// <summary>
+    ///     The style of the basemap from the basemap styles service (v2). The basemap styles service is a ready-to-use location service that serves vector and image tiles representing geographic features around the world.
+    ///     You can use the service to display:
+    ///          - Streets and navigation styles
+    ///          - Imagery, oceanic, and topographic styles
+    ///          - OSM standard and streets styles
+    ///          - Creative styles such as nova and blue print
+    ///          - Localized place labels
+    ///     Use of the basemap style service requires authentication via an API key or user authentication. To learn more about API keys, see the API keys section in the ArcGIS Developer documentation.
+    /// </summary>
+    public BasemapStyle? Style { get; set; }
 
     /// <inheritdoc />
     public override async Task RegisterChildComponent(MapComponent child)
@@ -35,6 +52,13 @@ public class Basemap : MapComponent
                 break;
             case Layer layer:
                 await View!.AddLayer(layer, true);
+
+                break;
+            case BasemapStyle style:
+                if (!style.Equals(Style))
+                {
+                    Style = style;
+                }
 
                 break;
             default:
@@ -57,6 +81,10 @@ public class Basemap : MapComponent
                 await View!.RemoveLayer(layer, true);
 
                 break;
+            case BasemapStyle:
+                Style = null;
+
+                break;
             default:
                 await base.UnregisterChildComponent(child);
 
@@ -69,10 +97,187 @@ public class Basemap : MapComponent
     {
         base.ValidateRequiredChildren();
         PortalItem?.ValidateRequiredChildren();
+        Style?.ValidateRequiredChildren();
 
         foreach (Layer layer in Layers)
         {
             layer.ValidateRequiredChildren();
         }
+    }
+}
+
+/// <summary>
+///     The style of the basemap from the basemap styles service (v2). The basemap styles service is a ready-to-use location service that serves vector and image tiles representing geographic features around the world.
+///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-support-BasemapStyle.html">ArcGIS Maps SDK for JavaScript</a>
+/// </summary>
+public class BasemapStyle : MapComponent
+{
+    [Parameter]
+    [EditorRequired]
+    [RequiredProperty]
+    public BasemapStyleName Name { get; set; }
+    
+    /// <summary>
+    ///     The language of the place labels in the basemap style. Choose from a variety of supported languages, including global and local.
+    ///     If not set, the app's current locale is used. If the app's locale is not supported by the service, the language will fall back to "global".
+    ///     <a target="_blank" href="https://developers.arcgis.com/rest/basemap-styles/#languages">ArcGIS REST APIs</a>
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Language { get; set; }
+    
+    /// <summary>
+    ///     The URL to the basemap styles service.
+    ///     Default Value:"https://basemapstyles-api.arcgis.com/arcgis/rest/services/styles/v2/webmaps"
+    /// </summary>
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ServiceUrl { get; set; }
+}
+
+/// <summary>
+///     All styles available from the ArcGIS Basemap Styles service.
+///     <a target="_blank" href="https://developers.arcgis.com/rest/basemap-styles/">ArcGIS REST APIs</a>
+/// </summary>
+[JsonConverter(typeof(EnumMemberConverter<BasemapStyleName>))]
+public enum BasemapStyleName
+{
+#pragma warning disable 1591
+    [EnumMember(Value = "arcgis/imagery")]
+    ArcgisImagery,
+    [EnumMember(Value = "arcgis/imagery/standard")]
+    ArcgisImageryStandard,
+    [EnumMember(Value = "arcgis/imagery/labels")]
+    ArcgisImageryLabels,
+    [EnumMember(Value = "arcgis/light-gray")]
+    ArcgisLightGray,
+    [EnumMember(Value = "arcgis/light-gray/base")]
+    ArcgisLightGrayBase,
+    [EnumMember(Value = "arcgis/light-gray/labels")]
+    ArcgisLightGrayLabels,
+    [EnumMember(Value = "arcgis/dark-gray")]
+    ArcgisDarkGray,
+    [EnumMember(Value = "arcgis/dark-gray/base")]
+    ArcgisDarkGrayBase,
+    [EnumMember(Value = "arcgis/dark-gray/labels")]
+    ArcgisDarkGrayLabels,
+    [EnumMember(Value = "arcgis/navigation")]
+    ArcgisNavigation,
+    [EnumMember(Value = "arcgis/navigation-night")]
+    ArcgisNavigationNight,
+    [EnumMember(Value = "arcgis/streets")]
+    ArcgisStreets,
+    [EnumMember(Value = "arcgis/streets-night")]
+    ArcgisStreetsNight,
+    [EnumMember(Value = "arcgis/streets-relief")]
+    ArcgisStreetsRelief,
+    [EnumMember(Value = "arcgis/streets-relief/base")]
+    ArcgisStreetsReliefBase,
+    [EnumMember(Value = "arcgis/topographic")]
+    ArcgisTopographic,
+    [EnumMember(Value = "arcgis/topographic/base")]
+    ArcgisTopographicBase,
+    [EnumMember(Value = "arcgis/oceans")]
+    ArcgisOceans,
+    [EnumMember(Value = "arcgis/oceans/base")]
+    ArcgisOceansBase,
+    [EnumMember(Value = "arcgis/oceans/labels")]
+    ArcgisOceansLabels,
+    [EnumMember(Value = "arcgis/terrain")]
+    ArcgisTerrain,
+    [EnumMember(Value = "arcgis/terrain/base")]
+    ArcgisTerrainBase,
+    [EnumMember(Value = "arcgis/terrain/detail")]
+    ArcgisTerrainDetail,
+    [EnumMember(Value = "arcgis/community")]
+    ArcgisCommunity,
+    [EnumMember(Value = "arcgis/charted-territory")]
+    ArcgisChartedTerritory,
+    [EnumMember(Value = "arcgis/charted-territory/base")]
+    ArcgisChartedTerritoryBase,
+    [EnumMember(Value = "arcgis/colored-pencil")]
+    ArcgisColoredPencil,
+    [EnumMember(Value = "arcgis/nova")]
+    ArcgisNova,
+    [EnumMember(Value = "arcgis/modern-antique")]
+    ArcgisModernAntique,
+    [EnumMember(Value = "arcgis/modern-antique/base")]
+    ArcgisModernAntiqueBase,
+    [EnumMember(Value = "arcgis/midcentury")]
+    ArcgisMidcentury,
+    [EnumMember(Value = "arcgis/newspaper")]
+    ArcgisNewspaper,
+    [EnumMember(Value = "arcgis/hillshade/light")]
+    ArcgisHillshadeLight,
+    [EnumMember(Value = "arcgis/hillshade/dark")]
+    ArcgisHillshadeDark,
+    [EnumMember(Value = "arcgis/human-geography")]
+    ArcgisHumanGeography,
+    [EnumMember(Value = "arcgis/human-geography/base")]
+    ArcgisHumanGeographyBase,
+    [EnumMember(Value = "arcgis/human-geography/detail")]
+    ArcgisHumanGeographyDetail,
+    [EnumMember(Value = "arcgis/human-geography/labels")]
+    ArcgisHumanGeographyLabels,
+    [EnumMember(Value = "arcgis/human-geography-dark")]
+    ArcgisHumanGeographyDark,
+    [EnumMember(Value = "arcgis/human-geography-dark/base")]
+    ArcgisHumanGeographyDarkBase,
+    [EnumMember(Value = "arcgis/human-geography-dark/detail")]
+    ArcgisHumanGeographyDarkDetail,
+    [EnumMember(Value = "arcgis/human-geography-dark/labels")]
+    ArcgisHumanGeographyDarkLabels,
+    [EnumMember(Value = "arcgis/outdoor")]
+    ArcgisOutdoor,
+    [EnumMember(Value = "osm/standard")]
+    OsmStandard,
+    [EnumMember(Value = "osm/standard-relief")]
+    OsmStandardRelief,
+    [EnumMember(Value = "osm/standard-relief/base")]
+    OsmStandardReliefBase,
+    [EnumMember(Value = "osm/streets")]
+    OsmStreets,
+    [EnumMember(Value = "osm/streets-relief")]
+    OsmStreetsRelief,
+    [EnumMember(Value = "osm/streets-relief/base")]
+    OsmStreetsReliefBase,
+    [EnumMember(Value = "osm/light-gray")]
+    OsmLightGray,
+    [EnumMember(Value = "osm/light-gray/base")]
+    OsmLightGrayBase,
+    [EnumMember(Value = "osm/light-gray/labels")]
+    OsmLightGrayLabels,
+    [EnumMember(Value = "osm/dark-gray")]
+    OsmDarkGray,
+    [EnumMember(Value = "osm/dark-gray/base")]
+    OsmDarkGrayBase,
+    [EnumMember(Value = "osm/dark-gray/labels")]
+    OsmDarkGrayLabels,
+    [EnumMember(Value = "osm/blueprint")]
+    OsmBlueprint,
+    [EnumMember(Value = "osm/hybrid")]
+    OsmHybrid,
+    [EnumMember(Value = "osm/hybrid/detail")]
+    OsmHybridDetail,
+    [EnumMember(Value = "osm/navigation")]
+    OsmNavigation,
+    [EnumMember(Value = "osm/navigation-dark")]
+    OsmNavigationDark
+#pragma warning restore 1591
+}
+
+internal class EnumMemberConverter<T> : JsonConverter<T> where T: struct, IConvertible
+{
+    public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    {
+        string attrVal = value.GetType()
+            .GetField(value.ToString()!)!
+            .GetCustomAttribute<EnumMemberAttribute>()!.Value!;
+        writer.WriteRawValue($"\"{attrVal}\"");
     }
 }

--- a/src/dymaptic.GeoBlazor.Core/Components/Map.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Map.cs
@@ -20,6 +20,7 @@ public class Map : MapComponent
     ///     Either <see cref="ArcGISDefaultBasemap" /> or <see cref="Basemap" /> should be set, but not both.
     /// </remarks>
     [Parameter]
+    [Obsolete("Define a Basemap with a BasemapStyle component instead.")]
     public string? ArcGISDefaultBasemap { get; set; }
 
     /// <summary>
@@ -31,9 +32,6 @@ public class Map : MapComponent
     /// <summary>
     ///     The <see cref="Basemap" /> for this map.
     /// </summary>
-    /// <remarks>
-    ///     Either <see cref="ArcGISDefaultBasemap" /> or <see cref="Basemap" /> should be set, but not both.
-    /// </remarks>
     public Basemap? Basemap { get; set; }
 
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/WebMap.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/WebMap.cs
@@ -16,7 +16,9 @@ public class WebMap : Map
     /// <summary>
     ///     The portal item from which the WebMap is loaded.
     /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete
     [RequiredProperty(nameof(Basemap), nameof(ArcGISDefaultBasemap))]
+#pragma warning restore CS0618 // Type or member is obsolete
     [RequiredProperty] // the extra required here is for WebMap only, whereas the previous allows a check against the Map base type
     public PortalItem? PortalItem { get; set; }
 

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -151,6 +151,7 @@ import FlowRenderer from "@arcgis/core/renderers/FlowRenderer";
 import UniqueValueRenderer from "@arcgis/core/renderers/UniqueValueRenderer.js";
 import ClassBreaksRenderer from "@arcgis/core/renderers/ClassBreaksRenderer.js";
 import MultidimensionalSubset from "@arcgis/core/layers/support/MultidimensionalSubset";
+import BasemapStyle from "@arcgis/core/support/BasemapStyle";
 
 
 export let arcGisObjectRefs: Record<string, Accessor> = {};
@@ -274,6 +275,17 @@ export async function buildMapView(id: string, dotNetReference: any, long: numbe
             if (mapObject.arcGISDefaultBasemap !== undefined &&
                 mapObject.arcGISDefaultBasemap !== null) {
                 basemap = mapObject.arcGISDefaultBasemap;
+            } else if (hasValue(mapObject.basemap?.style)) {
+                let style = new BasemapStyle({
+                    id: mapObject.basemap.style.name
+                });
+                if (hasValue(mapObject.basemap.style.language)) {
+                    style.language = mapObject.basemap.style.language
+                }
+                if (hasValue(mapObject.basemap.style.serviceUrl)) {
+                    style.serviceUrl = mapObject.basemap.style.serviceUrl;
+                }
+                basemap = new Basemap({ style: style })
             } else if (hasValue(mapObject.basemap?.portalItem?.id)) {
                 let portalItem = buildJsPortalItem(mapObject.basemap.portalItem);
                 basemap = new Basemap({ portalItem: portalItem });


### PR DESCRIPTION
ArcGIS has updated how they define basemaps. They have a new basemap rest service https://developers.arcgis.com/rest/basemap-styles/ that defines the "default" basemaps hosted by Esri with the following JS code:

```js
basemap: {
    style: {
        id: "arcgis/topographic"
    }
}
```

This looks like it will eventually replace being able to set `view.map.basemap` directly to a string value, and the old strings are marked as `legacy` here https://developers.arcgis.com/javascript/latest/api-reference/esri-Map.html#basemap.

To keep up with ArcGIS, and actually make discoverability simpler in GeoBlazor, I'm creating an `enum` that has the entire list of style `id`s. I chose to call them `Name` in GeoBlazor, since that seems to make more sense for a string/enum.

Here is the implementation in GeoBlazor:

```html
<MapView>
    <Map>
        <Basemap>
            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
        </Basemap>
    </Map>
</MapView>
```

I have also
- Marked `Map.ArcGISDefaultBasemap` as `Obsolete`, but not deleting, for a smoother transition.
- Updated the `Basemaps` sample to allow users to test out the new styles enum with a select dropdown.