### PR TITLE
Fix for UniqueValueRenderer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <CoreVersion>3.0.2</CoreVersion>
+        <CoreVersion>3.0.3-beta-1</CoreVersion>
     </PropertyGroup>
 </Project>

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleMarkerSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleMarkerSymbol.cs
@@ -80,6 +80,7 @@ public class SimpleMarkerSymbol : MarkerSymbol
     /// <summary>
     ///     The marker style.
     /// </summary>
+    [JsonPropertyName("style")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [Parameter]
     public SimpleMarkerStyle? MarkerStyle { get; set; }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -146,6 +146,8 @@ import HitTestResult = __esri.HitTestResult;
 import MapViewHitTestOptions = __esri.MapViewHitTestOptions;
 import LegendLayerInfos = __esri.LegendLayerInfos;
 import ScreenPoint = __esri.ScreenPoint;
+import Polyline from "@arcgis/core/geometry/Polyline";
+import Polygon from "@arcgis/core/geometry/Polygon";
 
 
 export let arcGisObjectRefs: Record<string, Accessor> = {};
@@ -155,7 +157,8 @@ export let graphicsRefs: Record<string, Graphic> = {};
 export let dotNetRefs = {};
 export let queryLayer: FeatureLayer;
 export let blazorServer: boolean = false;
-export { projection, geometryEngine, Graphic, Color };
+export { projection, geometryEngine, Graphic, Color, Point, Polyline, Polygon };
+export * as normalizeUtils from "@arcgis/core/geometry/support/normalizeUtils"
 let notifyExtentChanged: boolean = true;
 let uploadingLayers: Array<string> = [];
 let userChangedViewExtent: boolean = false;

--- a/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
@@ -100,7 +100,6 @@ export interface DotNetSimpleMarkerSymbol extends DotNetSymbol {
     path: string;
     size: number;
     style: string;
-    markerStyle: string;
     xOffset: number;
     yOffset: number;
 }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -747,7 +747,15 @@ export function buildJsUniqueValueRenderer(dnUniqueValueRenderer: DotNetUniqueVa
     }
     
     if (hasValue(dnUniqueValueRenderer.uniqueValueInfos) && dnUniqueValueRenderer.uniqueValueInfos.length > 0) {
-        uniqueValueRenderer.uniqueValueInfos = dnUniqueValueRenderer.uniqueValueInfos as any[];
+        for (let i = 0; i < dnUniqueValueRenderer.uniqueValueInfos.length; i++) {
+            let dnUniqueValueInfo = dnUniqueValueRenderer.uniqueValueInfos[i];
+            let uniqueValueInfo = new UniqueValueInfo();
+            copyValuesIfExists(dnUniqueValueInfo, uniqueValueInfo, 'label', 'value');
+            if (hasValue(dnUniqueValueInfo.symbol)) {
+                uniqueValueInfo.symbol = buildJsSymbol(dnUniqueValueInfo.symbol) as Symbol;
+            }
+            uniqueValueRenderer.uniqueValueInfos.push(uniqueValueInfo);
+        }
     }
     
     if (hasValue(dnUniqueValueRenderer.visualVariables) && dnUniqueValueRenderer.visualVariables.length > 0) {

--- a/templates/content/dymaptic.GeoBlazor.Template.Maui/dymaptic.GeoBlazor.Template.Maui.csproj
+++ b/templates/content/dymaptic.GeoBlazor.Template.Maui/dymaptic.GeoBlazor.Template.Maui.csproj
@@ -81,7 +81,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.2-beta-11" />
+		<PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.3-beta-1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />

--- a/templates/content/dymaptic.GeoBlazor.Template.Server/dymaptic.GeoBlazor.Template.Server.csproj
+++ b/templates/content/dymaptic.GeoBlazor.Template.Server/dymaptic.GeoBlazor.Template.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.2-beta-11" />
+    <PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.3-beta-1" />
   </ItemGroup>
 
 </Project>

--- a/templates/content/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp.Client/dymaptic.GeoBlazor.Template.WebApp.Client.csproj
+++ b/templates/content/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp.Client/dymaptic.GeoBlazor.Template.WebApp.Client.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.2-beta-11" />
+    <PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.3-beta-1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0-0" PrivateAssets="all" />
   </ItemGroup>

--- a/templates/content/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp.csproj
+++ b/templates/content/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\dymaptic.GeoBlazor.Template.WebApp.Client\dymaptic.GeoBlazor.Template.WebApp.Client.csproj" />
-		<PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.2-beta-11" />
+		<PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.3-beta-1" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.0" />
 	</ItemGroup>
 

--- a/templates/content/dymaptic.GeoBlazor.Template.WebAssembly/dymaptic.GeoBlazor.Template.WebAssembly.csproj
+++ b/templates/content/dymaptic.GeoBlazor.Template.WebAssembly/dymaptic.GeoBlazor.Template.WebAssembly.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.2-beta-11" />
+    <PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.3-beta-1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>

--- a/templates/dymaptic.GeoBlazor.Templates.csproj
+++ b/templates/dymaptic.GeoBlazor.Templates.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<PackageId>dymaptic.GeoBlazor.Templates</PackageId>
 		<Title>GeoBlazor Project Templates</Title>
-		<PackageVersion>3.0.2-beta-11</PackageVersion>
+		<PackageVersion>3.0.3-beta-1</PackageVersion>
 		<Version>2.5.2</Version>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<Company>dymaptic</Company>

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/RendererTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/RendererTests.razor
@@ -1,0 +1,63 @@
+@using dymaptic.GeoBlazor.Core.Extensions
+@inherits TestRunnerBase
+
+@{
+    base.BuildRenderTree(__builder);
+}
+
+@code {
+    [TestMethod]
+    public async Task CanRenderUniqueSimpleMarkerSymbols(Action renderHandler)
+    {
+        FeatureLayer? layer = null;
+        AddMapRenderFragment(
+            @<MapView class="map-view" OnViewRendered="renderHandler">
+                <Extent Xmax="-11122504.85982967"
+                        Xmin="-11367103.350342168"
+                        Ymax="4675194.398033299"
+                        Ymin="4430595.907520799">
+                    <SpatialReference Wkid="102100" />
+                </Extent>
+                <Map>
+                    <Basemap>
+                        <BasemapStyle Name="BasemapStyleName.ArcgisStreets" />
+                    </Basemap>
+                    <FeatureLayer @ref="layer">
+                        <PortalItem Id="cdff193a3e3743a5bc770e2743f215b3" />
+                        <UniqueValueRenderer Field="PGM_SYS_ACRNM">
+                            <DefaultSymbol>
+                                <SimpleMarkerSymbol Color="@(new MapColor("red"))" MarkerStyle="SimpleMarkerStyle.Circle" />
+                            </DefaultSymbol>
+                            <UniqueValueInfo Value="AIR">
+                                <SimpleMarkerSymbol Color="@(new MapColor("blue"))" MarkerStyle="SimpleMarkerStyle.Cross" />
+                            </UniqueValueInfo>
+                            <UniqueValueInfo Value="NPDES">
+                                <SimpleMarkerSymbol Color="@(new MapColor("yellow"))" MarkerStyle="SimpleMarkerStyle.Diamond" />
+                            </UniqueValueInfo>
+                            <UniqueValueInfo Value="NJ-NJEMS">
+                                <SimpleMarkerSymbol Color="@(new MapColor("green"))" MarkerStyle="SimpleMarkerStyle.Path" />
+                            </UniqueValueInfo>
+                            <UniqueValueInfo Value="CA-ENVIROVIEW">
+                                <SimpleMarkerSymbol Color="@(new MapColor("purple"))" MarkerStyle="SimpleMarkerStyle.Square" />
+                            </UniqueValueInfo>
+                            <UniqueValueInfo Value="AIRS/AFS">
+                                <SimpleMarkerSymbol Color="@(new MapColor("orange"))" MarkerStyle="SimpleMarkerStyle.Triangle" />
+                            </UniqueValueInfo>
+                            <UniqueValueInfo Value="EIS">
+                                <SimpleMarkerSymbol Color="@(new MapColor("black"))" MarkerStyle="SimpleMarkerStyle.X" />
+                            </UniqueValueInfo>
+                            <UniqueValueInfo Value="MN-TEMPO">
+                                <SimpleMarkerSymbol Color="@(new MapColor("darkgreen"))" MarkerStyle="SimpleMarkerStyle.Circle" />
+                            </UniqueValueInfo>
+                            <UniqueValueInfo Value="FIS">
+                                <SimpleMarkerSymbol Color="@(new MapColor("lightblue"))" MarkerStyle="SimpleMarkerStyle.Cross" />
+                            </UniqueValueInfo>
+                        </UniqueValueRenderer>
+                    </FeatureLayer>
+                </Map>
+            </MapView>);
+
+        await WaitForMapToRender();
+        await AssertJavaScript("rendererAsserts.assertUniqueValueInfos", args: [layer!.Id]);
+    }
+}

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/wwwroot/rendererAsserts.js
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/wwwroot/rendererAsserts.js
@@ -1,0 +1,31 @@
+﻿import {arcGisObjectRefs} from "./testRunner.js";
+
+export function assertUniqueValueInfos(methodName, layerId) {
+    let layer = arcGisObjectRefs[layerId];
+    if (layer.renderer.uniqueValueInfos === undefined) {
+        throw new Error(`Expected uniqueValueInfos`);
+    }
+    var colors = [];
+    var shapes = [];
+    for (let i = 0; i < layer.renderer.uniqueValueInfos.length; i++) {
+        let uvi = layer.renderer.uniqueValueInfos[i];
+        if (uvi.value === undefined) {
+            throw new Error(`Expected value`);
+        }
+        if (uvi.symbol === undefined) {
+            throw new Error(`Expected symbol`);
+        }
+        if (!colors.find(c => c === uvi.symbol.color.toHex())) {
+            colors.push(uvi.symbol.color.toHex());
+        }
+        if (!shapes.find(s => s === uvi.symbol.style)) {
+            shapes.push(uvi.symbol.style);
+        }
+    }
+    if (colors.length < 2) {
+        throw new Error(`Expected multiple colors`);
+    }
+    if (shapes.length < 2) {
+        throw new Error(`Expected multiple shapes`);
+    }
+}


### PR DESCRIPTION
Closes #343 

- Fixed JSON-serialized `SimpleMarkerSymbol.MarkerStyle` serializing as `style`
- Implemented manual copy of `UniqueValueInfo` symbols in `jsBuilder.buildJsUniqueValueRenderer`
- Created new unit test to verify color and shape of SimpleMarkerSymbols inside the UniqueValueRenderer
- Exporting unrelated properties in `arcGisJsInterop` as they were requested by other users for js extensions.