### PR TITLE
fix: jsModule is null for basemap layer

### DIFF
--- a/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
@@ -1339,8 +1339,9 @@ public partial class MapView : MapComponent
         {
             Map!.Layers.Add(layer);
             layer.Parent ??= Map;
-            layer.JsModule ??= ViewJsModule;
         }
+
+        layer.JsModule ??= ViewJsModule;
 
         if (ViewJsModule is null) return;
 

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/BaseMapTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/BaseMapTests.razor
@@ -4,7 +4,35 @@
     base.BuildRenderTree(__builder);
 }
 
-@code {
+@code {     
+    [TestMethod]
+    public async Task TestCanSetBaseMapLayerVisibility(Action renderHandler)
+    {
+        MapView? mapView = null;
+        async Task OnViewInitialized()
+        {
+            await mapView!.AddLayer(new ImageryTileLayer() { Url = "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer" }, isBasemapLayer: true );
+        }
+         AddMapRenderFragment(
+            @<MapView OnViewInitialized="@OnViewInitialized" @ref="@mapView" class="map-view" OnViewRendered="renderHandler">
+                <Map>
+                    <Basemap>
+                        <PortalItem Id="55ebf90799fa4a3fa57562700a68c405" />
+                    </Basemap>
+                </Map>
+            </MapView>);
+
+        await WaitForMapToRender();
+
+        ImageryTileLayer? imageryTileLayer = mapView!.Map!.Basemap!.Layers.OfType<ImageryTileLayer>().SingleOrDefault();
+        
+        Assert.IsNotNull(imageryTileLayer);
+        Assert.IsNotNull(imageryTileLayer.JsModule);
+
+        await imageryTileLayer.SetVisibility(false);
+
+        Assert.IsFalse(imageryTileLayer.Visible);
+    }
 
     [TestMethod]
     public async Task TestCanRenderArcGisDefaultBasemap(Action renderHandler)


### PR DESCRIPTION
Hi dear GeoBlazor Team,

Description:
We noticed an issue while setting visibility from a BaseMapLayer.
This issue can be reproduced only if a BaseMapLayer has been added by code to the MapView.
This issue does not occur if a BaseMapLayer has been added using markup of the component (Razor language).

Changes:
To fix this issue, JsModule has been set while executing the AddLayer method, whether isBasemapLayer is true or false.
New test method TestCanSetBaseMapLayerVisibility has been added to validate the fix.

Impact:
This change fix the failure while setting layer visibility from a BaseMapLayer.

Resolves #335

Br,
David from Team GIS - POST Luxembourg