### PR TITLE
Fix OBJECT_ID Errors in FeatureLayer Tests

### DIFF
--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerTests.razor
@@ -149,6 +149,8 @@
         await WaitForMapToRender();
         await AssertJavaScript("assertGraphicExistsInLayer", args: new object[] { layer!.Id, "point", 2000 });
         Assert.AreEqual(2000, result.AddFeatureResults.Length);
+        Assert.IsTrue(result.AddFeatureResults.All(f => f.Error is null));
+        Assert.IsTrue(result.AddFeatureResults.All(f => f.ObjectId.HasValue));
         Assert.AreEqual(2000, layer.Source!.Count);
     }
 
@@ -191,14 +193,22 @@
             ((Point)graphic.Geometry!).Y += 1;
         }
         
+        FeatureSet? features = await layer.QueryFeatures();
+        Assert.IsNotNull(features);
+        Assert.IsNotNull(features.Features);
+        Assert.AreEqual(2000, features.Features.Length);
+
         edits = new()
         {
-            UpdateFeatures = graphics
+            UpdateFeatures = features.Features.ToArray()
         };
+
         result = await layer!.ApplyEdits(edits);
         await WaitForMapToRender();
         await AssertJavaScript("assertGraphicExistsInLayer", args: new object[] { layer!.Id, "point", 2000 });
         Assert.AreEqual(2000, result.UpdateFeatureResults.Length);
+        Assert.IsTrue(result.AddFeatureResults.All(f => f.Error is null));
+        Assert.IsTrue(result.AddFeatureResults.All(f => f.ObjectId.HasValue));
     }
 
     [TestMethod]
@@ -234,14 +244,22 @@
         await AssertJavaScript("assertGraphicExistsInLayer", args: new object[] { layer!.Id, "point", 2000 });
         Assert.AreEqual(2000, result.AddFeatureResults.Length);
         
+        FeatureSet? features = await layer.QueryFeatures();
+        Assert.IsNotNull(features);
+        Assert.IsNotNull(features.Features);
+        Assert.AreEqual(2000, features.Features.Length);
+
         edits = new()
         {
-            DeleteFeatures = graphics
+            DeleteFeatures = features.Features.ToArray()
         };
+
         result = await layer!.ApplyEdits(edits);
         await WaitForMapToRender();
         await Assert.ThrowsExceptionAsync<JSException>(async() =>
             await AssertJavaScript("assertGraphicExistsInLayer", args: new object[] { layer!.Id, "point", 2000 }));
         Assert.AreEqual(2000, result.DeleteFeatureResults.Length);
+        Assert.IsTrue(result.AddFeatureResults.All(f => f.Error is null));
+        Assert.IsTrue(result.AddFeatureResults.All(f => f.ObjectId.HasValue));
     }
 }


### PR DESCRIPTION
Hi dear GeoBlazor Team,

The issue #306 was resolved by our team member @adrien426.

### Description:
This PR resolves recurring OBJECT_ID errors encountered during ApplyEdits operations in FeatureLayer tests. It addresses failures in TestCanUpdateManyFeaturesWithApplyEdits and TestCanDeleteManyFeaturesWithApplyEdits, where OBJECT_ID was being read from undefined.

### Changes:
Ensured OBJECT_ID is properly initialized and passed to ApplyEdits.
Adjusted test setup to correctly assign OBJECT_ID to features before edits.

### Impact:
These changes fix the test failures, allowing both update and delete operations to complete as expected, thus ensuring the integrity and reliability of FeatureLayer functionality.

![MicrosoftTeams-image (2)](https://github.com/dymaptic/GeoBlazor/assets/34795406/099bca6a-15a9-47ff-9f0b-4aa45af6b67e)

Yours sincerly,
David from Team GIS - POST Luxembourg