### PR TITLE
protobuf serialization fixes

### DIFF
--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/Graphic.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/Graphic.cs
@@ -315,7 +315,7 @@ public class Graphic : LayerObject
                 Geometry?.ToSerializationRecord(),
                 Symbol?.ToSerializationRecord(),
                 PopupTemplate?.ToSerializationRecord(),
-                Attributes?.ToSerializationRecord());
+                Attributes.ToSerializationRecord());
         }
 
         return _serializationRecord;

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleFillSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleFillSymbol.cs
@@ -107,7 +107,8 @@ public class SimpleFillSymbol : FillSymbol
     {
         return new SymbolSerializationRecord(Type, Color)
         {
-            Outline = Outline?.ToSerializationRecord(), Style = FillStyle?.ToString().ToKebabCase()
+            Outline = Outline?.ToSerializationRecord(), 
+            Style = FillStyle?.ToString().ToKebabCase()
         };
     }
 }

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleLineSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleLineSymbol.cs
@@ -59,7 +59,8 @@ public class SimpleLineSymbol : LineSymbol
     {
         return new SymbolSerializationRecord(Type, Color)
         {
-            Width = Width, LineStyle = LineStyle?.ToString().ToKebabCase()
+            Width = Width, 
+            Style = LineStyle?.ToString().ToKebabCase()
         };
     }
 }

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/TextSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/TextSymbol.cs
@@ -302,6 +302,10 @@ public class TextSymbol : Symbol
 
     internal override SymbolSerializationRecord ToSerializationRecord()
     {
+        double.TryParse(XOffset?.Replace("px", "").Replace("pt", ""),
+            out double xOffsetNum);
+        double.TryParse(YOffset?.Replace("px", "").Replace("pt", "")
+            , out double yOffsetNum);
         return new SymbolSerializationRecord(Type, Color)
         {
             Text = Text, 
@@ -312,12 +316,14 @@ public class TextSymbol : Symbol
             BackgroundColor = BackgroundColor,
             BorderLineSize = BorderLineSize,
             BorderLineColor = BorderLineColor,
-            HorizontalAlignment = HorizontalAlignment?.ToString(),
+            HorizontalAlignment = HorizontalAlignment?.ToString().ToKebabCase(),
             Kerning = Kerning,
             LineHeight = LineHeight,
             LineWidth = LineWidth,
             Rotated = Rotated,
-            VerticalAlignment = VerticalAlignment?.ToString()
+            VerticalAlignment = VerticalAlignment?.ToString().ToKebabCase(),
+            XOffset = xOffsetNum,
+            YOffset = yOffsetNum
         };
     }
 }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
@@ -112,6 +112,7 @@ export interface DotNetSimpleLineSymbol extends DotNetSymbol {
     miterLimit: number;
     style: string;
     width: number;
+    lineStyle: string;
 }
 
 export interface DotNetPictureMarkerSymbol extends DotNetSymbol {

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -420,7 +420,7 @@ export function buildJsSymbol(symbol: DotNetSymbol | null): Symbol | null {
                 join: dnSimpleLineSymbol.join as any ?? "round",
                 marker: dnSimpleLineSymbol.marker as any ?? null,
                 miterLimit: dnSimpleLineSymbol.miterLimit ?? 2,
-                style: dnSimpleLineSymbol.style as any ?? "solid",
+                style: dnSimpleLineSymbol.lineStyle as any ?? dnSimpleLineSymbol.style as any ?? "solid",
                 width: dnSimpleLineSymbol.width ?? 0.75
             });
         case "picture-marker":


### PR DESCRIPTION
Closes #295 

- Enums serialized to Protobuf need to be run through `ToKebabCase`, which was missed for `TextSymbol.HorizontalAlignment` and `TextSymbol.VerticalAlignment`
- XOffset and YOffset in `TextSymbol` were not serialized via Protobuf
- `SimpleLineSymbol.LineStyle` was not correctly setting `style` in JS.