### PR TITLE
Bug/319 localization double parse

### DIFF
--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/Symbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/Symbol.cs
@@ -176,19 +176,21 @@ internal record SymbolSerializationRecord : MapComponentSerializationRecord
     [ProtoMember(27)]
     public int? YScale { get; init; }
 
-    public Symbol FromSerializationRecord()
+    public Symbol FromSerializationRecord(bool isOutline = false)
     {
         return Type switch
         {
             "outline" => new Outline(Color, Width, LineStyle is null ? null : Enum.Parse<LineStyle>(LineStyle!, true)),
-            "simple-marker" => new SimpleMarkerSymbol(Outline?.FromSerializationRecord() as Outline, Color, Size, 
+            "simple-marker" => new SimpleMarkerSymbol(Outline?.FromSerializationRecord(true) as Outline, Color, Size, 
                 Style is null ? null : Enum.Parse<SimpleMarkerStyle>(Style!, true), Angle, XOffset, YOffset),
-            "simple-line" => new SimpleLineSymbol(Color, Width, LineStyle is null ? null : Enum.Parse<LineStyle>(LineStyle!, true)),
-            "simple-fill" => new SimpleFillSymbol(Outline?.FromSerializationRecord() as Outline, Color, 
+            "simple-line" => isOutline 
+                ? new Outline(Color, Width, LineStyle is null ? null : Enum.Parse<LineStyle>(LineStyle!, true))
+                : new SimpleLineSymbol(Color, Width, LineStyle is null ? null : Enum.Parse<LineStyle>(LineStyle!, true)),
+            "simple-fill" => new SimpleFillSymbol(Outline?.FromSerializationRecord(true) as Outline, Color, 
                 Style is null ? null : Enum.Parse<FillStyle>(Style!, true)),
             "picture-marker" => new PictureMarkerSymbol(Url!, Width, Height, Angle, XOffset, YOffset),
             "picture-fill" => new PictureFillSymbol(Url!, Width, Height, XOffset, YOffset, XScale, YScale, 
-                Outline?.FromSerializationRecord() as Outline),
+                Outline?.FromSerializationRecord(true) as Outline),
             "text" => new TextSymbol(Text ?? string.Empty, Color, HaloColor, HaloSize, 
                 MapFont?.FromSerializationRecord(), Angle, BackgroundColor, BorderLineColor,
                 BorderLineSize, HorizontalAlignment is null ? null : Enum.Parse<HorizontalAlignment>(HorizontalAlignment!, true),

--- a/src/dymaptic.GeoBlazor.Core/JsModuleManager.cs
+++ b/src/dymaptic.GeoBlazor.Core/JsModuleManager.cs
@@ -1,6 +1,6 @@
+using dymaptic.GeoBlazor.Core.Objects;
 using Microsoft.JSInterop;
 using System.Globalization;
-using System.Security.Claims;
 
 namespace dymaptic.GeoBlazor.Core;
 
@@ -9,6 +9,9 @@ namespace dymaptic.GeoBlazor.Core;
 /// </summary>
 public static class JsModuleManager
 {
+    /// <summary>
+    ///     The browser's culture information. Used to deserialize numbers and dates in <see cref="AttributesDictionary"/>.
+    /// </summary>
     public static CultureInfo ClientCultureInfo { get; set; } = CultureInfo.CurrentCulture;
     
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Objects/AttributesDictionary.cs
+++ b/src/dymaptic.GeoBlazor.Core/Objects/AttributesDictionary.cs
@@ -1,6 +1,7 @@
 ﻿using dymaptic.GeoBlazor.Core.Components;
 using ProtoBuf;
 using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Text.Json;
@@ -80,7 +81,7 @@ public class AttributesDictionary : IEquatable<AttributesDictionary>
                 switch (record.ValueType)
                 {
                     case "[object Number]":
-                        _backingDictionary[record.Key] = double.Parse(record.Value!);
+                        _backingDictionary[record.Key] = double.Parse(record.Value!, CultureInfo.CurrentCulture);
                         
                         break;
                     case "[object Boolean]":
@@ -99,7 +100,7 @@ public class AttributesDictionary : IEquatable<AttributesDictionary>
 
                         break;
                     case "[object Date]":
-                        _backingDictionary[record.Key] = DateTime.Parse(record.Value!);
+                        _backingDictionary[record.Key] = DateTime.Parse(record.Value!, CultureInfo.CurrentCulture);
 
                         break;
                     default:

--- a/src/dymaptic.GeoBlazor.Core/Objects/AttributesDictionary.cs
+++ b/src/dymaptic.GeoBlazor.Core/Objects/AttributesDictionary.cs
@@ -17,7 +17,7 @@ namespace dymaptic.GeoBlazor.Core.Objects;
 public class AttributesDictionary : IEquatable<AttributesDictionary>
 {
     /// <summary>
-    ///     Constructor
+    ///     Constructor for a new, empty dictionary
     /// </summary>
     public AttributesDictionary()
     {
@@ -25,16 +25,20 @@ public class AttributesDictionary : IEquatable<AttributesDictionary>
     }
 
     /// <summary>
-    ///     Constructor from existing dictionary
+    ///     Constructor from existing dictionary or JSON deserialized dictionary
     /// </summary>
     /// <param name="dictionary">
-    ///     The dictionary to use
+    ///     The dictionary to use.
     /// </param>
+    /// <remarks>
+    ///     It is possible to control the culture used for parsing numbers and dates by including a "geoBlazorCulture" key in the dictionary. The value should be a string representation of a culture name, such as "en-US" or "fr-FR".
+    ///     Alternatively, for a server-generated dictionary, the culture can be set in the server's CultureInfo.DefaultThreadCurrentUICulture property. It will fall back to `CultureInfo.CurrentCulture` if not set.
+    /// </remarks>
     public AttributesDictionary(Dictionary<string, object?> dictionary)
     {
         CultureInfo cultureInfo = dictionary.TryGetValue("geoBlazorCulture", out object? gbCulture)
             ? new CultureInfo(gbCulture!.ToString()!)
-            : CultureInfo.CurrentCulture;
+            : CultureInfo.DefaultThreadCurrentUICulture ?? CultureInfo.CurrentCulture;
         _backingDictionary = new Dictionary<string, object?>();
         var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
 
@@ -77,6 +81,12 @@ public class AttributesDictionary : IEquatable<AttributesDictionary>
         }
     }
 
+    /// <summary>
+    ///     Internal constructor for use with Protobuf deserialization
+    /// </summary>
+    /// <param name="serializedAttributes">
+    ///     The serialized attributes to use.
+    /// </param>
     internal AttributesDictionary(AttributeSerializationRecord[]? serializedAttributes)
     {
         _backingDictionary = new Dictionary<string, object?>();
@@ -94,7 +104,7 @@ public class AttributesDictionary : IEquatable<AttributesDictionary>
             }
             else
             {
-                cultureInfo = CultureInfo.CurrentCulture;
+                cultureInfo = CultureInfo.DefaultThreadCurrentUICulture ?? CultureInfo.CurrentCulture;
             }
 
 

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -385,7 +385,7 @@ export async function buildMapView(id: string, dotNetReference: any, long: numbe
         }
         
         if (hasValue(popupEnabled)) {
-            view.popupEnabled = popupEnabled;
+            view.popupEnabled = popupEnabled as boolean;
         }
         
         if (hasValue(constraints)) {
@@ -3339,4 +3339,8 @@ export function getWebMapBookmarks(viewId: string) {
 export function setStretchTypeForRenderer(rendererId, stretchType) {
     let renderer = arcGisObjectRefs[rendererId] as RasterStretchRenderer;
     renderer.stretchType = stretchType;
+}
+
+export function getBrowserLanguage(): string {
+    return navigator.language;
 }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
@@ -99,17 +99,14 @@ import Domain from "@arcgis/core/layers/support/Domain";
 import CodedValueDomain from "@arcgis/core/layers/support/CodedValueDomain";
 import InheritedDomain from "@arcgis/core/layers/support/InheritedDomain";
 import RangeDomain from "@arcgis/core/layers/support/RangeDomain";
-import Effect = __esri.Effect;
 import TileInfo from "@arcgis/core/layers/support/TileInfo";
 import LOD from "@arcgis/core/layers/support/LOD";
 import LayerSearchSource from "@arcgis/core/widgets/Search/LayerSearchSource";
-import SearchSource from "@arcgis/core/widgets/Search/SearchSource";
 import LocatorSearchSource from "@arcgis/core/widgets/Search/LocatorSearchSource";
 import SearchResult = __esri.SearchResult;
 import SuggestResult = __esri.SuggestResult;
 import FeatureType from "@arcgis/core/layers/support/FeatureType";
 import FeatureTemplate from "@arcgis/core/layers/support/FeatureTemplate";
-import FeatureTemplateThumbnail = __esri.FeatureTemplateThumbnail;
 import LabelClass from "@arcgis/core/layers/support/LabelClass";
 import Renderer from "@arcgis/core/renderers/Renderer";
 import PieChartRenderer from "@arcgis/core/renderers/PieChartRenderer";
@@ -120,7 +117,6 @@ import PieChartScheme = __esri.PieChartScheme;
 import SizeScheme = __esri.SizeScheme;
 import SizeSchemeForPoint = __esri.SizeSchemeForPoint;
 import SizeSchemeForPolygon = __esri.SizeSchemeForPolygon;
-import UniqueValuesResult = __esri.UniqueValuesResult;
 import AuthoringInfo from "@arcgis/core/renderers/support/AuthoringInfo";
 import AddressCandidate = __esri.AddressCandidate;
 import FeatureSet from "@arcgis/core/rest/support/FeatureSet";
@@ -146,6 +142,7 @@ export function buildDotNetGraphic(graphic: Graphic): DotNetGraphic | null {
 
     dotNetGraphic.uid = (graphic as any).uid;
     dotNetGraphic.attributes = graphic.attributes ?? {};
+    dotNetGraphic.attributes.geoBlazorCulture = navigator.language;
     if (graphic.symbol !== undefined && graphic.symbol !== null) {
         dotNetGraphic.symbol = buildDotNetSymbol(graphic.symbol);
     }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
@@ -142,7 +142,6 @@ export function buildDotNetGraphic(graphic: Graphic): DotNetGraphic | null {
 
     dotNetGraphic.uid = (graphic as any).uid;
     dotNetGraphic.attributes = graphic.attributes ?? {};
-    dotNetGraphic.attributes.geoBlazorCulture = navigator.language;
     if (graphic.symbol !== undefined && graphic.symbol !== null) {
         dotNetGraphic.symbol = buildDotNetSymbol(graphic.symbol);
     }

--- a/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
+++ b/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
@@ -33,6 +33,8 @@
         <InternalsVisibleTo Include="dymaptic.GeoBlazor.Core.Sample.Shared" />
         <InternalsVisibleTo Include="dymaptic.GeoBlazor.Core.Test" />
         <InternalsVisibleTo Include="dymaptic.GeoBlazor.Pro.Test.Unit" />
+        <InternalsVisibleTo Include="dymaptic.GeoBlazor.Core.Test.Blazor.Shared" />
+        <InternalsVisibleTo Include="dymaptic.GeoBlazor.Pro.Test.Blazor.Shared" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/LocalizationTests.cs
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/LocalizationTests.cs
@@ -31,16 +31,24 @@ public class LocalizationTests: TestRunnerBase
     }
     
     [TestMethod]
-    public void TestDeserializeAmericanDoubleAttributeInEuropeanCultureFails()
+    public void TestDeserializeAmericanDoubleAttributeInEuropeanCultureReturnsWrongValue()
     {
         string originalCulture = Thread.CurrentThread.CurrentCulture.Name;
         SetCulture("de-DE");
         AttributeSerializationRecord doubleAttribute = new("Value", "1.1", "[object Number]");
-
-        Assert.ThrowsException<SerializationException>(() =>
-        {
-            AttributesDictionary _ = new([doubleAttribute]);
-        });
+        AttributesDictionary attributes = new([doubleAttribute]);
+        Assert.AreEqual(11.0, attributes["Value"]);
+        SetCulture(originalCulture);
+    }
+    
+    [TestMethod]
+    public void TestDeserializeEuropeanDoubleAttributeInAmericanCultureReturnsWrongValue()
+    {
+        string originalCulture = Thread.CurrentThread.CurrentCulture.Name;
+        SetCulture("en-US");
+        AttributeSerializationRecord doubleAttribute = new("Value", "1,1", "[object Number]");
+        AttributesDictionary attributes = new([doubleAttribute]);
+        Assert.AreEqual(11.0, attributes["Value"]);
         SetCulture(originalCulture);
     }
 

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/LocalizationTests.cs
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/LocalizationTests.cs
@@ -1,0 +1,51 @@
+using dymaptic.GeoBlazor.Core.Objects;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Globalization;
+using System.Runtime.Serialization;
+
+
+namespace dymaptic.GeoBlazor.Core.Test.Blazor.Shared.Components;
+
+public class LocalizationTests: TestRunnerBase
+{
+    [TestMethod]
+    public void TestCanDeserializeAmericanDoubleAttribute()
+    {
+        string originalCulture = Thread.CurrentThread.CurrentCulture.Name;
+        SetCulture("en-US");
+        AttributeSerializationRecord doubleAttribute = new("Value", "1.1", "[object Number]");
+        AttributesDictionary attributes = new([doubleAttribute]);
+        Assert.AreEqual(1.1, attributes["Value"]);
+        SetCulture(originalCulture);
+    }
+    
+    [TestMethod]
+    public void TestCanDeserializeEuropeanDoubleAttribute()
+    {
+        string originalCulture = Thread.CurrentThread.CurrentCulture.Name;
+        SetCulture("de-DE");
+        AttributeSerializationRecord doubleAttribute = new("Value", "1,1", "[object Number]");
+        AttributesDictionary attributes = new([doubleAttribute]);
+        Assert.AreEqual(1.1, attributes["Value"]);
+        SetCulture(originalCulture);
+    }
+    
+    [TestMethod]
+    public void TestDeserializeAmericanDoubleAttributeInEuropeanCultureFails()
+    {
+        string originalCulture = Thread.CurrentThread.CurrentCulture.Name;
+        SetCulture("de-DE");
+        AttributeSerializationRecord doubleAttribute = new("Value", "1.1", "[object Number]");
+
+        Assert.ThrowsException<SerializationException>(() =>
+        {
+            AttributesDictionary _ = new([doubleAttribute]);
+        });
+        SetCulture(originalCulture);
+    }
+
+    private void SetCulture(string cultureName)
+    {
+        Thread.CurrentThread.CurrentCulture = new CultureInfo(cultureName);
+    }
+}

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/LocalizationTests.cs
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/LocalizationTests.cs
@@ -11,7 +11,7 @@ public class LocalizationTests: TestRunnerBase
     [TestMethod]
     public void TestCanDeserializeAmericanDoubleAttribute()
     {
-        string originalCulture = Thread.CurrentThread.CurrentCulture.Name;
+        string originalCulture = JsModuleManager.ClientCultureInfo.Name;
         SetCulture("en-US");
         AttributeSerializationRecord doubleAttribute = new("Value", "1.1", "[object Number]");
         AttributesDictionary attributes = new([doubleAttribute]);
@@ -22,7 +22,7 @@ public class LocalizationTests: TestRunnerBase
     [TestMethod]
     public void TestCanDeserializeEuropeanDoubleAttribute()
     {
-        string originalCulture = Thread.CurrentThread.CurrentCulture.Name;
+        string originalCulture = JsModuleManager.ClientCultureInfo.Name;
         SetCulture("de-DE");
         AttributeSerializationRecord doubleAttribute = new("Value", "1,1", "[object Number]");
         AttributesDictionary attributes = new([doubleAttribute]);
@@ -33,7 +33,7 @@ public class LocalizationTests: TestRunnerBase
     [TestMethod]
     public void TestDeserializeAmericanDoubleAttributeInEuropeanCultureReturnsWrongValue()
     {
-        string originalCulture = Thread.CurrentThread.CurrentCulture.Name;
+        string originalCulture = JsModuleManager.ClientCultureInfo.Name;
         SetCulture("de-DE");
         AttributeSerializationRecord doubleAttribute = new("Value", "1.1", "[object Number]");
         AttributesDictionary attributes = new([doubleAttribute]);
@@ -44,7 +44,7 @@ public class LocalizationTests: TestRunnerBase
     [TestMethod]
     public void TestDeserializeEuropeanDoubleAttributeInAmericanCultureReturnsWrongValue()
     {
-        string originalCulture = Thread.CurrentThread.CurrentCulture.Name;
+        string originalCulture = JsModuleManager.ClientCultureInfo.Name;
         SetCulture("en-US");
         AttributeSerializationRecord doubleAttribute = new("Value", "1,1", "[object Number]");
         AttributesDictionary attributes = new([doubleAttribute]);
@@ -54,6 +54,6 @@ public class LocalizationTests: TestRunnerBase
 
     private void SetCulture(string cultureName)
     {
-        Thread.CurrentThread.CurrentCulture = new CultureInfo(cultureName);
+        JsModuleManager.ClientCultureInfo = new CultureInfo(cultureName);
     }
 }

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/TestRunnerBase.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/TestRunnerBase.razor
@@ -177,14 +177,29 @@
         try
         {
             bool hasParameters = methodInfo.GetParameters().Any();
-            if (hasParameters)
+            if (methodInfo.ReturnType != typeof(Task))
             {
-                void RenderHandler() => _methodsWithRenderedMaps.Add(methodInfo.Name);
-                await (Task)methodInfo.Invoke(this, [(Action)RenderHandler])!;
+                if (hasParameters)
+                {
+                    void RenderHandler() => _methodsWithRenderedMaps.Add(methodInfo.Name);
+                    methodInfo.Invoke(this, [(Action)RenderHandler]);
+                }
+                else
+                {
+                    methodInfo.Invoke(this, null);
+                }
             }
             else
             {
-                await (Task)methodInfo.Invoke(this, null)!;
+                if (hasParameters)
+                {
+                    void RenderHandler() => _methodsWithRenderedMaps.Add(methodInfo.Name);
+                    await (Task)methodInfo.Invoke(this, [(Action)RenderHandler])!;
+                }
+                else
+                {
+                    await (Task)methodInfo.Invoke(this, null)!;
+                }
             }
 
             _passed[methodInfo.Name] = _resultBuilder.ToString();


### PR DESCRIPTION
Closes #319 
- Passes `navigator.language` with graphic attributes in `dotNetBuilder.buildDotNetGraphic`
- Uses the passed culture string if available to parse numbers and datetimes. Falls back to `CurrentCulture`.
- Added new unit tests to validate parsing
- Added support in `TestRunnerBase.razor` for synchronous tests

There is some question in my mind still if this is the "right" or "best" approach. The issue IMO stems from the following:

- Data sources, such as AGOL, can store feature data with a culture
- Client devices can have a different culture
- GeoBlazor servers could in theory have yet another culture

How these 3 pieces fit together, and how to _know_ that we aren't breaking data in any one scenario (data from AGOL in culture A, data from GeoBlazor in culture B, etc.).

For example, if we pass data to ArcGIS JS layers in culture A _from_ GeoBlazor, but the client is in culture B, when it returns to GB, it will have culture B tied to the data. Some of this stems from the fact that Blazor is both a server and client technology, often in the same application.