### PR TITLE
fix: can clear graphics on layer

### DIFF
--- a/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
@@ -1342,6 +1342,9 @@ public partial class MapView : MapComponent
             layer.JsModule ??= ViewJsModule;
         }
 
+        layer.View ??= this;
+        layer.JsModule ??= ViewJsModule;
+
         if (ViewJsModule is null) return;
 
         if (ProJsViewModule is not null && layer.GetType().Namespace!.Contains("Pro"))

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/GraphicsTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/GraphicsTests.razor
@@ -5,6 +5,31 @@
 }
 
 @code {
+    [TestMethod]
+    public async Task TestCanClearGraphics(Action renderHandler)
+    {
+        MapView? mapView = null;
+        GraphicsLayer graphicsLayer = new GraphicsLayer();
+
+        async Task OnViewInitialized()
+        {
+            await mapView!.AddLayer(graphicsLayer);
+        }
+        AddMapRenderFragment(
+        @<MapView OnViewInitialized="@OnViewInitialized" @ref="mapView" class="map-view" OnViewRendered="renderHandler">
+            <Map>
+                <Basemap>
+                    <PortalItem Id="55ebf90799fa4a3fa57562700a68c405" />
+                </Basemap>
+            </Map>
+        </MapView>);
+
+        await WaitForMapToRender();
+
+        await graphicsLayer.Clear();
+
+        Assert.IsNotNull(graphicsLayer.View);
+    }
 
     [TestMethod]
     public async Task TestGraphicIdRemainsConsistentAfterOperations(Action renderHandler)


### PR DESCRIPTION
Hi dear GeoBlazor Team,

Description:
We noticed an issue while clearing Graphics from a GraphicsLayer.
This issue can be reproduced only if a GraphicsLayer has been added by code to the MapView.
This issue does not occur if a GraphicsLayer has been added using markup of the component (Razor language).

Changes:
To fix this issue, View has been set while executing the AddLayer method.
New test method TestCanClearGraphics has been added to validate the fix.

Impact:
This change fix the failure while clearing Graphics from a GraphicsLayer.

Resolves #336 

Br,
David from Team GIS - POST Luxembourg