### PR TITLE
fix: implement graphic ID assignment based on presence in graphicsRefs

### DIFF
--- a/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
@@ -127,9 +127,9 @@ import DirectionsFeatureSet from "@arcgis/core/rest/support/DirectionsFeatureSet
 export function buildDotNetGraphic(graphic: Graphic): DotNetGraphic {
     let dotNetGraphic = {} as DotNetGraphic;
 
-    if (Object.values(arcGisObjectRefs).includes(graphic)) {
-        for (const k of Object.keys(arcGisObjectRefs)) {
-            if (arcGisObjectRefs[k] === graphic) {
+    if (Object.values(graphicsRefs).includes(graphic)) {
+        for (const k of Object.keys(graphicsRefs)) {
+            if (graphicsRefs[k] === graphic) {
                 dotNetGraphic.id = k;
                 break;
             }

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/GraphicsTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/GraphicsTests.razor
@@ -7,24 +7,67 @@
 @code {
 
     [TestMethod]
+    public async Task TestGraphicIdRemainsConsistentAfterOperations(Action renderHandler)
+    {
+        MapView? mapView = null;
+        Graphic? graphic = null;
+        GraphicsLayer? graphicsLayer = null;
+
+        AddMapRenderFragment(
+    @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
+        <Map ArcGISDefaultBasemap="arcgis-imagery">
+            <GraphicsLayer @ref="graphicsLayer">
+                <Graphic @ref="graphic">
+                    <Point X="0" Y="0" />
+                </Graphic>
+            </GraphicsLayer>
+        </Map>
+    </MapView>
+    );
+
+        await WaitForMapToRender();
+
+        var hitTestOptions = new HitTestOptions()
+        {
+            IncludeLayersByArcGISId = new string[] { graphicsLayer!.Id.ToString() }
+        };
+
+        var hitTestResult = await mapView!.HitTest((Point)graphic!.Geometry!, hitTestOptions);
+
+        var graphicHit = hitTestResult.Results.OfType<GraphicHit>().ToArray();
+
+        Assert.AreEqual(1, graphicHit.Count());
+
+        var firstGraphic = graphicHit[0];
+
+        Assert.IsNotNull(firstGraphic.Layer);
+        Assert.IsNotNull(firstGraphic.MapPoint);
+        Assert.IsNotNull(firstGraphic.Graphic);
+
+
+        Assert.AreEqual<Guid>(graphic.Id, firstGraphic.Graphic.Id);
+    }
+
+    [TestMethod]
     public async Task TestCanDeleteGraphicWithNewGeometry(Action renderHandler)
     {
         MapView? mapView = null;
-        AddMapRenderFragment( 
-            @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-            </MapView>);
+        AddMapRenderFragment(
+    @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
+        <Map ArcGISDefaultBasemap="arcgis-imagery" />
+    </MapView>);
 
         await WaitForMapToRender();
 
         var testGraphic = new Graphic(new Point(0, 0),
-            new SimpleMarkerSymbol(color: new MapColor("red"), size: 10));
+        new SimpleMarkerSymbol(color: new MapColor("red"), size: 10));
         await mapView!.AddGraphic(testGraphic);
         await WaitForMapToRender();
         await testGraphic.SetGeometry(new Point(1, 1));
         await WaitForMapToRender();
         await mapView.RemoveGraphic(testGraphic);
     }
+
 
     [TestMethod]
     public async Task TestGraphicsAddedViaMarkupAreOnlyAddedOnce(Action renderHandler)


### PR DESCRIPTION
Fixes #303 

To address this, we've implemented a fix to maintain the consistency of graphic IDs after operations like rendering, adding, or removing graphics. The provided test method, TestGraphicIdRemainsConsistentAfterOperations, ensures that the graphic ID remains the same before and after map operations. It does so by performing a hit test and verifying that the ID of a graphic, before and after the operation, matches as expected.

Edit: Adding @adrien426, the one that wrote the code 😉