### PR TITLE
fix: layer JsModule is null after AddLayer

### DIFF
--- a/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
@@ -1295,6 +1295,7 @@ public partial class MapView : MapComponent
         {
             Map!.Layers.Add(layer);
             layer.Parent ??= Map;
+            layer.JsModule ??= ViewJsModule;
         }
 
         if (ViewJsModule is null) return;

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerTests.razor
@@ -7,6 +7,32 @@
 @code {
 
     [TestMethod]
+    public async Task TestCanSetFeatureLayerVisibility(Action renderHandler)
+    {
+        MapView? mapView = null;
+        async Task OnViewInitialized()
+        {
+            await mapView!.AddLayer(new FeatureLayer() { Title = "Test", Url = "https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/TrailRuns/FeatureServer/0" });
+        }
+        AddMapRenderFragment(
+            @<MapView OnViewInitialized="@OnViewInitialized" @ref="@mapView" class="map-view" OnViewRendered="renderHandler">
+                <Map ArcGISDefaultBasemap="topo-vector">
+                </Map>
+            </MapView>);
+        await WaitForMapToRender();
+        await AssertJavaScript("assertLayerExists", args: "feature");
+
+        FeatureLayer? featureLayer = mapView!.Map!.Layers.OfType<FeatureLayer>().SingleOrDefault();
+        
+        Assert.IsNotNull(featureLayer);
+        Assert.IsNotNull(featureLayer.JsModule);
+
+        await featureLayer.SetVisibility(false);
+
+        Assert.IsFalse(featureLayer.Visible);
+    }
+
+    [TestMethod]
     public async Task TestCanRenderFeatureLayer(Action renderHandler)
     {
         AddMapRenderFragment(


### PR DESCRIPTION
Hi dear GeoBlazor Team,

Description:
We noticed an issue while setting layer visibility.
This issue can be reproduced only if layer has been added by code to the MapView.
This issue does not occur if layer has been added using markup of the component (Razor language).

Changes:
To fix this issue, JsModule has been set while executing the AddLayer method.
New test method TestCanSetFeatureLayerVisibility has been added to validate the fix.

Impact:
This change fix the failure while setting layer visibility.

Resolves #321 

Br,
David from Team GIS - POST Luxembourg
