### PR TITLE
Split JS Bundled Files, Update References

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <CoreVersion>3.0.3-beta-5</CoreVersion>
+        <CoreVersion>3.0.3-beta-6</CoreVersion>
     </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <CoreVersion>3.0.3-beta-4</CoreVersion>
+        <CoreVersion>3.0.3-beta-5</CoreVersion>
     </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <CoreVersion>3.0.3-beta-6</CoreVersion>
+        <CoreVersion>3.1.0</CoreVersion>
     </PropertyGroup>
 </Project>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Maui/dymaptic.GeoBlazor.Core.Sample.Maui.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Maui/dymaptic.GeoBlazor.Core.Sample.Maui.csproj
@@ -69,11 +69,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="8.0.3" />
-        <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="8.0.70" />
+        <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.70" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Maui/wwwroot/index.html
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Maui/wwwroot/index.html
@@ -14,10 +14,8 @@
     <link href="_content/dymaptic.GeoBlazor.Core"/>
     <script src="_content/dymaptic.GeoBlazor.Core.Sample.Shared/functions.js"></script>
     <link href="_content/dymaptic.GeoBlazor.Core/assets/esri/themes/light/main.css" rel="stylesheet"/>
-    <script src="https://cdn.jsdelivr.net/npm/@esri/calcite-components@2.0.0/dist/calcite/calcite.esm.js"
-            type="module"></script>
-    <link href="https://cdn.jsdelivr.net/npm/@esri/calcite-components@2.0.0/dist/calcite/calcite.css"
-          rel="stylesheet" type="text/css" />
+    <script type="module" src="https://js.arcgis.com/calcite-components/2.10.1/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/2.10.1/calcite.css" />
 </head>
 
 <body>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Server/Pages/_Layout.cshtml
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Server/Pages/_Layout.cshtml
@@ -16,10 +16,8 @@
         <link href="_content/dymaptic.GeoBlazor.Core.Sample.Shared" />
         <script src="_content/dymaptic.GeoBlazor.Core.Sample.Shared/functions.js"></script>
         <link href="_content/dymaptic.GeoBlazor.Core/assets/esri/themes/light/main.css" rel="stylesheet" />
-        <script src="https://cdn.jsdelivr.net/npm/@@esri/calcite-components@@2.0.0/dist/calcite/calcite.esm.js"
-                    type="module"></script>
-        <link href="https://cdn.jsdelivr.net/npm/@@esri/calcite-components@@2.0.0/dist/calcite/calcite.css"
-              rel="stylesheet" type="text/css" />
+        <script type="module" src="https://js.arcgis.com/calcite-components/2.10.1/calcite.esm.js"></script>
+        <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/2.10.1/calcite.css" />
         <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
     </head>
     <body>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/QueryRelatedFeatures.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/QueryRelatedFeatures.razor
@@ -13,7 +13,8 @@
 <MapView Class="map-view"
          OnClick="OnClick"
          Longitude="-98.5795" Latitude="39.8282"
-         Zoom="3">
+         Zoom="3"
+         PopupEnabled="false">
     <Map>
         <Basemap>
             <PortalItem Id="00c8181753cd4673810a1ede1f52a922" />
@@ -22,7 +23,6 @@
             <PortalItem Id="7a301e848a7c4bfcaefdac4fe98a7f99" />
         </FeatureLayer>
     </Map>
-    <PopupWidget AutoOpenEnabled="false" />
     <ExpandWidget ExpandTooltip="Show Legend" Position="OverlayPosition.TopRight">
         <LegendWidget />
     </ExpandWidget>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ServerSideQueries.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ServerSideQueries.razor
@@ -13,7 +13,8 @@
 <MapView @ref="_mapView"
          OnViewInitialized="OnViewInitialized"
          Class="map-view"
-         OnClick="OnClick">
+         OnClick="OnClick"
+         PopupEnabled="false">
     <Map ArcGISDefaultBasemap="gray-vector">
         <FeatureLayer @ref="_featureLayer" OutFields="@(new[] { "*" })">
             <PortalItem Id="234d2e3f6f554e0e84757662469c26d3" />
@@ -25,8 +26,7 @@
             Ymin="4536523.6511999965">
         <SpatialReference Wkid="102100" />
     </Extent>
-    <PopupWidget AutoOpenEnabled="false"
-                 DockEnabled="true">
+    <PopupWidget DockEnabled="true">
         <PopupDockOptions ButtonEnabled="false"
                           BreakPoint="@(new BreakPoint(false))"
                           Position="PopupDockPosition.BottomRight" />

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/dymaptic.GeoBlazor.Core.Sample.Shared.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/dymaptic.GeoBlazor.Core.Sample.Shared.csproj
@@ -11,10 +11,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Markdig" Version="0.33.0"/>
+        <PackageReference Include="Markdig" Version="0.37.0" />
         <PackageReference Include="MarkdigExtensions.SyntaxHighlighting" Version="1.0.3"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.7"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.7"/>
         <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0"/>
     </ItemGroup>
 

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Wasm/dymaptic.GeoBlazor.Core.Sample.Wasm.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Wasm/dymaptic.GeoBlazor.Core.Sample.Wasm.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Wasm/wwwroot/index.html
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Wasm/wwwroot/index.html
@@ -15,10 +15,8 @@
           rel="stylesheet"/>
     <script src="_content/dymaptic.GeoBlazor.Core.Sample.Shared/functions.js"></script>
     <link href="_content/dymaptic.GeoBlazor.Core/assets/esri/themes/light/main.css" rel="stylesheet"/>
-    <script src="https://cdn.jsdelivr.net/npm/@esri/calcite-components@2.0.0/dist/calcite/calcite.esm.js"
-            type="module"></script>
-    <link href="https://cdn.jsdelivr.net/npm/@esri/calcite-components@2.0.0/dist/calcite/calcite.css"
-          rel="stylesheet" type="text/css" />
+    <script type="module" src="https://js.arcgis.com/calcite-components/2.10.1/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/2.10.1/calcite.css" />
 </head>
 
 <body>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.WasmOAuth/dymaptic.GeoBlazor.Core.Sample.WasmOAuth.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.WasmOAuth/dymaptic.GeoBlazor.Core.Sample.WasmOAuth.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" PrivateAssets="all"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.WasmOAuth/wwwroot/index.html
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.WasmOAuth/wwwroot/index.html
@@ -8,7 +8,8 @@
     <link href="css/app.css" rel="stylesheet"/>
     <link href="_content/dymaptic.GeoBlazor.Core"/>
     <link href="_content/dymaptic.GeoBlazor.Core/assets/esri/themes/light/main.css" rel="stylesheet"/>
-
+    <script type="module" src="https://js.arcgis.com/calcite-components/2.10.1/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/2.10.1/calcite.css" />
     <link href="dymaptic.GeoBlazor.Core.Sample.WasmOAuth.styles.css" rel="stylesheet"/>
 </head>
 

--- a/samples/dymaptic.GeoBlazor.Core.Sample.WebApp/Components/App.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.WebApp/Components/App.razor
@@ -13,10 +13,8 @@
         <link href="_content/dymaptic.GeoBlazor.Core.Sample.Shared" />
         <script src="_content/dymaptic.GeoBlazor.Core.Sample.Shared/functions.js"></script>
         <link href="_content/dymaptic.GeoBlazor.Core/assets/esri/themes/light/main.css" rel="stylesheet" />
-        <script src="https://cdn.jsdelivr.net/npm/@@esri/calcite-components@@2.0.0/dist/calcite/calcite.esm.js"
-                    type="module"></script>
-        <link href="https://cdn.jsdelivr.net/npm/@@esri/calcite-components@@2.0.0/dist/calcite/calcite.css"
-              rel="stylesheet" type="text/css" />
+        <script type="module" src="https://js.arcgis.com/calcite-components/2.10.1/calcite.esm.js"></script>
+        <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/2.10.1/calcite.css" />
         <HeadOutlet @rendermode="@_configuredRenderMode" />
     </head>
 

--- a/samples/dymaptic.GeoBlazor.Core.Sample.WebApp/dymaptic.GeoBlazor.Core.Sample.WebApp.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.WebApp/dymaptic.GeoBlazor.Core.Sample.WebApp.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\dymaptic.GeoBlazor.Core.Sample.Shared\dymaptic.GeoBlazor.Core.Sample.Shared.csproj" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.7" />
         <ProjectReference Include="..\dymaptic.GeoBlazor.Core.Sample.WebApp.Client\dymaptic.GeoBlazor.Core.Sample.WebApp.Client.csproj" />
     </ItemGroup>
 

--- a/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/MapView.razor.cs
@@ -959,7 +959,16 @@ public partial class MapView : MapComponent
     /// </summary>
     [Parameter]
     public long QueryResultsMaxSizeLimit { get; set; } = 1_000_000_000L;
-    
+
+    /// <summary>
+    ///     Controls whether the popup opens when users click on the view.
+    ///     When true, a Popup instance is created and assigned to view.popup the first time the user clicks on the view, unless popup is null. The popup then processes the click event.
+    ///     When false, the click event is ignored and popup is not created for features but will open for other scenarios that use a popup, such as displaying Search results.
+    ///     Default Value:true
+    /// </summary>
+    [Parameter]
+    public bool? PopupEnabled { get; set; }
+
     /// <summary>
     ///     For internal use only, this looks up a missing <see cref="DotNetObjectReference"/> for a <see cref="PopupTemplate"/>
     ///     and returns it to JavaScript.
@@ -2156,7 +2165,7 @@ public partial class MapView : MapComponent
             await ViewJsModule.InvokeVoidAsync("buildMapView", CancellationTokenSource.Token, Id,
                 DotNetObjectReference, Longitude, Latitude, Rotation, Map, Zoom, Scale,
                 mapType, Widgets, Graphics, SpatialReference, Constraints, Extent,
-                EventRateLimitInMilliseconds, GetActiveEventHandlers(), IsServer, HighlightOptions);
+                EventRateLimitInMilliseconds, GetActiveEventHandlers(), IsServer, HighlightOptions, PopupEnabled);
 
             Rendering = false;
             MapRendered = true;

--- a/src/dymaptic.GeoBlazor.Core/Components/Views/SceneView.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/SceneView.cs
@@ -242,7 +242,8 @@ public class SceneView : MapView
                 CancellationTokenSource.Token, Id, DotNetObjectReference,
                 Longitude, Latitude, Rotation, Map, Zoom, Scale,
                 mapType, Widgets, Graphics, SpatialReference, Constraints, Extent,
-                EventRateLimitInMilliseconds, GetActiveEventHandlers(), IsServer, HighlightOptions, ZIndex, Tilt);
+                EventRateLimitInMilliseconds, GetActiveEventHandlers(), IsServer, HighlightOptions,
+                PopupEnabled, ZIndex, Tilt);
             Rendering = false;
             MapRendered = true;
             

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/PopupWidget.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/PopupWidget.cs
@@ -53,6 +53,7 @@ public class PopupWidget : Widget
     ///     DefaultValue: true
     /// </summary>
     [Parameter]
+    [Obsolete("Use MapView.PopupEnabled instead")]
     public bool? AutoOpenEnabled { get; set; }
 
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/ScaleBarWidget.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/ScaleBarWidget.cs
@@ -31,8 +31,10 @@ public class ScaleBarWidget : Widget
 public enum ScaleUnit
 {
 #pragma warning disable CS1591
+    [Obsolete("Use Imperial Instead")]
     NonMetric,
     Metric,
-    Dual
+    Dual,
+    Imperial
 #pragma warning restore CS1591
 }

--- a/src/dymaptic.GeoBlazor.Core/Objects/AttributesDictionary.cs
+++ b/src/dymaptic.GeoBlazor.Core/Objects/AttributesDictionary.cs
@@ -1,8 +1,5 @@
 ﻿using dymaptic.GeoBlazor.Core.Components;
 using ProtoBuf;
-using System.Diagnostics;
-using System.Reflection;
-using System.Reflection.Metadata;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -372,9 +369,15 @@ internal class AttributesDictionaryConverter : JsonConverter<AttributesDictionar
     public override AttributesDictionary? Read(ref Utf8JsonReader reader, Type typeToConvert,
         JsonSerializerOptions options)
     {
+        // if first symbol is array
+        if (reader.TokenType == JsonTokenType.StartArray)
+        {
+            AttributeSerializationRecord[]? records = JsonSerializer.Deserialize<AttributeSerializationRecord[]>(ref reader, options);
+            return new AttributesDictionary(records);
+        }
+        
         // read as a dictionary
-        Dictionary<string, object?>? dictionary =
-            JsonSerializer.Deserialize<Dictionary<string, object?>>(ref reader, options);
+        Dictionary<string, object?>? dictionary = JsonSerializer.Deserialize<Dictionary<string, object?>>(ref reader, options);
 
         if (dictionary is null)
         {

--- a/src/dymaptic.GeoBlazor.Core/Objects/Dimension.cs
+++ b/src/dymaptic.GeoBlazor.Core/Objects/Dimension.cs
@@ -114,6 +114,9 @@ public class Dimension: IEquatable<Dimension>
         throw new FormatException("Invalid dimension string. Formats supported: 12pt, 12px, 12.0, 12.0px, 12.0pt");
     }
 
+    /// <summary>
+    ///     Determines if two Dimensions are equal to each other in Points.
+    /// </summary>
     public bool Equals(Dimension? other)
     {
         if (ReferenceEquals(null, other)) return false;
@@ -122,6 +125,7 @@ public class Dimension: IEquatable<Dimension>
         return Points.Equals(other.Points);
     }
 
+    /// <inheritdoc />
     public override bool Equals(object? obj)
     {
         if (ReferenceEquals(null, obj)) return false;
@@ -131,16 +135,23 @@ public class Dimension: IEquatable<Dimension>
         return Equals((Dimension)obj);
     }
 
+    /// <inheritdoc />
     public override int GetHashCode()
     {
         return Points.GetHashCode();
     }
 
+    /// <summary>
+    ///     Equality Operator
+    /// </summary>
     public static bool operator ==(Dimension? left, Dimension? right)
     {
         return Equals(left, right);
     }
 
+    /// <summary>
+    ///     Inequality Operator
+    /// </summary>
     public static bool operator !=(Dimension? left, Dimension? right)
     {
         return !Equals(left, right);

--- a/src/dymaptic.GeoBlazor.Core/Objects/Dimension.cs
+++ b/src/dymaptic.GeoBlazor.Core/Objects/Dimension.cs
@@ -9,7 +9,7 @@ namespace dymaptic.GeoBlazor.Core.Objects;
 ///     Dimensions can include `pt` or `px` units. If no units are specified, `pt` is assumed.
 /// </summary>
 [JsonConverter(typeof(DimensionConverter))]
-public class Dimension
+public class Dimension: IEquatable<Dimension>
 {
     /// <summary>
     ///     Constructs a new Dimension from a string. Supports `pt` or `px` units. If no units are specified, `pt` is assumed.
@@ -112,6 +112,38 @@ public class Dimension
         }
         
         throw new FormatException("Invalid dimension string. Formats supported: 12pt, 12px, 12.0, 12.0px, 12.0pt");
+    }
+
+    public bool Equals(Dimension? other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+
+        return Points.Equals(other.Points);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (ReferenceEquals(null, obj)) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != this.GetType()) return false;
+
+        return Equals((Dimension)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return Points.GetHashCode();
+    }
+
+    public static bool operator ==(Dimension? left, Dimension? right)
+    {
+        return Equals(left, right);
+    }
+
+    public static bool operator !=(Dimension? left, Dimension? right)
+    {
+        return !Equals(left, right);
     }
 }
 

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -7,54 +7,20 @@ import SceneView from "@arcgis/core/views/SceneView";
 import MapView from "@arcgis/core/views/MapView";
 import WebMap from "@arcgis/core/WebMap";
 import WebScene from "@arcgis/core/WebScene";
-import * as route from "@arcgis/core/rest/route";
-import RouteParameters from "@arcgis/core/rest/support/RouteParameters";
 import FeatureSet from "@arcgis/core/rest/support/FeatureSet";
-import ServiceAreaParameters from "@arcgis/core/rest/support/ServiceAreaParameters";
-import * as serviceArea from "@arcgis/core/rest/serviceArea";
 import Graphic from "@arcgis/core/Graphic";
 import Point from "@arcgis/core/geometry/Point";
 import SpatialReference from "@arcgis/core/geometry/SpatialReference";
-import * as locator from "@arcgis/core/rest/locator";
-import BasemapGallery from "@arcgis/core/widgets/BasemapGallery";
-import ScaleBar from "@arcgis/core/widgets/ScaleBar";
-import Legend from "@arcgis/core/widgets/Legend";
-import PortalBasemapsSource from "@arcgis/core/widgets/BasemapGallery/support/PortalBasemapsSource";
 import Portal from "@arcgis/core/portal/Portal";
-import BasemapToggle from "@arcgis/core/widgets/BasemapToggle";
-import Expand from "@arcgis/core/widgets/Expand";
-import Search from "@arcgis/core/widgets/Search";
-import Locate from "@arcgis/core/widgets/Locate";
 import Widget from "@arcgis/core/widgets/Widget";
-import Measurement from "@arcgis/core/widgets/Measurement";
-import Bookmarks from "@arcgis/core/widgets/Bookmarks";
 import GraphicsLayer from "@arcgis/core/layers/GraphicsLayer";
 import FeatureLayer from "@arcgis/core/layers/FeatureLayer";
-import MapImageLayer from "@arcgis/core/layers/MapImageLayer";
 import Layer from "@arcgis/core/layers/Layer";
-import VectorTileLayer from "@arcgis/core/layers/VectorTileLayer";
-import TileLayer from "@arcgis/core/layers/TileLayer";
-import GeoJSONLayer from "@arcgis/core/layers/GeoJSONLayer";
-import CSVLayer from "@arcgis/core/layers/CSVLayer";
-import GeoRSSLayer from "@arcgis/core/layers/GeoRSSLayer";
-import BingMapsLayer from "@arcgis/core/layers/BingMapsLayer";
 import PopupTemplate from "@arcgis/core/PopupTemplate";
-import Query from "@arcgis/core/rest/support/Query";
 import View from "@arcgis/core/views/View";
 import ArcGisSymbol from "@arcgis/core/symbols/Symbol";
 import Accessor from "@arcgis/core/core/Accessor";
-
-import Home from "@arcgis/core/widgets/Home";
-import Compass from "@arcgis/core/widgets/Compass";
-import LayerList from "@arcgis/core/widgets/LayerList";
-import ListItem from "@arcgis/core/widgets/LayerList/ListItem";
 import * as reactiveUtils from "@arcgis/core/core/reactiveUtils";
-import BasemapLayerList from "@arcgis/core/widgets/BasemapLayerList";
-import FeatureLayerWrapper from "./featureLayer";
-import KMLLayer from "@arcgis/core/layers/KMLLayer";
-import WCSLayer from "@arcgis/core/layers/WCSLayer";
-import ImageryLayer from "@arcgis/core/layers/ImageryLayer.js";
-import ImageryTileLayer from "@arcgis/core/layers/ImageryTileLayer.js";
 
 import {
     buildDotNetBookmark,
@@ -116,36 +82,17 @@ import {
     DotNetViewHit,
     MapCollection
 } from "./definitions";
-import WebTileLayer from "@arcgis/core/layers/WebTileLayer";
-import TileInfo from "@arcgis/core/layers/support/TileInfo";
-import LOD from "@arcgis/core/layers/support/LOD";
-import OpenStreetMapLayer from "@arcgis/core/layers/OpenStreetMapLayer";
-import Camera from "@arcgis/core/Camera";
+import Popup from "@arcgis/core/widgets/Popup";
+import {load} from "protobufjs";
+import AuthenticationManager from "./authenticationManager";
+import Renderer from "@arcgis/core/renderers/Renderer";
+import Color from "@arcgis/core/Color";
+import BasemapStyle from "@arcgis/core/support/BasemapStyle";
 import ProjectionWrapper from "./projection";
 import GeometryEngineWrapper from "./geometryEngine";
 import LocatorWrapper from "./locator";
-import FeatureLayerViewWrapper from "./featureLayerView";
-import Popup from "@arcgis/core/widgets/Popup";
-import ElevationLayer from "@arcgis/core/layers/ElevationLayer";
-import PopupWidgetWrapper from "./popupWidgetWrapper";
-import {load} from "protobufjs";
-import AuthenticationManager from "./authenticationManager";
-import RasterStretchRenderer from "@arcgis/core/renderers/RasterStretchRenderer";
-import DimensionalDefinition from "@arcgis/core/layers/support/DimensionalDefinition";
-import Renderer from "@arcgis/core/renderers/Renderer";
-import Color from "@arcgis/core/Color";
-import BingMapsLayerWrapper from "./bingMapsLayer";
-import SearchWidgetWrapper from "./searchWidgetWrapper";
-import SearchSource from "@arcgis/core/widgets/Search/SearchSource";
-import BasemapStyle from "@arcgis/core/support/BasemapStyle";
-import Slider from "@arcgis/core/widgets/Slider";
-import SliderWidgetWrapper from "./sliderWidgetWrapper";
-import ListItemPanel from "@arcgis/core/widgets/LayerList/ListItemPanel";
-import ImageryTileLayerWrapper from "./imageryTileLayer";
-import HitTestResult = __esri.HitTestResult;
-import MapViewHitTestOptions = __esri.MapViewHitTestOptions;
-import LegendLayerInfos = __esri.LegendLayerInfos;
-import ScreenPoint = __esri.ScreenPoint;
+import Query from "@arcgis/core/rest/support/Query";
+import ListItem from "@arcgis/core/widgets/LayerList/ListItem";
 
 
 export let arcGisObjectRefs: Record<string, Accessor> = {};
@@ -173,17 +120,19 @@ export function setProperty(obj, prop, value) {
     }
 }
 
-export function setSublayerProperty(layerObj: any, sublayerId: number, prop: string, value: any) {
+export async function setSublayerProperty(layerObj: any, sublayerId: number, prop: string, value: any) {
+    let TileLayer = (await import('@arcgis/core/layers/TileLayer')).default;
     let sublayer = (layerObj as TileLayer)?.sublayers.find(sl => sl.id === sublayerId);
     if (hasValue(sublayer)) {
         setProperty(sublayer, prop, value);
     }
 }
 
-export function setSublayerPopupTemplate(layerObj: any, sublayerId: number, popupTemplate: any, viewId: string) {
+export async function setSublayerPopupTemplate(layerObj: any, sublayerId: number, popupTemplate: any, viewId: string) {
+    let TileLayer = (await import('@arcgis/core/layers/TileLayer')).default;
     let sublayer = (layerObj as TileLayer)?.sublayers.find(sl => sl.id === sublayerId);
     if (hasValue(sublayer) && hasValue(popupTemplate)) {
-        sublayer.popupTemplate = buildJsPopupTemplate(popupTemplate, viewId) as PopupTemplate;
+        sublayer.popupTemplate = await buildJsPopupTemplate(popupTemplate, viewId) as PopupTemplate;
     }
 }
 
@@ -193,37 +142,48 @@ export function setAssetsPath(path: string) {
     }
 }
 
-export function getObjectReference(objectRef: any) {
+export async function getObjectReference(objectRef: any) {
     if (!hasValue(objectRef)) return objectRef;
     try {
         // check the class name first, as some esri types fail the `instanceof` check
         switch (objectRef?.__proto__.declaredClass) {
             case 'esri.views.2d.layers.FeatureLayerView2D':
             case 'esri.views.3d.layers.FeatureLayerView3D':
+                let FeatureLayerViewWrapper = (await import("./featureLayerViewWrapper")).default;
                 return new FeatureLayerViewWrapper(objectRef);
         }
         
         if (objectRef instanceof Layer) {
             if (objectRef instanceof FeatureLayer) {
+                let FeatureLayerWrapper = (await import("./featureLayerWrapper")).default;
                 return new FeatureLayerWrapper(objectRef);
             }
+            let BingMapsLayer = (await import("@arcgis/core/layers/BingMapsLayer")).default;
             if (objectRef instanceof BingMapsLayer) {
-                return new BingMapsLayerWrapper(objectRef);
+                let BingMapsLayerWrapper = (await import("./bingMapsLayerWrapper")).default;
+                return new BingMapsLayerWrapper(objectRef as BingMapsLayer);
             }
+            let ImageryTileLayer = (await import("@arcgis/core/layers/ImageryTileLayer")).default;
             if (objectRef instanceof ImageryTileLayer) {
-                return new ImageryTileLayerWrapper(objectRef);
+                let ImageryTileLayerWrapper = (await import("./imageryTileLayerWrapper")).default;
+                return new ImageryTileLayerWrapper(objectRef as ImageryTileLayer);
             }
         }
         if (objectRef instanceof Graphic) {
             return buildDotNetGraphic(objectRef);
         }
         if (objectRef instanceof Popup) {
+            let PopupWidgetWrapper = (await import("./popupWidgetWrapper")).default;
             return new PopupWidgetWrapper(objectRef);
         }
+        let Search = (await import("@arcgis/core/widgets/Search")).default;
         if (objectRef instanceof Search) {
+            let SearchWidgetWrapper = (await import("./searchWidgetWrapper")).default;
             return new SearchWidgetWrapper(objectRef);
         }
+        let Slider = (await import("@arcgis/core/widgets/Slider")).default;
         if (objectRef instanceof Slider) {
+            let SliderWidgetWrapper = (await import("./sliderWidgetWrapper")).default;
             return new SliderWidgetWrapper(objectRef);
         }
         return objectRef;
@@ -574,9 +534,9 @@ function setEventListeners(view: __esri.View, dotNetRef: any, eventRateLimit: nu
         let layerRef;
         let layerViewRef;
         // @ts-ignore
-        layerRef = DotNet.createJSObjectReference(getObjectReference(evt.layer));
+        layerRef = DotNet.createJSObjectReference(await getObjectReference(evt.layer));
         // @ts-ignore
-        layerViewRef = DotNet.createJSObjectReference(getObjectReference(evt.layerView));
+        layerViewRef = DotNet.createJSObjectReference(await getObjectReference(evt.layerView));
 
         let result = {
             layerObjectRef: layerRef,
@@ -725,7 +685,8 @@ export function registerGeoBlazorObject(jsObjectRef: any, geoBlazorId: string) {
     }
 }
 
-export function registerGeoBlazorSublayer(layerId, sublayerId, sublayerGeoBlazorId) {
+export async function registerGeoBlazorSublayer(layerId, sublayerId, sublayerGeoBlazorId) {
+    let TileLayer = (await import('@arcgis/core/layers/TileLayer')).default;
     let layer = arcGisObjectRefs[layerId] as TileLayer;
     arcGisObjectRefs[sublayerGeoBlazorId] = layer.allSublayers.find(sl => sl.id === sublayerId);
 }
@@ -912,6 +873,7 @@ export async function queryFeatureLayer(queryObject: any, layerObject: any, symb
     viewId: string): Promise<void> {
     try {
         setWaitCursor(viewId);
+        let Query = (await import('@arcgis/core/rest/support/Query')).default;
         let query = new Query({
             where: queryObject.where,
             outFields: queryObject.outFields,
@@ -924,7 +886,7 @@ export async function queryFeatureLayer(queryObject: any, layerObject: any, symb
         } else if (hasValue(queryObject.geometry)) {
             query.geometry = buildJsGeometry(queryObject.geometry)!;
         }
-        let popupTemplate = buildJsPopupTemplate(popupTemplateObject, viewId) as PopupTemplate;
+        let popupTemplate = await buildJsPopupTemplate(popupTemplateObject, viewId) as PopupTemplate;
         await addLayer(layerObject, viewId, false, true, () => {
             displayQueryResults(query, symbol, popupTemplate, viewId);
         });
@@ -1012,7 +974,7 @@ export async function updateLayer(layerObject: any, viewId: string): Promise<voi
                 }
 
                 if (hasValue(layerObject.popupTemplate)) {
-                    featureLayer.popupTemplate = buildJsPopupTemplate(layerObject.popupTemplate, viewId) as PopupTemplate;
+                    featureLayer.popupTemplate = await buildJsPopupTemplate(layerObject.popupTemplate, viewId) as PopupTemplate;
                 }
                 // on first pass the renderer is often left blank, but it fills in when the round trip happens to the server
                 if (hasValue(layerObject.renderer) && layerObject.renderer.type !== featureLayer.renderer.type) {
@@ -1038,6 +1000,7 @@ export async function updateLayer(layerObject: any, viewId: string): Promise<voi
 
                 break;
             case 'geo-json':
+                let GeoJSONLayer = (await import('@arcgis/core/layers/GeoJSONLayer')).default;
                 let geoJsonLayer = currentLayer as GeoJSONLayer;
                 if (hasValue(layerObject.renderer)) {
                     let renderer = buildJsRenderer(layerObject.renderer);
@@ -1052,7 +1015,7 @@ export async function updateLayer(layerObject: any, viewId: string): Promise<voi
                     });
                 }
                 if (hasValue(layerObject.popupTemplate)) {
-                    geoJsonLayer.popupTemplate = buildJsPopupTemplate(layerObject.popupTemplate, viewId ?? null) as PopupTemplate;
+                    geoJsonLayer.popupTemplate = await buildJsPopupTemplate(layerObject.popupTemplate, viewId ?? null) as PopupTemplate;
                 }
                 if (hasValue(layerObject.proProperties?.FeatureReduction)) {
                     geoJsonLayer.featureReduction = buildJsFeatureReduction(layerObject.proProperties.FeatureReduction, viewId);
@@ -1062,16 +1025,19 @@ export async function updateLayer(layerObject: any, viewId: string): Promise<voi
                 }
                 break;
             case 'web-tile':
+                let WebTileLayer = (await import('@arcgis/core/layers/WebTileLayer')).default;
                 let webTileLayer = currentLayer as WebTileLayer;
                 copyValuesIfExists(layerObject, webTileLayer,
                     'subDomains', 'blendMode', 'copyright', 'maxScale', 'minScale', 'refreshInterval');
 
                 if (hasValue(layerObject.tileInfo)) {
+                    let TileInfo = (await import('@arcgis/core/layers/support/TileInfo')).default;
                     webTileLayer.tileInfo = new TileInfo();
                     copyValuesIfExists(layerObject.tileInfo, webTileLayer.tileInfo,
                         'dpi', 'format', 'isWrappable', 'size');
 
                     if (hasValue(layerObject.tileInfo.lods)) {
+                        let LOD = (await import('@arcgis/core/layers/support/LOD')).default;
                         webTileLayer.tileInfo.lods = layerObject.tileInfo.lods.map(l => {
                             let lod = new LOD();
                             copyValuesIfExists(l, lod, 'level', 'levelValue', 'resolution', 'scale');
@@ -1093,16 +1059,19 @@ export async function updateLayer(layerObject: any, viewId: string): Promise<voi
 
                 break;
             case 'open-street-map':
+                let OpenStreetMapLayer = (await import('@arcgis/core/layers/OpenStreetMapLayer')).default;
                 let openStreetMapLayer = currentLayer as OpenStreetMapLayer;
                 copyValuesIfExists(layerObject, openStreetMapLayer,
                     'subDomains', 'blendMode', 'copyright', 'maxScale', 'minScale', 'refreshInterval')
 
                 if (hasValue(layerObject.tileInfo)) {
+                    let TileInfo = (await import('@arcgis/core/layers/support/TileInfo')).default;
                     openStreetMapLayer.tileInfo = new TileInfo();
                     copyValuesIfExists(layerObject.tileInfo, openStreetMapLayer.tileInfo,
                         'dpi', 'format', 'isWrappable', 'size');
 
                     if (hasValue(layerObject.tileInfo.lods)) {
+                        let LOD = (await import('@arcgis/core/layers/support/LOD')).default;
                         openStreetMapLayer.tileInfo.lods = layerObject.tileInfo.lods.map(l => {
                             let lod = new LOD();
                             copyValuesIfExists(l, lod, 'level', 'levelValue', 'resolution', 'scale');
@@ -1124,6 +1093,7 @@ export async function updateLayer(layerObject: any, viewId: string): Promise<voi
 
                 break;
             case 'csv':
+                let CSVLayer = (await import('@arcgis/core/layers/CSVLayer')).default;
                 if (hasValue(layerObject.proProperties?.FeatureReduction)) {
                     (currentLayer as CSVLayer).featureReduction = buildJsFeatureReduction(layerObject.proProperties.FeatureReduction, viewId);
                 } else {
@@ -1132,6 +1102,7 @@ export async function updateLayer(layerObject: any, viewId: string): Promise<voi
                 }
                 break;
             case 'map-image':
+                let MapImageLayer = (await import('@arcgis/core/layers/MapImageLayer')).default;
                 copyValuesIfExists(layerObject, currentLayer, 'blendMode', 'customParameters', 'dpi',
                     'gdbVersion', 'imageFormat', 'imageMaxHeight', 'imageMaxWidth', 'imageTransparency', 'legendEnabled',
                     'maxScale', 'minScale', 'refreshInterval', 'timeExtent', 'timeInfo',
@@ -1145,6 +1116,7 @@ export async function updateLayer(layerObject: any, viewId: string): Promise<voi
                 break;
                 
             case 'imagery':
+                let ImageryLayer = (await import('@arcgis/core/layers/ImageryLayer')).default;
                 copyValuesIfExists(layerObject, currentLayer, 'blendMode', 'maxScale', 'minScale', 'bandIds',
                     'compressionQuality', 'compressionTolerance', 'copyright', 'definitionExpression', 'format',
                     'hasMultidimensions', 'imageMaxHeight', 'imageMaxWidth', 'interpolation', 'legendEnabled',
@@ -1160,6 +1132,7 @@ export async function updateLayer(layerObject: any, viewId: string): Promise<voi
                 break;
                 
             case 'imagery-tile':
+                let ImageryTileLayer = (await import('@arcgis/core/layers/ImageryTileLayer')).default;
                 copyValuesIfExists(layerObject, currentLayer, 'blendMode', 'maxScale', 'minScale', 'bandIds',
                     'copyright', 'interpolation', 'legendEnabled', 'useViewTime', 
                     'customParameters');
@@ -1210,14 +1183,17 @@ export async function updateWidget(widgetObject: any, viewId: string): Promise<v
 
         switch (widgetObject.type) {
             case 'bookmarks':
+                let Bookmarks = (await import('@arcgis/core/widgets/Bookmarks')).default;
                 let bookmarks = currentWidget as Bookmarks;
                 if (hasValue(widgetObject.bookmarks)) {
                     bookmarks.bookmarks = widgetObject.bookmarks.map(buildJsBookmark);
                 }
                 break;
             case 'search':
+                let Search = (await import('@arcgis/core/widgets/Search')).default;
                 let search = currentWidget as Search;
                 if (hasValue(widgetObject.sources)) {
+                    let SearchSource = (await import('@arcgis/core/widgets/Search/SearchSource')).default;
                     let sources: SearchSource[] = [];
                     for (const source of widgetObject.sources) {
                         let jsSource = await buildJsSearchSource(source, viewId);
@@ -1228,7 +1204,7 @@ export async function updateWidget(widgetObject: any, viewId: string): Promise<v
                 }
 
                 if (hasValue(widgetObject.popupTemplate)) {
-                    search.popupTemplate = buildJsPopupTemplate(widgetObject.popupTemplate, viewId) as PopupTemplate;
+                    search.popupTemplate = await buildJsPopupTemplate(widgetObject.popupTemplate, viewId) as PopupTemplate;
                 }
 
                 if (hasValue(widgetObject.portal)) {
@@ -1238,6 +1214,7 @@ export async function updateWidget(widgetObject: any, viewId: string): Promise<v
                 }
                 break;
             case 'basemapLayerList':
+                let BasemapLayerList = (await import('@arcgis/core/widgets/BasemapLayerList')).default;
                 let basemapLayerList = currentWidget as BasemapLayerList;
                 if (hasValue(widgetObject.visibleElements)) {
                     basemapLayerList.visibleElements = {
@@ -1261,10 +1238,11 @@ export async function updateWidget(widgetObject: any, viewId: string): Promise<v
         logError(error, viewId);
     }
 }
-export function findPlaces(addressQueryParams: any, symbol: any, popupTemplateObject: any, viewId: string): void {
+export async function findPlaces(addressQueryParams: any, symbol: any, popupTemplateObject: any, viewId: string): void {
     try {
         setWaitCursor(viewId);
         let view = arcGisObjectRefs[viewId] as MapView;
+        let locator = await import('@arcgis/core/rest/locator');
         locator.addressToLocations(addressQueryParams.locatorUrl, {
             location: view.center,
             categories: addressQueryParams.categories,
@@ -1275,7 +1253,7 @@ export function findPlaces(addressQueryParams: any, symbol: any, popupTemplateOb
             .then(function (results) {
                 view.popup.close();
                 view.graphics.removeAll();
-                let popupTemplate = buildJsPopupTemplate(popupTemplateObject, viewId) as PopupTemplate;
+                let popupTemplate = await buildJsPopupTemplate(popupTemplateObject, viewId) as PopupTemplate;
                 results.forEach(function (result) {
                     view.graphics.add(new Graphic({
                         attributes: result.attributes,
@@ -1397,7 +1375,7 @@ export function closePopup(viewId: string): void {
 export async function showPopup(popupTemplateObject: any, location: DotNetPoint, viewId: string): Promise<void> {
     try {
         setWaitCursor(viewId);
-        let popupTemplate = buildJsPopupTemplate(popupTemplateObject, viewId) as PopupTemplate;
+        let popupTemplate = await buildJsPopupTemplate(popupTemplateObject, viewId) as PopupTemplate;
 
         await (arcGisObjectRefs[viewId] as View).openPopup({
             title: popupTemplate.title as string,
@@ -1436,10 +1414,10 @@ export async function addGraphic(streamRefOrGraphicObject: any, viewId: string, 
         let graphicId: string;
         if (streamRefOrGraphicObject.hasOwnProperty("_streamPromise")) {
             let graphics = await getGraphicsFromProtobufStream(streamRefOrGraphicObject) as any[];
-            graphic = buildJsGraphic(graphics[0], viewId) as Graphic;
+            graphic = await buildJsGraphic(graphics[0], viewId) as Graphic;
             graphicId = graphics[0].id;
         } else {
-            graphic = buildJsGraphic(streamRefOrGraphicObject, viewId) as Graphic;
+            graphic = await buildJsGraphic(streamRefOrGraphicObject, viewId) as Graphic;
             graphicId = streamRefOrGraphicObject.id;
         }
         let view = arcGisObjectRefs[viewId] as View;
@@ -1472,7 +1450,7 @@ export async function addGraphicsFromStream(streamRef: any, viewId: string, abor
             if (abortSignal.aborted) {
                 return;
             }
-            let jsGraphic = buildJsGraphic(g, viewId) as Graphic;
+            let jsGraphic = await buildJsGraphic(g, viewId) as Graphic;
             jsGraphics.push(jsGraphic);
         }
         if (abortSignal.aborted) {
@@ -1505,7 +1483,7 @@ export function addGraphicsSynchronously(graphicsArray: Uint8Array, viewId: stri
         let jsGraphics: Graphic[] = [];
         let view = arcGisObjectRefs[viewId] as View;
         for (const g of graphics) {
-            let jsGraphic = buildJsGraphic(g, viewId) as Graphic;
+            let jsGraphic = await buildJsGraphic(g, viewId) as Graphic;
             jsGraphics.push(jsGraphic);
         }
         if (hasValue(layerId)) {
@@ -1569,7 +1547,7 @@ export function getGraphicVisibility(id: string): boolean {
 export function setGraphicPopupTemplate(id: string, popupTemplate: DotNetPopupTemplate, dotNetRef: any, viewId: string): void {
     let graphic = graphicsRefs[id];
     popupTemplate.dotNetPopupTemplateReference = dotNetRef;
-    let jsPopupTemplate = buildJsPopupTemplate(popupTemplate, viewId) as PopupTemplate;
+    let jsPopupTemplate = await buildJsPopupTemplate(popupTemplate, viewId) as PopupTemplate;
     if (hasValue(graphic) && hasValue(popupTemplate) && graphic.popupTemplate !== jsPopupTemplate) {
         graphic.popupTemplate = jsPopupTemplate;
     }
@@ -1641,6 +1619,8 @@ export function clearGraphics(viewId: string, layerId?: string | null): void {
 export async function drawRouteAndGetDirections(routeUrl: string, routeSymbol: any, viewId: string): Promise<any[]> {
     try {
         setWaitCursor(viewId);
+        let route = await import('@arcgis/core/rest/route');
+        let RouteParameters = (await import('@arcgis/core/rest/support/RouteParameters')).default;
         let view = arcGisObjectRefs[viewId] as View;
         const routeParams = new RouteParameters({
             stops: new FeatureSet({
@@ -1676,9 +1656,12 @@ export async function drawRouteAndGetDirections(routeUrl: string, routeSymbol: a
     return [];
 }
 
-export function solveServiceArea(url: string, driveTimeCutoffs: number[], serviceAreaSymbol: any, viewId: string): void {
+export async function solveServiceArea(url: string, driveTimeCutoffs: number[], serviceAreaSymbol: any, viewId: string): void {
     try {
         setWaitCursor(viewId);
+        let ServiceAreaParameters = (await import('@arcgis/core/rest/support/ServiceAreaParameters')).default;
+        let serviceArea = await import('@arcgis/core/rest/serviceArea');
+        
         let view = arcGisObjectRefs[viewId] as View;
         const featureSet = new FeatureSet({
             features: [(view.graphics as MapCollection).items[0]]
@@ -1778,7 +1761,7 @@ export async function goToGraphics(graphics, viewId: string): Promise<void> {
     for (const graphic of graphics) {
         delete graphic.dotNetGraphicReference;
         delete graphic.layerId;
-        let jsGraphic = buildJsGraphic(graphic, viewId);
+        let jsGraphic = await buildJsGraphic(graphic, viewId);
         if (jsGraphic !== null) {
             jsGraphics.push(jsGraphic);
         }
@@ -1860,6 +1843,7 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
     let newWidget: Widget;
     switch (widget.type) {
         case 'locate':
+            let Locate = (await import('@arcgis/core/widgets/Locate')).default;
             const locate = new Locate({
                 view: view,
                 rotationEnabled: widget.rotationEnabled ?? undefined,
@@ -1876,12 +1860,14 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
 
             break;
         case 'search':
+            let Search = (await import('@arcgis/core/widgets/Search')).default;
             const search = new Search({
                 view: view
             });
             newWidget = search;
 
             if (hasValue(widget.sources)) {
+                let SearchSource = (await import('@arcgis/core/widgets/Search/SearchSource')).default;
                 let sources: SearchSource[] = [];
                 for (const source of widget.sources) {
                     let jsSource = await buildJsSearchSource(source, viewId);
@@ -1891,7 +1877,7 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
             }
 
             if (hasValue(widget.popupTemplate)) {
-                search.popupTemplate = buildJsPopupTemplate(widget.popupTemplate, viewId) as PopupTemplate;
+                search.popupTemplate = await buildJsPopupTemplate(widget.popupTemplate, viewId) as PopupTemplate;
             }
 
             if (hasValue(widget.portal)) {
@@ -1921,6 +1907,7 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
                 'searchTerm', 'suggestionsEnabled');
             break;
         case 'basemapToggle':
+            let BasemapToggle = (await import('@arcgis/core/widgets/BasemapToggle')).default;
             // the esri definition file is missing basemapToggle.nextBasemap, but it is in the docs.
             let basemapToggle = new BasemapToggle({
                 view: view
@@ -1938,6 +1925,8 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
             }
             break;
         case 'basemapGallery':
+            let BasemapGallery = (await import('@arcgis/core/widgets/BasemapGallery')).default;
+            let PortalBasemapsSource = (await import('@arcgis/core/widgets/BasemapGallery/support/PortalBasemapsSource')).default;
             let source = new PortalBasemapsSource();
             if (hasValue(widget.portalBasemapsSource)) {
                 const portal = new Portal();
@@ -1966,6 +1955,7 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
             });
             break;
         case 'scaleBar':
+            let ScaleBar = (await import('@arcgis/core/widgets/ScaleBar')).default;
             const scaleBar = new ScaleBar({
                 view: view
             });
@@ -1975,6 +1965,7 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
             }
             break;
         case 'legend':
+            let Legend = (await import('@arcgis/core/widgets/Legend')).default;
             const legend = new Legend({
                 view: view
             });
@@ -2010,6 +2001,7 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
             }
             break;
         case 'home':
+            let Home = (await import('@arcgis/core/widgets/Home')).default;
             const homeBtn = new Home({
                 view: view,
             });
@@ -2019,12 +2011,14 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
             }
             break;
         case 'compass':
+            let Compass = (await import('@arcgis/core/widgets/Compass')).default;
             const compassWidget = new Compass({
                 view: view
             });
             newWidget = compassWidget;
             break;
         case 'layerList':
+            let LayerList = (await import('@arcgis/core/widgets/LayerList')).default;
             const layerListWidget = new LayerList({
                 view: view
             });
@@ -2035,13 +2029,14 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
                     let dotNetListItem = buildDotNetListItem(evt.item);
                     let returnItem = await widget.layerListWidgetObjectReference.invokeMethodAsync('OnListItemCreated', dotNetListItem) as DotNetListItem;
                     if (hasValue(returnItem)) {
-                        updateListItem(evt.item, returnItem);
+                        await updateListItem(evt.item, returnItem);
                     }
                 };
             }
 
             break;
         case 'basemapLayerList':
+            let BasemapLayerList = (await import('@arcgis/core/widgets/BasemapLayerList')).default;
             const basemapLayerListWidget = new BasemapLayerList({
                 view: view
             });
@@ -2052,7 +2047,7 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
                     let dotNetBaseListItem = buildDotNetListItem(evt.item);
                     let returnItem = await widget.baseLayerListWidgetObjectReference.invokeMethodAsync('OnBaseListItemCreated', dotNetBaseListItem) as DotNetListItem;
                     if (hasValue(returnItem)) {
-                        updateListItem(evt.item, returnItem);
+                        await updateListItem(evt.item, returnItem);
                     }
                 };
             }
@@ -2061,7 +2056,7 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
                     let dotNetReferenceListItem = buildDotNetListItem(evt.item);
                     let returnItem = await widget.baseLayerListWidgetObjectReference.invokeMethodAsync('OnReferenceListItemCreated', dotNetReferenceListItem) as DotNetListItem;
                     if (hasValue(returnItem)) {
-                        updateListItem(evt.item, returnItem);
+                        await updateListItem(evt.item, returnItem);
                     }
                 };
             }
@@ -2080,6 +2075,7 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
             
             break;
         case 'expand':
+            let Expand = (await import('@arcgis/core/widgets/Expand')).default;
             let content: any;
             let expandWidgetDiv = 
                 document.getElementById(`widget-container-${widget.id}`) as HTMLElement;
@@ -2143,6 +2139,7 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
             newWidget = await setPopup(widget, viewId) as Popup;
             break;
         case 'measurement':
+            let Measurement = (await import('@arcgis/core/widgets/Measurement')).default;
             newWidget = new Measurement({
                 view: view,
                 activeTool: widget.activeTool ?? undefined,
@@ -2152,6 +2149,7 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
             });
             break;
         case 'bookmarks':
+            let Bookmarks = (await import('@arcgis/core/widgets/Bookmarks')).default;
             const bookmarkWidget = new Bookmarks({
                 view: view,
                 editingEnabled: widget.editingEnabled,
@@ -2171,6 +2169,7 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
             newWidget = bookmarkWidget;
             break;
         case 'slider':
+            let Slider = (await import('@arcgis/core/widgets/Slider')).default;
             const slider = new Slider({
                 container: widget.containerId
             });
@@ -2312,12 +2311,12 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
     arcGisObjectRefs[widget.id] = newWidget;
     dotNetRefs[widget.id] = widget.dotNetComponentReference;
     // @ts-ignore
-    let jsRef = DotNet.createJSObjectReference(getObjectReference(newWidget));
+    let jsRef = DotNet.createJSObjectReference(await getObjectReference(newWidget));
     await widget.dotNetWidgetReference.invokeMethodAsync('OnJsWidgetCreated', jsRef);
     return newWidget;
 }
 
-function updateListItem(jsItem: ListItem, dnItem: DotNetListItem) {
+async function updateListItem(jsItem: ListItem, dnItem: DotNetListItem) {
     copyValuesIfExists(dnItem, jsItem, 'title', 'visible', 'childrenSortable', 'hidden',
         'open', 'sortable');
     
@@ -2325,7 +2324,7 @@ function updateListItem(jsItem: ListItem, dnItem: DotNetListItem) {
         for (let i = 0; i < dnItem.children.length; i++) {
             let child = dnItem.children[i];
             let jsChild = jsItem.children[i];
-            updateListItem(jsChild, child);
+            await updateListItem(jsChild, child);
         }
     }
     if (hasValue(dnItem.actionsSections)) {
@@ -2336,7 +2335,7 @@ function updateListItem(jsItem: ListItem, dnItem: DotNetListItem) {
             let dnSection = dnItem.actionsSections[i];
             for (let j = 0; j < dnSection.length; j++) {
                 let dnAction = dnSection[j];
-                let action = buildJsAction(dnAction);
+                let action = await buildJsAction(dnAction);
                 section.push(action);
             }
         }
@@ -2348,6 +2347,7 @@ function updateListItem(jsItem: ListItem, dnItem: DotNetListItem) {
     }
     
     if (hasValue(dnItem.panel)) {
+        let ListItemPanel = (await import('@arcgis/core/widgets/LayerList/ListItemPanel')).default;
         if (hasValue(dnItem.panel.contentDivId)) {
             let contentDiv = document.getElementById(dnItem.panel.contentDivId);
             if (contentDiv !== null) {
@@ -2449,7 +2449,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
         let oldLayer = arcGisObjectRefs[layerObject.id] as Layer;
         if (!oldLayer.destroyed) {
             if (wrap) {
-                return getObjectReference(arcGisObjectRefs[layerObject.id] as Layer);
+                return await getObjectReference(arcGisObjectRefs[layerObject.id] as Layer);
             }
             return arcGisObjectRefs[layerObject.id] as Layer;
         }
@@ -2461,7 +2461,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             let graphicsLayer = newLayer as GraphicsLayer;
             let jsGraphics: Graphic[] = [];
             for (const g of layerObject.graphics) {
-                let jsGraphic = buildJsGraphic(g, viewId ?? null) as Graphic;
+                let jsGraphic = await buildJsGraphic(g, viewId ?? null) as Graphic;
                 jsGraphics.push(jsGraphic);
             }
             graphicsLayer.addMany(jsGraphics);
@@ -2492,7 +2492,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
                 if (hasValue(layerObject.source)) {
                     for (let i = 0; i < layerObject.source.length; i++) {
                         const graphicObject = layerObject.source[i];
-                        let graphic = buildJsGraphic(graphicObject, viewId ?? null);
+                        let graphic = await buildJsGraphic(graphicObject, viewId ?? null);
                         if (graphic !== null) {
                             source.push(graphic);
                         }
@@ -2514,7 +2514,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             }
 
             if (hasValue(layerObject.popupTemplate)) {
-                featureLayer.popupTemplate = buildJsPopupTemplate(layerObject.popupTemplate, viewId ?? null) as PopupTemplate;
+                featureLayer.popupTemplate = await buildJsPopupTemplate(layerObject.popupTemplate, viewId ?? null) as PopupTemplate;
             }
             if (hasValue(layerObject.renderer)) {
                 let renderer = buildJsRenderer(layerObject.renderer);
@@ -2542,6 +2542,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             }
             break;
         case 'map-image':
+            let MapImageLayer = (await import('@arcgis/core/layers/MapImageLayer')).default;
             if (hasValue(layerObject.portalItem)) {
                 let portalItem = buildJsPortalItem(layerObject.portalItem);
                 newLayer = new MapImageLayer({ portalItem: portalItem });
@@ -2561,6 +2562,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             }
             break;
         case 'vector-tile':
+            let VectorTileLayer = (await import('@arcgis/core/layers/VectorTileLayer')).default;
             if (hasValue(layerObject.portalItem)) {
                 let portalItem = buildJsPortalItem(layerObject.portalItem);
                 newLayer = new VectorTileLayer({ portalItem: portalItem });
@@ -2571,6 +2573,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             }
             break;
         case 'tile':
+            let TileLayer = (await import('@arcgis/core/layers/TileLayer')).default;
             if (hasValue(layerObject.portalItem)) {
                 let portalItem = buildJsPortalItem(layerObject.portalItem);
 
@@ -2591,6 +2594,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             
             break;
         case 'elevation':
+            let ElevationLayer = (await import('@arcgis/core/layers/ElevationLayer')).default;
             if (hasValue(layerObject.portalItem)) {
                 let portalItem = buildJsPortalItem(layerObject.portalItem);
                 newLayer = new ElevationLayer({ portalItem: portalItem });
@@ -2601,6 +2605,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             }
             break;
         case 'geo-json':
+            let GeoJSONLayer = (await import('@arcgis/core/layers/GeoJSONLayer')).default;
             newLayer = new GeoJSONLayer({
                 url: layerObject.url
             });
@@ -2612,7 +2617,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
                 gjLayer.spatialReference = buildJsSpatialReference(layerObject.spatialReference);
             }
             if (hasValue(layerObject.popupTemplate)) {
-                gjLayer.popupTemplate = buildJsPopupTemplate(layerObject.popupTemplate, viewId ?? null) as PopupTemplate;
+                gjLayer.popupTemplate = await buildJsPopupTemplate(layerObject.popupTemplate, viewId ?? null) as PopupTemplate;
             }
             if (hasValue(layerObject.proProperties?.FeatureReduction)) {
                 (newLayer as GeoJSONLayer).featureReduction = buildJsFeatureReduction(layerObject.proProperties.FeatureReduction, viewId!);
@@ -2621,9 +2626,11 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             copyValuesIfExists(layerObject, gjLayer, 'copyright');
             break;
         case 'geo-rss':
+            let GeoRSSLayer = (await import('@arcgis/core/layers/GeoRSSLayer')).default;
             newLayer = new GeoRSSLayer({ url: layerObject.url });
             break;
         case 'web-tile':
+            let WebTileLayer = (await import('@arcgis/core/layers/WebTileLayer')).default;
             let webTileLayer: WebTileLayer;
             if (hasValue(layerObject.urlTemplate)) {
                 webTileLayer = new WebTileLayer({
@@ -2639,11 +2646,13 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
                 'subDomains', 'blendMode', 'copyright', 'maxScale', 'minScale', 'refreshInterval');
 
             if (hasValue(layerObject.tileInfo)) {
+                let TileInfo = (await import('@arcgis/core/layers/support/TileInfo')).default;
                 webTileLayer.tileInfo = new TileInfo();
                 copyValuesIfExists(layerObject.tileInfo, webTileLayer.tileInfo,
                     'dpi', 'format', 'isWrappable', 'size');
 
                 if (hasValue(layerObject.tileInfo.lods)) {
+                    let LOD = (await import('@arcgis/core/layers/support/LOD')).default;
                     webTileLayer.tileInfo.lods = layerObject.tileInfo.lods.map(l => {
                         let lod = new LOD();
                         copyValuesIfExists(l, lod, 'level', 'levelValue', 'resolution', 'scale');
@@ -2662,6 +2671,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
 
             break;
         case 'open-street-map':
+            let OpenStreetMapLayer = (await import('@arcgis/core/layers/OpenStreetMapLayer')).default;
             let openStreetMapLayer: OpenStreetMapLayer;
             if (hasValue(layerObject.urlTemplate)) {
                 openStreetMapLayer = new OpenStreetMapLayer({
@@ -2679,11 +2689,13 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
                 'subDomains', 'blendMode', 'copyright', 'maxScale', 'minScale', 'refreshInterval')
 
             if (hasValue(layerObject.tileInfo)) {
+                let TileInfo = (await import('@arcgis/core/layers/support/TileInfo')).default;
                 openStreetMapLayer.tileInfo = new TileInfo();
                 copyValuesIfExists(layerObject.tileInfo, openStreetMapLayer.tileInfo,
                     'dpi', 'format', 'isWrappable', 'size');
 
                 if (hasValue(layerObject.tileInfo.lods)) {
+                    let LOD = (await import('@arcgis/core/layers/support/LOD')).default;
                     openStreetMapLayer.tileInfo.lods = layerObject.tileInfo.lods.map(l => {
                         let lod = new LOD();
                         copyValuesIfExists(l, lod, 'level', 'levelValue', 'resolution', 'scale');
@@ -2702,6 +2714,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
 
             break;
         case 'csv':
+            let CSVLayer = (await import('@arcgis/core/layers/CSVLayer')).default;
             newLayer = new CSVLayer({
                 url: layerObject.url,
                 copyright: layerObject.copyright
@@ -2716,7 +2729,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
                 });
             }
             if (hasValue(layerObject.popupTemplate)) {
-                csvLayer.popupTemplate = buildJsPopupTemplate(layerObject.popupTemplate, viewId ?? null) as PopupTemplate;
+                csvLayer.popupTemplate = await buildJsPopupTemplate(layerObject.popupTemplate, viewId ?? null) as PopupTemplate;
             }
             if (hasValue(layerObject.proProperties?.FeatureReduction)) {
                 (newLayer as CSVLayer).featureReduction = buildJsFeatureReduction(layerObject.proProperties.FeatureReduction, viewId!);
@@ -2725,6 +2738,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             copyValuesIfExists(layerObject, csvLayer, 'blendMode', 'copyright', 'delimiter', 'displayField');
             break;
         case 'kml':
+            let KMLLayer = (await import('@arcgis/core/layers/KMLLayer')).default;
             let kmlLayer: KMLLayer;
             if (hasValue(layerObject.url)) {
                 kmlLayer = new KMLLayer({
@@ -2738,6 +2752,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             copyValuesIfExists(layerObject, kmlLayer, 'sublayers', 'blendMode', 'maxScale', 'minScale', 'title', 'visible');
             break;
         case 'wcs':
+            let WCSLayer = (await import('@arcgis/core/layers/WCSLayer')).default;
             newLayer = new WCSLayer({
                 url: layerObject.url,
                 title: layerObject.title
@@ -2745,12 +2760,14 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             let wcsLayer = newLayer as WCSLayer;
 
             if (hasValue(layerObject.renderer) && (layerObject.renderer.type == 'raster-stretch')) {
+                let RasterStretchRenderer = (await import('@arcgis/core/renderers/RasterStretchRenderer')).default;
                 wcsLayer.renderer = buildJsRasterStretchRenderer(layerObject.renderer) as RasterStretchRenderer;
             }
             if (hasValue(layerObject.multidimensionalDefinition) && layerObject.multidimensionalDefinition.length > 0) {
                 wcsLayer.multidimensionalDefinition = [];
+                let DimensionalDefinition = await (await import('@arcgis/core/layers/support/DimensionalDefinition')).default;
                 for (let i = 0; i < layerObject.multidimensionalDefinition.length; i++) {
-
+                
                     let wcsMDD = new DimensionalDefinition;
                     if (hasValue(layerObject.multidimensionalDefinition.VariableName)) {
                         wcsMDD.variableName = layerObject.multidimensionalDefinition.VariableName;
@@ -2772,6 +2789,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             newLayer = wcsLayer;
             break;
         case 'bing-maps':
+            let BingMapsLayer = (await import('@arcgis/core/layers/BingMapsLayer')).default;
             const bing = new BingMapsLayer({
                 key: layerObject.key,
                 style: layerObject.style
@@ -2790,6 +2808,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             copyValuesIfExists('blendMode', 'maxScale', 'minScale', 'refreshInterval');
             break;
         case 'imagery':
+            let ImageryLayer = (await import('@arcgis/core/layers/ImageryLayer')).default;
             if (hasValue(layerObject.url)) {
                 newLayer = new ImageryLayer({
                     url: layerObject.url
@@ -2820,7 +2839,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             }
             
             if (hasValue(layerObject.popupTemplate)) {
-                imageryLayer.popupTemplate = buildJsPopupTemplate(layerObject.popupTemplate, viewId ?? null) as PopupTemplate;
+                imageryLayer.popupTemplate = await buildJsPopupTemplate(layerObject.popupTemplate, viewId ?? null) as PopupTemplate;
             }
 
             copyValuesIfExists('bandIds', 'blendMode', 'compressionQuality', 'compressionTolerance',
@@ -2833,6 +2852,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
             newLayer = imageryLayer;
             break;
         case 'imagery-tile':
+            let ImageryTileLayer = (await import('@arcgis/core/layers/ImageryTileLayer')).default;
             if (hasValue(layerObject.url)) {
                 newLayer = new ImageryTileLayer({
                     url: layerObject.url
@@ -2855,7 +2875,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
                 imageryTileLayer.multidimensionalSubset = buildJsMultidimensionalSubset(layerObject.multidimensionsionalSubset);
             }
             if (hasValue(layerObject.popupTemplate)) {
-                imageryTileLayer.popupTemplate = buildJsPopupTemplate(layerObject.popupTemplate, viewId ?? null) as PopupTemplate;
+                imageryTileLayer.popupTemplate = await buildJsPopupTemplate(layerObject.popupTemplate, viewId ?? null) as PopupTemplate;
             }
 
             copyValuesIfExists('bandIds', 'blendMode', 'copyright', 'interpolation', 
@@ -2878,7 +2898,7 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
     arcGisObjectRefs[layerObject.id] = newLayer;
 
     if (wrap) {
-        return getObjectReference(newLayer);
+        return await getObjectReference(newLayer);
     }
 
     return newLayer;
@@ -3332,7 +3352,8 @@ export function getWebMapBookmarks(viewId: string) {
     return null;
 }
 
-export function setStretchTypeForRenderer(rendererId, stretchType) {
+export async function setStretchTypeForRenderer(rendererId, stretchType) {
+    let RasterStretchRenderer = (await import('@arcgis/core/renderers/RasterStretchRenderer')).default;
     let renderer = arcGisObjectRefs[rendererId] as RasterStretchRenderer;
     renderer.stretchType = stretchType;
 }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
@@ -867,11 +867,11 @@ export function buildDotNetExpressionInfo(expressionInfo: any): DotNetExpression
 }
 
 export function buildDotNetFieldInfoFormat(format: FieldInfoFormat | null): DotNetFieldInfoFormat | null {
-    if (format === null) return null;
+    if (!hasValue(format)) return null;
     return {
-        dateFormat: format.dateFormat,
-        digitSeparator: format.digitSeparator,
-        places: format.places
+        dateFormat: format!.dateFormat,
+        digitSeparator: format!.digitSeparator,
+        places: format!.places
     } as DotNetFieldInfoFormat;
 }
 

--- a/src/dymaptic.GeoBlazor.Core/Scripts/featureLayer.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/featureLayer.ts
@@ -210,7 +210,7 @@ export default class FeatureLayerWrapper implements IPropertyWrapper {
         abortSignal: AbortSignal): Promise<any> {
         let jsGraphics: Graphic[] = [];
         for (const g of graphics) {
-            let jsGraphic = await buildJsGraphic(g, viewId) as Graphic;
+            let jsGraphic = buildJsGraphic(g, viewId) as Graphic;
             jsGraphics.push(jsGraphic);
         }
         if (abortSignal.aborted) {
@@ -316,8 +316,8 @@ export default class FeatureLayerWrapper implements IPropertyWrapper {
     async getFieldDomain(fieldName: string, graphic: DotNetGraphic): Promise<DotNetDomain | null> {
 
         let options: any | undefined = undefined;
-        if (graphic !== null && graphic !== undefined) {
-            let featureGraphic = await buildJsGraphic(graphic, null) as Graphic;
+        if (graphic != null && graphic != undefined) {
+            let featureGraphic = buildJsGraphic(graphic, null) as Graphic;
             options = {
                 feature: featureGraphic
             };

--- a/src/dymaptic.GeoBlazor.Core/Scripts/featureLayer.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/featureLayer.ts
@@ -210,7 +210,7 @@ export default class FeatureLayerWrapper implements IPropertyWrapper {
         abortSignal: AbortSignal): Promise<any> {
         let jsGraphics: Graphic[] = [];
         for (const g of graphics) {
-            let jsGraphic = buildJsGraphic(g, viewId) as Graphic;
+            let jsGraphic = await buildJsGraphic(g, viewId) as Graphic;
             jsGraphics.push(jsGraphic);
         }
         if (abortSignal.aborted) {
@@ -316,8 +316,8 @@ export default class FeatureLayerWrapper implements IPropertyWrapper {
     async getFieldDomain(fieldName: string, graphic: DotNetGraphic): Promise<DotNetDomain | null> {
 
         let options: any | undefined = undefined;
-        if (graphic != null && graphic != undefined) {
-            let featureGraphic = buildJsGraphic(graphic, null) as Graphic;
+        if (graphic !== null && graphic !== undefined) {
+            let featureGraphic = await buildJsGraphic(graphic, null) as Graphic;
             options = {
                 feature: featureGraphic
             };

--- a/src/dymaptic.GeoBlazor.Core/Scripts/graphic.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/graphic.ts
@@ -59,8 +59,8 @@ export default class GraphicWrapper implements IPropertyWrapper {
         return this.graphic.visible;
     }
 
-    async setPopupTemplate(popupTemplate: DotNetPopupTemplate, viewId: string): Promise<void> {
-        let jsPopupTemplate = await buildJsPopupTemplate(popupTemplate, viewId);
+    setPopupTemplate(popupTemplate: DotNetPopupTemplate, viewId: string): void {
+        let jsPopupTemplate = buildJsPopupTemplate(popupTemplate, viewId);
         if (jsPopupTemplate !== null && this.graphic.popupTemplate !== jsPopupTemplate) {
             this.graphic.popupTemplate = jsPopupTemplate;
         }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/graphic.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/graphic.ts
@@ -59,8 +59,8 @@ export default class GraphicWrapper implements IPropertyWrapper {
         return this.graphic.visible;
     }
 
-    setPopupTemplate(popupTemplate: DotNetPopupTemplate, viewId: string): void {
-        let jsPopupTemplate = buildJsPopupTemplate(popupTemplate, viewId);
+    async setPopupTemplate(popupTemplate: DotNetPopupTemplate, viewId: string): Promise<void> {
+        let jsPopupTemplate = await buildJsPopupTemplate(popupTemplate, viewId);
         if (jsPopupTemplate !== null && this.graphic.popupTemplate !== jsPopupTemplate) {
             this.graphic.popupTemplate = jsPopupTemplate;
         }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -11,35 +11,8 @@ import Geometry from "@arcgis/core/geometry/Geometry";
 import Point from "@arcgis/core/geometry/Point";
 import Polyline from "@arcgis/core/geometry/Polyline";
 import Polygon from "@arcgis/core/geometry/Polygon";
-import TextSymbol from "@arcgis/core/symbols/TextSymbol";
-import SimpleRenderer from "@arcgis/core/renderers/SimpleRenderer";
 import Renderer from "@arcgis/core/renderers/Renderer";
-import Field from "@arcgis/core/layers/support/Field";
-import Font from "@arcgis/core/symbols/Font";
-import Bookmark from "@arcgis/core/webmap/Bookmark"
-import Viewpoint from "@arcgis/core/Viewpoint";
-import FeatureEffect from "@arcgis/core/layers/support/FeatureEffect";
-import FeatureFilter from "@arcgis/core/layers/support/FeatureFilter";
-import RasterStretchRenderer from "@arcgis/core/renderers/RasterStretchRenderer.js"
-import ColorRamp from "@arcgis/core/rest/support/ColorRamp.js";
-import DimensionalDefinition from "@arcgis/core/layers/support/DimensionalDefinition.js";
-import MultipartColorRamp from "@arcgis/core/rest/support/MultipartColorRamp.js";
-import AlgorithmicColorRamp from "@arcgis/core/rest/support/AlgorithmicColorRamp.js";
-import RasterShadedReliefRenderer from "@arcgis/core/renderers/RasterShadedReliefRenderer.js";
-import RasterColormapRenderer from "@arcgis/core/renderers/RasterColormapRenderer.js";
-import VectorFieldRenderer from "@arcgis/core/renderers/VectorFieldRenderer.js";
-import FlowRenderer from "@arcgis/core/renderers/FlowRenderer.js";
-import ClassBreaksRenderer from "@arcgis/core/renderers/ClassBreaksRenderer.js";
-import ClassBreakInfo from "@arcgis/core/renderers/support/ClassBreakInfo.js";
-import UniqueValueRenderer from "@arcgis/core/renderers/UniqueValueRenderer.js";
-import ColormapInfo from "@arcgis/core/renderers/support/ColormapInfo.js";
-import MultidimensionalSubset from "@arcgis/core/layers/support/MultidimensionalSubset.js";
-import PolygonSymbol3D from "@arcgis/core/symbols/PolygonSymbol3D.js";
-import FieldsIndex from "@arcgis/core/layers/support/FieldsIndex.js";
-import UniqueValue from "@arcgis/core/renderers/support/UniqueValue.js";
-import UniqueValueInfo from "@arcgis/core/renderers/support/UniqueValueInfo.js";
-import UniqueValueClass from "@arcgis/core/renderers/support/UniqueValueClass.js";
-import UniqueValueGroup from "@arcgis/core/renderers/support/UniqueValueGroup.js";
+
 import {
     DotNetApplyEdits,
     DotNetAttachmentsEdit,
@@ -92,86 +65,11 @@ import {
     DotNetViewpoint,
     DotNetVisualVariable, DotNetFeatureSet, DotNetPictureFillSymbol,
 } from "./definitions";
-import PictureMarkerSymbol from "@arcgis/core/symbols/PictureMarkerSymbol";
-import PictureFillSymbol from "@arcgis/core/symbols/PictureFillSymbol";
 import Popup from "@arcgis/core/widgets/Popup";
 import Query from "@arcgis/core/rest/support/Query";
-import FieldsContent from "@arcgis/core/popup/content/FieldsContent";
-import TextContent from "@arcgis/core/popup/content/TextContent";
-import FieldInfo from "@arcgis/core/popup/FieldInfo";
-import FieldInfoFormat from "@arcgis/core/popup/support/FieldInfoFormat";
-import MediaContent from "@arcgis/core/popup/content/MediaContent";
-import BarChartMediaInfo from "@arcgis/core/popup/content/BarChartMediaInfo";
-import ColumnChartMediaInfo from "@arcgis/core/popup/content/ColumnChartMediaInfo";
-import ChartMediaInfoValue from "@arcgis/core/popup/content/support/ChartMediaInfoValue";
-import ImageMediaInfoValue from "@arcgis/core/popup/content/support/ImageMediaInfoValue";
-import ImageMediaInfo from "@arcgis/core/popup/content/ImageMediaInfo";
-import LineChartMediaInfo from "@arcgis/core/popup/content/LineChartMediaInfo";
-import PieChartMediaInfo from "@arcgis/core/popup/content/PieChartMediaInfo";
-import AttachmentsContent from "@arcgis/core/popup/content/AttachmentsContent";
-import ExpressionContent from "@arcgis/core/popup/content/ExpressionContent";
 import Layer from "@arcgis/core/layers/Layer";
-import RelationshipQuery from "@arcgis/core/rest/support/RelationshipQuery";
-import TopFeaturesQuery from "@arcgis/core/rest/support/TopFeaturesQuery";
-import popupExpressionInfo from "@arcgis/core/popup/ExpressionInfo";
-import SimpleMarkerSymbol from "@arcgis/core/symbols/SimpleMarkerSymbol";
 import Symbol from "@arcgis/core/symbols/Symbol";
-import SimpleFillSymbol from "@arcgis/core/symbols/SimpleFillSymbol";
-import SimpleLineSymbol from "@arcgis/core/symbols/SimpleLineSymbol";
-import ElementExpressionInfo from "@arcgis/core/popup/ElementExpressionInfo";
-import ChartMediaInfoValueSeries from "@arcgis/core/popup/content/support/ChartMediaInfoValueSeries";
-import { buildDotNetGraphic, buildDotNetPoint, buildDotNetSpatialReference } from "./dotNetBuilder";
-import FormTemplate from "@arcgis/core/form/FormTemplate";
-import Element from "@arcgis/core/form/elements/Element";
-import GroupElement from "@arcgis/core/form/elements/GroupElement";
-import CodedValueDomain from "@arcgis/core/layers/support/CodedValueDomain";
-import RangeDomain from "@arcgis/core/layers/support/RangeDomain";
-import TextBoxInput from "@arcgis/core/form/elements/inputs/TextBoxInput";
-import TextAreaInput from "@arcgis/core/form/elements/inputs/TextAreaInput";
-import DateTimePickerInput from "@arcgis/core/form/elements/inputs/DateTimePickerInput";
-import BarcodeScannerInput from "@arcgis/core/form/elements/inputs/BarcodeScannerInput";
-import ComboBoxInput from "@arcgis/core/form/elements/inputs/ComboBoxInput";
-import RadioButtonsInput from "@arcgis/core/form/elements/inputs/RadioButtonsInput";
-import SwitchInput from "@arcgis/core/form/elements/inputs/SwitchInput";
-import SearchSource from "@arcgis/core/widgets/Search/SearchSource";
-import FeatureTemplate from "@arcgis/core/layers/support/FeatureTemplate";
-import ViewClickEvent = __esri.ViewClickEvent;
-import PopupOpenOptions = __esri.PopupOpenOptions;
-import PopupDockOptions = __esri.PopupDockOptions;
-import ContentProperties = __esri.ContentProperties;
-import FeatureLayerBaseApplyEditsEdits = __esri.FeatureLayerBaseApplyEditsEdits;
-import AttachmentEdit = __esri.AttachmentEdit;
-import CodedValue = __esri.CodedValue;
-import SearchSourceFilter = __esri.SearchSourceFilter;
-import SearchResult = __esri.SearchResult;
-import SuggestResult = __esri.SuggestResult;
-import LabelClass from "@arcgis/core/layers/support/LabelClass";
-import VisualVariable from "@arcgis/core/renderers/visualVariables/VisualVariable";
-import ColorVariable from "@arcgis/core/renderers/visualVariables/ColorVariable";
-import RotationVariable from "@arcgis/core/renderers/visualVariables/RotationVariable";
-import SizeVariable from "@arcgis/core/renderers/visualVariables/SizeVariable";
-import OpacityVariable from "@arcgis/core/renderers/visualVariables/OpacityVariable";
-import FeatureReductionCluster from "@arcgis/core/layers/support/FeatureReductionCluster";
-import FeatureReductionBinning from "@arcgis/core/layers/support/FeatureReductionBinning";
-import FeatureReductionSelection from "@arcgis/core/layers/support/FeatureReductionSelection";
-import AggregateField from "@arcgis/core/layers/support/AggregateField";
-import supportExpressionInfo from "@arcgis/core/layers/support/ExpressionInfo";
-import PieChartRenderer from "@arcgis/core/renderers/PieChartRenderer";
-import AttributeColorInfo from "@arcgis/core/renderers/support/AttributeColorInfo";
-import AuthoringInfo from "@arcgis/core/renderers/support/AuthoringInfo";
-import AuthoringInfoVisualVariable from "@arcgis/core/renderers/support/AuthoringInfoVisualVariable";
-import ActionButton from "@arcgis/core/support/actions/ActionButton";
-import ActionToggle from "@arcgis/core/support/actions/ActionToggle";
-import FeatureSet from "@arcgis/core/rest/support/FeatureSet";
-import Sublayer from "@arcgis/core/layers/support/Sublayer.js";
-import DynamicMapLayer = __esri.DynamicMapLayer;
-import DynamicDataLayer = __esri.DynamicDataLayer;
-import TableDataSource = __esri.TableDataSource;
-import QueryTableDataSource = __esri.QueryTableDataSource;
-import RasterDataSource = __esri.RasterDataSource;
-import JoinTableDataSource = __esri.JoinTableDataSource;
-import DynamicDataLayerFields = __esri.DynamicDataLayerFields;
-import TickConfig = __esri.TickConfig;
+import {buildDotNetGraphic} from "./dotNetBuilder";
 
 export function buildJsSpatialReference(dotNetSpatialReference: DotNetSpatialReference): SpatialReference {
     if (dotNetSpatialReference === undefined || dotNetSpatialReference === null) {
@@ -202,8 +100,8 @@ export function buildJsExtent(dotNetExtent: DotNetExtent, currentSpatialReferenc
     return extent;
 }
 
-export function buildJsGraphic(graphicObject: any, viewId: string | null)
-    : Graphic | null {
+export async function buildJsGraphic(graphicObject: any, viewId: string | null)
+    : Promise<Graphic | null> {
     let graphic: Graphic;
     if (graphicsRefs.hasOwnProperty(graphicObject.id)) {
         graphic = graphicsRefs[graphicObject.id];
@@ -219,7 +117,7 @@ export function buildJsGraphic(graphicObject: any, viewId: string | null)
     graphic.attributes = buildJsAttributes(graphicObject.attributes);
 
     if (hasValue(graphicObject.popupTemplate)) {
-        graphic.popupTemplate = buildJsPopupTemplate(graphicObject.popupTemplate, viewId) as PopupTemplate;
+        graphic.popupTemplate = await buildJsPopupTemplate(graphicObject.popupTemplate, viewId) as PopupTemplate;
     }
     
     copyValuesIfExists(graphicObject, graphic, 'visible');
@@ -264,7 +162,7 @@ export function buildJsAttributes(attributes: any): any {
     }
 }
 
-export function buildJsPopupTemplate(popupTemplateObject: DotNetPopupTemplate, viewId: string | null): PopupTemplate | null {
+export async function buildJsPopupTemplate(popupTemplateObject: DotNetPopupTemplate, viewId: string | null): PopupTemplate | null {
     if (!hasValue(popupTemplateObject)) return null;
     
     let content;
@@ -306,7 +204,8 @@ export function buildJsPopupTemplate(popupTemplateObject: DotNetPopupTemplate, v
     });
 
     if (hasValue(popupTemplateObject.fieldInfos)) {
-        template.fieldInfos = popupTemplateObject.fieldInfos.map(buildJsFieldInfo);
+        template.fieldInfos = popupTemplateObject.fieldInfos
+            .map(async (f) => await buildJsFieldInfo(f));
     }
 
     if (hasValue(popupTemplateObject.expressionInfos)) {
@@ -322,23 +221,26 @@ export function buildJsPopupTemplate(popupTemplateObject: DotNetPopupTemplate, v
     return template;
 }
 
-export function buildJsAction(dnAction: any): ActionButton | ActionToggle {
+export async function buildJsAction(dnAction: any): Promise<any> {
     if (dnAction.type === "button") {
+        let ActionButton = (await import("@arcgis/core/support/actions/ActionButton")).default;
         let jsAction = new ActionButton();
         copyValuesIfExists(dnAction, jsAction, 'active', 'className', 'disabled', 'icon', 'id', 'image', 'title', 
             'visible');
         return jsAction;
     }
 
+    let ActionToggle = (await import("@arcgis/core/support/actions/ActionToggle")).default;
     let jsAction = new ActionToggle();
     copyValuesIfExists(dnAction, jsAction, 'active', 'disabled', 'icon', 'id', 'title', 'value', 'visible');
     return jsAction;
 }
 
-export function buildJsPopupContent(popupContentObject: DotNetPopupContent): ContentProperties | null {
+export async function buildJsPopupContent(popupContentObject: DotNetPopupContent): any | null {
     switch (popupContentObject?.type) {
         case "fields":
             let dnFieldsContent = popupContentObject as DotNetFieldsPopupContent;
+            let FieldsContent = (await import("@arcgis/core/popup/content/FieldsContent")).default;
             let fieldsContent = new FieldsContent({
                 description: dnFieldsContent.description ?? '',
                 title: dnFieldsContent.title ?? ''
@@ -351,11 +253,13 @@ export function buildJsPopupContent(popupContentObject: DotNetPopupContent): Con
             return fieldsContent;
         case "text":
             let dnTextContent = popupContentObject as DotNetTextPopupContent;
+            let TextContent = (await import("@arcgis/core/popup/content/TextContent")).default;
             return new TextContent({
                 text: dnTextContent.text ?? null
             });
         case "media":
             let dnMediaContent = popupContentObject as DotNetMediaPopupContent;
+            let MediaContent = (await import("@arcgis/core/popup/content/MediaContent")).default;
             let mediaContent = new MediaContent();
             if (dnMediaContent.mediaInfos !== undefined && dnMediaContent.mediaInfos !== null &&
                 dnMediaContent.mediaInfos.length > 0) {
@@ -364,6 +268,7 @@ export function buildJsPopupContent(popupContentObject: DotNetPopupContent): Con
             return mediaContent;
         case "attachments":
             let dnAttachmentsContent = popupContentObject as DotNetAttachmentsPopupContent;
+            let AttachmentsContent = (await import("@arcgis/core/popup/content/AttachmentsContent")).default;
             return new AttachmentsContent({
                 description: dnAttachmentsContent.description ?? '',
                 title: dnAttachmentsContent.title ?? '',
@@ -371,6 +276,7 @@ export function buildJsPopupContent(popupContentObject: DotNetPopupContent): Con
             });
         case "expression":
             let dnExpressionContent = popupContentObject as DotNetExpressionPopupContent;
+            let ExpressionContent = (await import("@arcgis/core/popup/content/ExpressionContent")).default;
             let expressionContent = new ExpressionContent();
             if (hasValue(dnExpressionContent.expressionInfo)) {
                 expressionContent.expressionInfo = buildJsElementExpressionInfo(dnExpressionContent.expressionInfo);
@@ -380,7 +286,8 @@ export function buildJsPopupContent(popupContentObject: DotNetPopupContent): Con
     return null;
 }
 
-export function buildJsFieldInfo(fieldInfoObject: DotNetFieldInfo): FieldInfo {
+export async function buildJsFieldInfo(fieldInfoObject: DotNetFieldInfo): Promise<any> {
+    let FieldInfo = (await import("@arcgis/core/popup/FieldInfo")).default;
     let fieldInfo = new FieldInfo();
     copyValuesIfExists(fieldInfoObject, fieldInfo, 'fieldName', 'label', 'tooltip', 'stringFieldOption', 'visible', 'isEditable');
 
@@ -1171,7 +1078,7 @@ export async function buildJsPopup(dotNetPopup: any, viewId: string): Promise<Po
         let features: Graphic[] = [];
         for (const f of dotNetPopup.features) {
             delete f.dotNetGraphicReference;
-            let graphic = buildJsGraphic(f, viewId) as Graphic;
+            let graphic = await buildJsGraphic(f, viewId) as Graphic;
             features.push(graphic);
         }
         popup.features = features;
@@ -1230,7 +1137,7 @@ export async function buildJsPopupOptions(dotNetPopupOptions: any): Promise<Popu
     if (hasValue(dotNetPopupOptions.features)) {
         let features: Graphic[] = [];
         for (const f of dotNetPopupOptions.features) {
-            let graphic = buildJsGraphic(f, null) as Graphic;
+            let graphic = await buildJsGraphic(f, null) as Graphic;
             graphic.layer = arcGisObjectRefs[f.layerId] as Layer;
             features.push(graphic);
         }
@@ -1464,7 +1371,7 @@ export function buildJsPortalItem(dotNetPortalItem: any): any {
 }
 
 export function buildJsApplyEdits(dotNetApplyEdits: DotNetApplyEdits, viewId: string): FeatureLayerBaseApplyEditsEdits {
-    let addFeatures = dotNetApplyEdits.addFeatures?.map(f => buildJsGraphic(f, viewId)!);
+    let addFeatures = dotNetApplyEdits.addFeatures?.map(async f => await buildJsGraphic(f, viewId)!);
     let deleteFeatures = dotNetApplyEdits.deleteFeatures?.map(f => buildJsGraphic(f, viewId)!);
     let updateFeatures = dotNetApplyEdits.updateFeatures?.map(f => buildJsGraphic(f, viewId)!);
     let addAttachments = dotNetApplyEdits.addAttachments?.map(a => buildJsAttachmentEdit(a, viewId)!);
@@ -1778,7 +1685,7 @@ export async function buildJsSearchSource(dotNetSource: any, viewId: string): Pr
     };
 
     if (hasValue(dotNetSource.popupTemplate)) {
-        source.popupTemplate = buildJsPopupTemplate(dotNetSource.popupTemplate, viewId);
+        source.popupTemplate = await buildJsPopupTemplate(dotNetSource.popupTemplate, viewId);
     }
 
     if (hasValue(dotNetSource.resultSymbol)) {
@@ -1918,7 +1825,7 @@ export function buildJsFeatureReduction(dnFeatureReduction: any, viewId: string 
                 cluster.labelingInfo = dnFeatureReduction.labelingInfo.map(buildJsLabelClass);
             }
             if (hasValue(dnFeatureReduction.popupTemplate)) {
-                cluster.popupTemplate = buildJsPopupTemplate(dnFeatureReduction.popupTemplate, viewId) as PopupTemplate;
+                cluster.popupTemplate = await buildJsPopupTemplate(dnFeatureReduction.popupTemplate, viewId) as PopupTemplate;
             }
             if (hasValue(dnFeatureReduction.renderer)) {
                 cluster.renderer = buildJsRenderer(dnFeatureReduction.renderer) as Renderer;
@@ -1938,7 +1845,7 @@ export function buildJsFeatureReduction(dnFeatureReduction: any, viewId: string 
                 labelsVisible: dnFeatureReduction.labelsVisible ?? undefined,
                 maxScale: dnFeatureReduction.maxScale ?? undefined,
                 popupEnabled: dnFeatureReduction.popupEnabled ?? true,
-                popupTemplate: buildJsPopupTemplate(dnFeatureReduction.popupTemplate, viewId) ?? undefined,
+                popupTemplate: await buildJsPopupTemplate(dnFeatureReduction.popupTemplate, viewId) ?? undefined,
                 renderer: buildJsRenderer(dnFeatureReduction.renderer) ?? undefined
             } as FeatureReductionBinning;
             let binning = new FeatureReductionBinning();
@@ -1949,7 +1856,7 @@ export function buildJsFeatureReduction(dnFeatureReduction: any, viewId: string 
                 binning.labelingInfo = dnFeatureReduction.labelingInfo.map(buildJsLabelClass);
             }
             if (hasValue(dnFeatureReduction.popupTemplate)) {
-                binning.popupTemplate = buildJsPopupTemplate(dnFeatureReduction.popupTemplate, viewId) as PopupTemplate;
+                binning.popupTemplate = await buildJsPopupTemplate(dnFeatureReduction.popupTemplate, viewId) as PopupTemplate;
             }
             if (hasValue(dnFeatureReduction.renderer)) {
                 binning.renderer = buildJsRenderer(dnFeatureReduction.renderer) as Renderer;
@@ -2025,7 +1932,7 @@ export function buildJsSublayer(dotNetSublayer: any): Sublayer {
     }
     
     if (hasValue(dotNetSublayer.popupTemplate)) {
-        sublayer.popupTemplate = buildJsPopupTemplate(dotNetSublayer.popupTemplate, null) as PopupTemplate;
+        sublayer.popupTemplate = await buildJsPopupTemplate(dotNetSublayer.popupTemplate, null) as PopupTemplate;
     }
     
     if (hasValue(dotNetSublayer.source)) {

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -11,8 +11,35 @@ import Geometry from "@arcgis/core/geometry/Geometry";
 import Point from "@arcgis/core/geometry/Point";
 import Polyline from "@arcgis/core/geometry/Polyline";
 import Polygon from "@arcgis/core/geometry/Polygon";
+import TextSymbol from "@arcgis/core/symbols/TextSymbol";
+import SimpleRenderer from "@arcgis/core/renderers/SimpleRenderer";
 import Renderer from "@arcgis/core/renderers/Renderer";
-
+import Field from "@arcgis/core/layers/support/Field";
+import Font from "@arcgis/core/symbols/Font";
+import Bookmark from "@arcgis/core/webmap/Bookmark"
+import Viewpoint from "@arcgis/core/Viewpoint";
+import FeatureEffect from "@arcgis/core/layers/support/FeatureEffect";
+import FeatureFilter from "@arcgis/core/layers/support/FeatureFilter";
+import RasterStretchRenderer from "@arcgis/core/renderers/RasterStretchRenderer.js"
+import ColorRamp from "@arcgis/core/rest/support/ColorRamp.js";
+import DimensionalDefinition from "@arcgis/core/layers/support/DimensionalDefinition.js";
+import MultipartColorRamp from "@arcgis/core/rest/support/MultipartColorRamp.js";
+import AlgorithmicColorRamp from "@arcgis/core/rest/support/AlgorithmicColorRamp.js";
+import RasterShadedReliefRenderer from "@arcgis/core/renderers/RasterShadedReliefRenderer.js";
+import RasterColormapRenderer from "@arcgis/core/renderers/RasterColormapRenderer.js";
+import VectorFieldRenderer from "@arcgis/core/renderers/VectorFieldRenderer.js";
+import FlowRenderer from "@arcgis/core/renderers/FlowRenderer.js";
+import ClassBreaksRenderer from "@arcgis/core/renderers/ClassBreaksRenderer.js";
+import ClassBreakInfo from "@arcgis/core/renderers/support/ClassBreakInfo.js";
+import UniqueValueRenderer from "@arcgis/core/renderers/UniqueValueRenderer.js";
+import ColormapInfo from "@arcgis/core/renderers/support/ColormapInfo.js";
+import MultidimensionalSubset from "@arcgis/core/layers/support/MultidimensionalSubset.js";
+import PolygonSymbol3D from "@arcgis/core/symbols/PolygonSymbol3D.js";
+import FieldsIndex from "@arcgis/core/layers/support/FieldsIndex.js";
+import UniqueValue from "@arcgis/core/renderers/support/UniqueValue.js";
+import UniqueValueInfo from "@arcgis/core/renderers/support/UniqueValueInfo.js";
+import UniqueValueClass from "@arcgis/core/renderers/support/UniqueValueClass.js";
+import UniqueValueGroup from "@arcgis/core/renderers/support/UniqueValueGroup.js";
 import {
     DotNetApplyEdits,
     DotNetAttachmentsEdit,
@@ -65,11 +92,87 @@ import {
     DotNetViewpoint,
     DotNetVisualVariable, DotNetFeatureSet, DotNetPictureFillSymbol,
 } from "./definitions";
+import PictureMarkerSymbol from "@arcgis/core/symbols/PictureMarkerSymbol";
+import PictureFillSymbol from "@arcgis/core/symbols/PictureFillSymbol";
 import Popup from "@arcgis/core/widgets/Popup";
 import Query from "@arcgis/core/rest/support/Query";
+import FieldsContent from "@arcgis/core/popup/content/FieldsContent";
+import TextContent from "@arcgis/core/popup/content/TextContent";
+import FieldInfo from "@arcgis/core/popup/FieldInfo";
+import FieldInfoFormat from "@arcgis/core/popup/support/FieldInfoFormat";
+import MediaContent from "@arcgis/core/popup/content/MediaContent";
+import BarChartMediaInfo from "@arcgis/core/popup/content/BarChartMediaInfo";
+import ColumnChartMediaInfo from "@arcgis/core/popup/content/ColumnChartMediaInfo";
+import ChartMediaInfoValue from "@arcgis/core/popup/content/support/ChartMediaInfoValue";
+import ImageMediaInfoValue from "@arcgis/core/popup/content/support/ImageMediaInfoValue";
+import ImageMediaInfo from "@arcgis/core/popup/content/ImageMediaInfo";
+import LineChartMediaInfo from "@arcgis/core/popup/content/LineChartMediaInfo";
+import PieChartMediaInfo from "@arcgis/core/popup/content/PieChartMediaInfo";
+import AttachmentsContent from "@arcgis/core/popup/content/AttachmentsContent";
+import ExpressionContent from "@arcgis/core/popup/content/ExpressionContent";
 import Layer from "@arcgis/core/layers/Layer";
+import RelationshipQuery from "@arcgis/core/rest/support/RelationshipQuery";
+import TopFeaturesQuery from "@arcgis/core/rest/support/TopFeaturesQuery";
+import popupExpressionInfo from "@arcgis/core/popup/ExpressionInfo";
+import SimpleMarkerSymbol from "@arcgis/core/symbols/SimpleMarkerSymbol";
 import Symbol from "@arcgis/core/symbols/Symbol";
-import {buildDotNetGraphic} from "./dotNetBuilder";
+import SimpleFillSymbol from "@arcgis/core/symbols/SimpleFillSymbol";
+import SimpleLineSymbol from "@arcgis/core/symbols/SimpleLineSymbol";
+import ElementExpressionInfo from "@arcgis/core/popup/ElementExpressionInfo";
+import ChartMediaInfoValueSeries from "@arcgis/core/popup/content/support/ChartMediaInfoValueSeries";
+import { buildDotNetGraphic, buildDotNetPoint, buildDotNetSpatialReference } from "./dotNetBuilder";
+import FormTemplate from "@arcgis/core/form/FormTemplate";
+import Element from "@arcgis/core/form/elements/Element";
+import GroupElement from "@arcgis/core/form/elements/GroupElement";
+import CodedValueDomain from "@arcgis/core/layers/support/CodedValueDomain";
+import RangeDomain from "@arcgis/core/layers/support/RangeDomain";
+import TextBoxInput from "@arcgis/core/form/elements/inputs/TextBoxInput";
+import TextAreaInput from "@arcgis/core/form/elements/inputs/TextAreaInput";
+import DateTimePickerInput from "@arcgis/core/form/elements/inputs/DateTimePickerInput";
+import BarcodeScannerInput from "@arcgis/core/form/elements/inputs/BarcodeScannerInput";
+import ComboBoxInput from "@arcgis/core/form/elements/inputs/ComboBoxInput";
+import RadioButtonsInput from "@arcgis/core/form/elements/inputs/RadioButtonsInput";
+import SwitchInput from "@arcgis/core/form/elements/inputs/SwitchInput";
+import SearchSource from "@arcgis/core/widgets/Search/SearchSource";
+import FeatureTemplate from "@arcgis/core/layers/support/FeatureTemplate";
+import ViewClickEvent = __esri.ViewClickEvent;
+import PopupOpenOptions = __esri.PopupOpenOptions;
+import PopupDockOptions = __esri.PopupDockOptions;
+import ContentProperties = __esri.ContentProperties;
+import FeatureLayerBaseApplyEditsEdits = __esri.FeatureLayerBaseApplyEditsEdits;
+import AttachmentEdit = __esri.AttachmentEdit;
+import CodedValue = __esri.CodedValue;
+import SearchSourceFilter = __esri.SearchSourceFilter;
+import SearchResult = __esri.SearchResult;
+import SuggestResult = __esri.SuggestResult;
+import LabelClass from "@arcgis/core/layers/support/LabelClass";
+import VisualVariable from "@arcgis/core/renderers/visualVariables/VisualVariable";
+import ColorVariable from "@arcgis/core/renderers/visualVariables/ColorVariable";
+import RotationVariable from "@arcgis/core/renderers/visualVariables/RotationVariable";
+import SizeVariable from "@arcgis/core/renderers/visualVariables/SizeVariable";
+import OpacityVariable from "@arcgis/core/renderers/visualVariables/OpacityVariable";
+import FeatureReductionCluster from "@arcgis/core/layers/support/FeatureReductionCluster";
+import FeatureReductionBinning from "@arcgis/core/layers/support/FeatureReductionBinning";
+import FeatureReductionSelection from "@arcgis/core/layers/support/FeatureReductionSelection";
+import AggregateField from "@arcgis/core/layers/support/AggregateField";
+import supportExpressionInfo from "@arcgis/core/layers/support/ExpressionInfo";
+import PieChartRenderer from "@arcgis/core/renderers/PieChartRenderer";
+import AttributeColorInfo from "@arcgis/core/renderers/support/AttributeColorInfo";
+import AuthoringInfo from "@arcgis/core/renderers/support/AuthoringInfo";
+import AuthoringInfoVisualVariable from "@arcgis/core/renderers/support/AuthoringInfoVisualVariable";
+import ActionButton from "@arcgis/core/support/actions/ActionButton";
+import ActionToggle from "@arcgis/core/support/actions/ActionToggle";
+import FeatureSet from "@arcgis/core/rest/support/FeatureSet";
+import Sublayer from "@arcgis/core/layers/support/Sublayer.js";
+import DynamicMapLayer = __esri.DynamicMapLayer;
+import DynamicDataLayer = __esri.DynamicDataLayer;
+import TableDataSource = __esri.TableDataSource;
+import QueryTableDataSource = __esri.QueryTableDataSource;
+import RasterDataSource = __esri.RasterDataSource;
+import JoinTableDataSource = __esri.JoinTableDataSource;
+import DynamicDataLayerFields = __esri.DynamicDataLayerFields;
+import TickConfig = __esri.TickConfig;
+import MapView from "@arcgis/core/views/MapView";
 
 export function buildJsSpatialReference(dotNetSpatialReference: DotNetSpatialReference): SpatialReference {
     if (dotNetSpatialReference === undefined || dotNetSpatialReference === null) {
@@ -100,8 +203,8 @@ export function buildJsExtent(dotNetExtent: DotNetExtent, currentSpatialReferenc
     return extent;
 }
 
-export async function buildJsGraphic(graphicObject: any, viewId: string | null)
-    : Promise<Graphic | null> {
+export function buildJsGraphic(graphicObject: any, viewId: string | null)
+    : Graphic | null {
     let graphic: Graphic;
     if (graphicsRefs.hasOwnProperty(graphicObject.id)) {
         graphic = graphicsRefs[graphicObject.id];
@@ -117,7 +220,7 @@ export async function buildJsGraphic(graphicObject: any, viewId: string | null)
     graphic.attributes = buildJsAttributes(graphicObject.attributes);
 
     if (hasValue(graphicObject.popupTemplate)) {
-        graphic.popupTemplate = await buildJsPopupTemplate(graphicObject.popupTemplate, viewId) as PopupTemplate;
+        graphic.popupTemplate = buildJsPopupTemplate(graphicObject.popupTemplate, viewId) as PopupTemplate;
     }
     
     copyValuesIfExists(graphicObject, graphic, 'visible');
@@ -162,7 +265,7 @@ export function buildJsAttributes(attributes: any): any {
     }
 }
 
-export async function buildJsPopupTemplate(popupTemplateObject: DotNetPopupTemplate, viewId: string | null): PopupTemplate | null {
+export function buildJsPopupTemplate(popupTemplateObject: DotNetPopupTemplate, viewId: string | null): PopupTemplate | null {
     if (!hasValue(popupTemplateObject)) return null;
     
     let content;
@@ -204,8 +307,7 @@ export async function buildJsPopupTemplate(popupTemplateObject: DotNetPopupTempl
     });
 
     if (hasValue(popupTemplateObject.fieldInfos)) {
-        template.fieldInfos = popupTemplateObject.fieldInfos
-            .map(async (f) => await buildJsFieldInfo(f));
+        template.fieldInfos = popupTemplateObject.fieldInfos.map(buildJsFieldInfo);
     }
 
     if (hasValue(popupTemplateObject.expressionInfos)) {
@@ -221,26 +323,23 @@ export async function buildJsPopupTemplate(popupTemplateObject: DotNetPopupTempl
     return template;
 }
 
-export async function buildJsAction(dnAction: any): Promise<any> {
+export function buildJsAction(dnAction: any): ActionButton | ActionToggle {
     if (dnAction.type === "button") {
-        let ActionButton = (await import("@arcgis/core/support/actions/ActionButton")).default;
         let jsAction = new ActionButton();
         copyValuesIfExists(dnAction, jsAction, 'active', 'className', 'disabled', 'icon', 'id', 'image', 'title', 
             'visible');
         return jsAction;
     }
 
-    let ActionToggle = (await import("@arcgis/core/support/actions/ActionToggle")).default;
     let jsAction = new ActionToggle();
     copyValuesIfExists(dnAction, jsAction, 'active', 'disabled', 'icon', 'id', 'title', 'value', 'visible');
     return jsAction;
 }
 
-export async function buildJsPopupContent(popupContentObject: DotNetPopupContent): any | null {
+export function buildJsPopupContent(popupContentObject: DotNetPopupContent): ContentProperties | null {
     switch (popupContentObject?.type) {
         case "fields":
             let dnFieldsContent = popupContentObject as DotNetFieldsPopupContent;
-            let FieldsContent = (await import("@arcgis/core/popup/content/FieldsContent")).default;
             let fieldsContent = new FieldsContent({
                 description: dnFieldsContent.description ?? '',
                 title: dnFieldsContent.title ?? ''
@@ -253,13 +352,11 @@ export async function buildJsPopupContent(popupContentObject: DotNetPopupContent
             return fieldsContent;
         case "text":
             let dnTextContent = popupContentObject as DotNetTextPopupContent;
-            let TextContent = (await import("@arcgis/core/popup/content/TextContent")).default;
             return new TextContent({
                 text: dnTextContent.text ?? null
             });
         case "media":
             let dnMediaContent = popupContentObject as DotNetMediaPopupContent;
-            let MediaContent = (await import("@arcgis/core/popup/content/MediaContent")).default;
             let mediaContent = new MediaContent();
             if (dnMediaContent.mediaInfos !== undefined && dnMediaContent.mediaInfos !== null &&
                 dnMediaContent.mediaInfos.length > 0) {
@@ -268,7 +365,6 @@ export async function buildJsPopupContent(popupContentObject: DotNetPopupContent
             return mediaContent;
         case "attachments":
             let dnAttachmentsContent = popupContentObject as DotNetAttachmentsPopupContent;
-            let AttachmentsContent = (await import("@arcgis/core/popup/content/AttachmentsContent")).default;
             return new AttachmentsContent({
                 description: dnAttachmentsContent.description ?? '',
                 title: dnAttachmentsContent.title ?? '',
@@ -276,7 +372,6 @@ export async function buildJsPopupContent(popupContentObject: DotNetPopupContent
             });
         case "expression":
             let dnExpressionContent = popupContentObject as DotNetExpressionPopupContent;
-            let ExpressionContent = (await import("@arcgis/core/popup/content/ExpressionContent")).default;
             let expressionContent = new ExpressionContent();
             if (hasValue(dnExpressionContent.expressionInfo)) {
                 expressionContent.expressionInfo = buildJsElementExpressionInfo(dnExpressionContent.expressionInfo);
@@ -286,8 +381,7 @@ export async function buildJsPopupContent(popupContentObject: DotNetPopupContent
     return null;
 }
 
-export async function buildJsFieldInfo(fieldInfoObject: DotNetFieldInfo): Promise<any> {
-    let FieldInfo = (await import("@arcgis/core/popup/FieldInfo")).default;
+export function buildJsFieldInfo(fieldInfoObject: DotNetFieldInfo): FieldInfo {
     let fieldInfo = new FieldInfo();
     copyValuesIfExists(fieldInfoObject, fieldInfo, 'fieldName', 'label', 'tooltip', 'stringFieldOption', 'visible', 'isEditable');
 
@@ -1054,6 +1148,7 @@ export function buildJsViewClickEvent(dotNetClickEvent: any): ViewClickEvent {
 }
 
 export async function buildJsPopup(dotNetPopup: any, viewId: string): Promise<Popup> {
+    
     let popup = new Popup({
         alignment: dotNetPopup.alignment ?? "auto",
         content: dotNetPopup.content ?? null,
@@ -1061,7 +1156,6 @@ export async function buildJsPopup(dotNetPopup: any, viewId: string): Promise<Po
         visible: dotNetPopup.visible ?? false,
         dockEnabled: dotNetPopup.dockEnabled ?? false,
         autoCloseEnabled: dotNetPopup.autoCloseEnabled ?? false,
-        autoOpenEnabled: dotNetPopup.autoOpenEnabled ?? true,
         collapseEnabled: dotNetPopup.collapseEnabled ?? true,
         defaultPopupTemplateEnabled: dotNetPopup.defaultPopupTemplateEnabled ?? false,
         headingLevel: dotNetPopup.headingLevel ?? 2,
@@ -1069,6 +1163,13 @@ export async function buildJsPopup(dotNetPopup: any, viewId: string): Promise<Po
         label: dotNetPopup.label ?? '',
         spinnerEnabled: dotNetPopup.spinnerEnabled ?? true
     });
+    
+    if (hasValue(dotNetPopup.autoOpenEnabled)) {
+        let view = arcGisObjectRefs[viewId] as MapView;
+        if (hasValue(view)) {
+            view.popupEnabled = dotNetPopup.autoOpenEnabled;
+        }
+    }
     
     if (hasValue(dotNetPopup.actions)) {
         popup.actions = dotNetPopup.actions.map(buildJsAction) as any;
@@ -1086,7 +1187,7 @@ export async function buildJsPopup(dotNetPopup: any, viewId: string): Promise<Po
         let features: Graphic[] = [];
         for (const f of dotNetPopup.features) {
             delete f.dotNetGraphicReference;
-            let graphic = await buildJsGraphic(f, viewId) as Graphic;
+            let graphic = buildJsGraphic(f, viewId) as Graphic;
             features.push(graphic);
         }
         popup.features = features;
@@ -1145,7 +1246,7 @@ export async function buildJsPopupOptions(dotNetPopupOptions: any): Promise<Popu
     if (hasValue(dotNetPopupOptions.features)) {
         let features: Graphic[] = [];
         for (const f of dotNetPopupOptions.features) {
-            let graphic = await buildJsGraphic(f, null) as Graphic;
+            let graphic = buildJsGraphic(f, null) as Graphic;
             graphic.layer = arcGisObjectRefs[f.layerId] as Layer;
             features.push(graphic);
         }
@@ -1379,7 +1480,7 @@ export function buildJsPortalItem(dotNetPortalItem: any): any {
 }
 
 export function buildJsApplyEdits(dotNetApplyEdits: DotNetApplyEdits, viewId: string): FeatureLayerBaseApplyEditsEdits {
-    let addFeatures = dotNetApplyEdits.addFeatures?.map(async f => await buildJsGraphic(f, viewId)!);
+    let addFeatures = dotNetApplyEdits.addFeatures?.map(f => buildJsGraphic(f, viewId)!);
     let deleteFeatures = dotNetApplyEdits.deleteFeatures?.map(f => buildJsGraphic(f, viewId)!);
     let updateFeatures = dotNetApplyEdits.updateFeatures?.map(f => buildJsGraphic(f, viewId)!);
     let addAttachments = dotNetApplyEdits.addAttachments?.map(a => buildJsAttachmentEdit(a, viewId)!);
@@ -1693,7 +1794,7 @@ export async function buildJsSearchSource(dotNetSource: any, viewId: string): Pr
     };
 
     if (hasValue(dotNetSource.popupTemplate)) {
-        source.popupTemplate = await buildJsPopupTemplate(dotNetSource.popupTemplate, viewId);
+        source.popupTemplate = buildJsPopupTemplate(dotNetSource.popupTemplate, viewId);
     }
 
     if (hasValue(dotNetSource.resultSymbol)) {
@@ -1833,7 +1934,7 @@ export function buildJsFeatureReduction(dnFeatureReduction: any, viewId: string 
                 cluster.labelingInfo = dnFeatureReduction.labelingInfo.map(buildJsLabelClass);
             }
             if (hasValue(dnFeatureReduction.popupTemplate)) {
-                cluster.popupTemplate = await buildJsPopupTemplate(dnFeatureReduction.popupTemplate, viewId) as PopupTemplate;
+                cluster.popupTemplate = buildJsPopupTemplate(dnFeatureReduction.popupTemplate, viewId) as PopupTemplate;
             }
             if (hasValue(dnFeatureReduction.renderer)) {
                 cluster.renderer = buildJsRenderer(dnFeatureReduction.renderer) as Renderer;
@@ -1853,7 +1954,7 @@ export function buildJsFeatureReduction(dnFeatureReduction: any, viewId: string 
                 labelsVisible: dnFeatureReduction.labelsVisible ?? undefined,
                 maxScale: dnFeatureReduction.maxScale ?? undefined,
                 popupEnabled: dnFeatureReduction.popupEnabled ?? true,
-                popupTemplate: await buildJsPopupTemplate(dnFeatureReduction.popupTemplate, viewId) ?? undefined,
+                popupTemplate: buildJsPopupTemplate(dnFeatureReduction.popupTemplate, viewId) ?? undefined,
                 renderer: buildJsRenderer(dnFeatureReduction.renderer) ?? undefined
             } as FeatureReductionBinning;
             let binning = new FeatureReductionBinning();
@@ -1864,7 +1965,7 @@ export function buildJsFeatureReduction(dnFeatureReduction: any, viewId: string 
                 binning.labelingInfo = dnFeatureReduction.labelingInfo.map(buildJsLabelClass);
             }
             if (hasValue(dnFeatureReduction.popupTemplate)) {
-                binning.popupTemplate = await buildJsPopupTemplate(dnFeatureReduction.popupTemplate, viewId) as PopupTemplate;
+                binning.popupTemplate = buildJsPopupTemplate(dnFeatureReduction.popupTemplate, viewId) as PopupTemplate;
             }
             if (hasValue(dnFeatureReduction.renderer)) {
                 binning.renderer = buildJsRenderer(dnFeatureReduction.renderer) as Renderer;
@@ -1940,7 +2041,7 @@ export function buildJsSublayer(dotNetSublayer: any): Sublayer {
     }
     
     if (hasValue(dotNetSublayer.popupTemplate)) {
-        sublayer.popupTemplate = await buildJsPopupTemplate(dotNetSublayer.popupTemplate, null) as PopupTemplate;
+        sublayer.popupTemplate = buildJsPopupTemplate(dotNetSublayer.popupTemplate, null) as PopupTemplate;
     }
     
     if (hasValue(dotNetSublayer.source)) {

--- a/src/dymaptic.GeoBlazor.Core/assetCopy.ps1
+++ b/src/dymaptic.GeoBlazor.Core/assetCopy.ps1
@@ -38,3 +38,12 @@ Else
     Write-Output "Asset files already copied. To update, delete wwwroot/assets contents and run again"
 }
 
+# if there is a folder called `assets` inside the assets folder, delete it
+# and move everything to the root of the assets folder
+$assetsFolder = "$OutputDir/assets"
+if ((Test-Path -Path $assetsFolder) -eq $true)
+{
+    Write-Output "Moving assets to root of assets folder"
+    Get-ChildItem -Path $assetsFolder -Recurse | Move-Item -Destination $OutputDir
+    Remove-Item -Path $assetsFolder -Recurse
+}

--- a/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
+++ b/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
@@ -19,7 +19,7 @@
         <PackageProjectUrl>https://geoblazor.com</PackageProjectUrl>
         <RepositoryType>git</RepositoryType>
         <PackageIcon>Blazor-API-500px.png</PackageIcon>
-        <GeneratePackageOnBuild Condition="$(Configuration) == 'RELEASE'">true</GeneratePackageOnBuild>
+        <GeneratePackageOnBuild Condition="$(Configuration) == 'RELEASE' AND $(GeneratePackage) != 'false'">true</GeneratePackageOnBuild>
         <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -37,24 +37,24 @@
 
     <ItemGroup>
         <PackageReference Include="DefaultDocumentation" Version="0.8.2" PrivateAssets="all" />
-        <PackageReference Include="protobuf-net" Version="3.2.26" />
+        <PackageReference Include="protobuf-net" Version="3.2.30" />
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.16" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.32" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.20" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.7" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     </ItemGroup>
     <PropertyGroup Condition="$(Configuration) == 'RELEASE' AND $(TargetFrameworks.StartsWith($(TargetFramework)))">

--- a/src/dymaptic.GeoBlazor.Core/package-lock.json
+++ b/src/dymaptic.GeoBlazor.Core/package-lock.json
@@ -8,33 +8,33 @@
       "name": "dymaptic.GeoBlazor.Core",
       "license": "ISC",
       "dependencies": {
-        "@arcgis/core": "4.29.10",
-        "esbuild": "0.20.2",
-        "protobufjs": "7.2.6"
+        "@arcgis/core": "4.30.9",
+        "esbuild": "0.23.0",
+        "protobufjs": "7.3.2"
       },
       "devDependencies": {
-        "@types/node": "^20.11.24"
+        "@types/node": "^20.14.11"
       }
     },
     "node_modules/@arcgis/core": {
-      "version": "4.29.10",
-      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.29.10.tgz",
-      "integrity": "sha512-EMJOJkeXG7sYeKLrjEWvF3cKWCFB4CFEjcsfRi0j9UlULv9NV9IarVryG1oLCg17CtEzcKjl7EZXiPnZsX5M2Q==",
+      "version": "4.30.9",
+      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.30.9.tgz",
+      "integrity": "sha512-tOM6QmXRikmD26uqIsFk2yxBwUpmAYJjp4vd9tl+VEfAXaLyArjHC8/op/OvyJZtfHNiL5zcSR7/YsiUddHPXA==",
       "dependencies": {
-        "@esri/arcgis-html-sanitizer": "~3.0.1",
+        "@esri/arcgis-html-sanitizer": "~4.0.3",
         "@esri/calcite-colors": "~6.1.0",
-        "@esri/calcite-components": "^2.4.0",
-        "@popperjs/core": "~2.11.8",
-        "@vaadin/grid": "~24.3.6",
-        "@zip.js/zip.js": "~2.7.34",
+        "@esri/calcite-components": "^2.8.5",
+        "@vaadin/grid": "~24.3.13",
+        "@zip.js/zip.js": "~2.7.44",
         "luxon": "~3.4.4",
+        "marked": "~12.0.2",
         "sortablejs": "~1.15.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
-      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.0.tgz",
+      "integrity": "sha512-3sG8Zwa5fMcA9bgqB8AfWPQ+HFke6uD3h1s3RIwUNK8EG7a4buxvuFTs3j1IMs2NXAk9F30C/FF4vxRgQCcmoQ==",
       "cpu": [
         "ppc64"
       ],
@@ -43,13 +43,13 @@
         "aix"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
-      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.0.tgz",
+      "integrity": "sha512-+KuOHTKKyIKgEEqKbGTK8W7mPp+hKinbMBeEnNzjJGyFcWsfrXjSTNluJHCY1RqhxFurdD8uNXQDei7qDlR6+g==",
       "cpu": [
         "arm"
       ],
@@ -58,13 +58,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
-      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.0.tgz",
+      "integrity": "sha512-EuHFUYkAVfU4qBdyivULuu03FhJO4IJN9PGuABGrFy4vUuzk91P2d+npxHcFdpUnfYKy0PuV+n6bKIpHOB3prQ==",
       "cpu": [
         "arm64"
       ],
@@ -73,13 +73,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
-      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.0.tgz",
+      "integrity": "sha512-WRrmKidLoKDl56LsbBMhzTTBxrsVwTKdNbKDalbEZr0tcsBgCLbEtoNthOW6PX942YiYq8HzEnb4yWQMLQuipQ==",
       "cpu": [
         "x64"
       ],
@@ -88,13 +88,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
-      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.0.tgz",
+      "integrity": "sha512-YLntie/IdS31H54Ogdn+v50NuoWF5BDkEUFpiOChVa9UnKpftgwzZRrI4J132ETIi+D8n6xh9IviFV3eXdxfow==",
       "cpu": [
         "arm64"
       ],
@@ -103,13 +103,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
-      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.0.tgz",
+      "integrity": "sha512-IMQ6eme4AfznElesHUPDZ+teuGwoRmVuuixu7sv92ZkdQcPbsNHzutd+rAfaBKo8YK3IrBEi9SLLKWJdEvJniQ==",
       "cpu": [
         "x64"
       ],
@@ -118,13 +118,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
-      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.0.tgz",
+      "integrity": "sha512-0muYWCng5vqaxobq6LB3YNtevDFSAZGlgtLoAc81PjUfiFz36n4KMpwhtAd4he8ToSI3TGyuhyx5xmiWNYZFyw==",
       "cpu": [
         "arm64"
       ],
@@ -133,13 +133,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
-      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.0.tgz",
+      "integrity": "sha512-XKDVu8IsD0/q3foBzsXGt/KjD/yTKBCIwOHE1XwiXmrRwrX6Hbnd5Eqn/WvDekddK21tfszBSrE/WMaZh+1buQ==",
       "cpu": [
         "x64"
       ],
@@ -148,13 +148,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
-      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.0.tgz",
+      "integrity": "sha512-SEELSTEtOFu5LPykzA395Mc+54RMg1EUgXP+iw2SJ72+ooMwVsgfuwXo5Fn0wXNgWZsTVHwY2cg4Vi/bOD88qw==",
       "cpu": [
         "arm"
       ],
@@ -163,13 +163,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
-      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.0.tgz",
+      "integrity": "sha512-j1t5iG8jE7BhonbsEg5d9qOYcVZv/Rv6tghaXM/Ug9xahM0nX/H2gfu6X6z11QRTMT6+aywOMA8TDkhPo8aCGw==",
       "cpu": [
         "arm64"
       ],
@@ -178,13 +178,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
-      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.0.tgz",
+      "integrity": "sha512-P7O5Tkh2NbgIm2R6x1zGJJsnacDzTFcRWZyTTMgFdVit6E98LTxO+v8LCCLWRvPrjdzXHx9FEOA8oAZPyApWUA==",
       "cpu": [
         "ia32"
       ],
@@ -193,13 +193,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
-      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.0.tgz",
+      "integrity": "sha512-InQwepswq6urikQiIC/kkx412fqUZudBO4SYKu0N+tGhXRWUqAx+Q+341tFV6QdBifpjYgUndV1hhMq3WeJi7A==",
       "cpu": [
         "loong64"
       ],
@@ -208,13 +208,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
-      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.0.tgz",
+      "integrity": "sha512-J9rflLtqdYrxHv2FqXE2i1ELgNjT+JFURt/uDMoPQLcjWQA5wDKgQA4t/dTqGa88ZVECKaD0TctwsUfHbVoi4w==",
       "cpu": [
         "mips64el"
       ],
@@ -223,13 +223,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
-      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.0.tgz",
+      "integrity": "sha512-cShCXtEOVc5GxU0fM+dsFD10qZ5UpcQ8AM22bYj0u/yaAykWnqXJDpd77ublcX6vdDsWLuweeuSNZk4yUxZwtw==",
       "cpu": [
         "ppc64"
       ],
@@ -238,13 +238,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
-      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.0.tgz",
+      "integrity": "sha512-HEtaN7Y5UB4tZPeQmgz/UhzoEyYftbMXrBCUjINGjh3uil+rB/QzzpMshz3cNUxqXN7Vr93zzVtpIDL99t9aRw==",
       "cpu": [
         "riscv64"
       ],
@@ -253,13 +253,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
-      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.0.tgz",
+      "integrity": "sha512-WDi3+NVAuyjg/Wxi+o5KPqRbZY0QhI9TjrEEm+8dmpY9Xir8+HE/HNx2JoLckhKbFopW0RdO2D72w8trZOV+Wg==",
       "cpu": [
         "s390x"
       ],
@@ -268,13 +268,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
-      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.0.tgz",
+      "integrity": "sha512-a3pMQhUEJkITgAw6e0bWA+F+vFtCciMjW/LPtoj99MhVt+Mfb6bbL9hu2wmTZgNd994qTAEw+U/r6k3qHWWaOQ==",
       "cpu": [
         "x64"
       ],
@@ -283,13 +283,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.0.tgz",
+      "integrity": "sha512-cRK+YDem7lFTs2Q5nEv/HHc4LnrfBCbH5+JHu6wm2eP+d8OZNoSMYgPZJq78vqQ9g+9+nMuIsAO7skzphRXHyw==",
       "cpu": [
         "x64"
       ],
@@ -298,13 +298,28 @@
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.0.tgz",
+      "integrity": "sha512-suXjq53gERueVWu0OKxzWqk7NxiUWSUlrxoZK7usiF50C6ipColGR5qie2496iKGYNLhDZkPxBI3erbnYkU0rQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.0.tgz",
+      "integrity": "sha512-6p3nHpby0DM/v15IFKMjAaayFhqnXV52aEmv1whZHX56pdkK+MEaLoQWj+H42ssFarP1PcomVhbsR4pkz09qBg==",
       "cpu": [
         "x64"
       ],
@@ -313,13 +328,13 @@
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
-      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.0.tgz",
+      "integrity": "sha512-BFelBGfrBwk6LVrmFzCq1u1dZbG4zy/Kp93w2+y83Q5UGYF1d8sCzeLI9NXjKyujjBBniQa8R8PzLFAUrSM9OA==",
       "cpu": [
         "x64"
       ],
@@ -328,13 +343,13 @@
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
-      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.0.tgz",
+      "integrity": "sha512-lY6AC8p4Cnb7xYHuIxQ6iYPe6MfO2CC43XXKo9nBXDb35krYt7KGhQnOkRGar5psxYkircpCqfbNDB4uJbS2jQ==",
       "cpu": [
         "arm64"
       ],
@@ -343,13 +358,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
-      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.0.tgz",
+      "integrity": "sha512-7L1bHlOTcO4ByvI7OXVI5pNN6HSu6pUQq9yodga8izeuB1KcT2UkHaH6118QJwopExPn0rMHIseCTx1CRo/uNA==",
       "cpu": [
         "ia32"
       ],
@@ -358,13 +373,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
-      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.0.tgz",
+      "integrity": "sha512-Arm+WgUFLUATuoxCJcahGuk6Yj9Pzxd6l11Zb/2aAuv5kWWvvfhLFo2fni4uSK5vzlUdCGZ/BdV5tH8klj8p8g==",
       "cpu": [
         "x64"
       ],
@@ -373,15 +388,18 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esri/arcgis-html-sanitizer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-3.0.1.tgz",
-      "integrity": "sha512-cwZJwsYCJZwtBQU2AmaiIVFg5nZcVwInPYja1/OgC9iKYO+ytZRoc5h+0S9/ygbFNoS8Nd0RX9A85stLX/BgiA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-4.0.3.tgz",
+      "integrity": "sha512-B06V4Spjhcy2zcKH9SaTrZwRGjUTlsCSGImdCpe7fN/Q3HxLa4QosMgrRJQ+Q8guLhBA177+6Fjwzl/xIrmY7A==",
       "dependencies": {
         "xss": "1.0.13"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@esri/calcite-colors": {
@@ -390,20 +408,21 @@
       "integrity": "sha512-wHQYWFtDa6c328EraXEVZvgOiaQyYr0yuaaZ0G3cB4C3lSkWefW34L/e5TLAhtuG3zJ/wR6pl5X1YYNfBc0/4Q=="
     },
     "node_modules/@esri/calcite-components": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.6.0.tgz",
-      "integrity": "sha512-GbpascF/mI3TvC5EQejzMi8zDG/wv0pzGU5HzUsrzHqIkIwRruuIe7qdg/srjaEQkXwwpJKxfd8r5QaBXjlQWw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.10.1.tgz",
+      "integrity": "sha512-8M2ZBYcEk20x34TDxZ6H5rLCWtGrOJLtHA/k6yWL/GJTC85/gvY153XxbGN8F1ywJb/3imvhy/SlfNRPnVPQNQ==",
       "dependencies": {
-        "@floating-ui/dom": "1.6.3",
-        "@stencil/core": "4.9.0",
+        "@floating-ui/dom": "1.6.5",
+        "@stencil/core": "4.18.3",
         "@types/color": "3.0.6",
         "color": "4.2.3",
         "composed-offset-position": "0.0.4",
-        "dayjs": "1.11.10",
+        "dayjs": "1.11.11",
         "focus-trap": "7.5.4",
         "lodash-es": "4.17.21",
         "sortablejs": "1.15.1",
-        "timezone-groups": "0.8.0"
+        "timezone-groups": "0.8.0",
+        "type-fest": "4.18.2"
       }
     },
     "node_modules/@esri/calcite-components/node_modules/sortablejs": {
@@ -412,26 +431,26 @@
       "integrity": "sha512-P5Cjvb0UG1ZVNiDPj/n4V+DinttXG6K8n7vM/HQf0C25K3YKQTQY6fsr/sEGsJGpQ9exmPxluHxKBc0mLKU1lQ=="
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.4.tgz",
+      "integrity": "sha512-a4IowK4QkXl4SCWTGUR0INAfEOX3wtsYw3rKK5InQEHMGObkR8Xk44qYQD9P4r6HHw0iIfK6GUKECmY8sTkqRA==",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.1"
+        "@floating-ui/utils": "^0.2.4"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
-      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.5.tgz",
+      "integrity": "sha512-Nsdud2X65Dz+1RHjAIP0t8z5e2ff/IRbei6BqFrl1urT8sDVzM1HMQ+R0XcU5ceRfyO3I6ayeqIfh+6Wb8LGTw==",
       "dependencies": {
         "@floating-ui/core": "^1.0.0",
         "@floating-ui/utils": "^0.2.0"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
-      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.4.tgz",
+      "integrity": "sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA=="
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.2.0",
@@ -457,15 +476,6 @@
       "integrity": "sha512-JlAHuy+1qIC6hL1ojEUfIVD58fzTpJAoCxFwV5yr0mYTXV1H8bz5zy0+rC963Cgr9iNXQ4T9ncSjC2fkF9BQfw==",
       "dependencies": {
         "@webcomponents/shadycss": "^1.9.1"
-      }
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -523,9 +533,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@stencil/core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.9.0.tgz",
-      "integrity": "sha512-aWSkhBmk3yPwRAkUwBbzRwmdhb8hKiQ/JMr9m5jthpBZLjtppYbzz6PN2MhSMDfRp6K93eQw5WogSEH4HHuB6w==",
+      "version": "4.18.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.18.3.tgz",
+      "integrity": "sha512-8yoG5AFQYEPocVtuoc5kvRS0Hku0MoDWDUpADRaXPVHsOFLmxR16LJENj25ucCz5GEfeTGQ/tCE8JAypPmr/fQ==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -551,14 +561,14 @@
       }
     },
     "node_modules/@types/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-87W6MJCKZYDhLAx/J1ikW8niMvmGRyY+rpUxWpL1cO7F8Uu5CHuQoFv+R0/L5pgNdW4jTyda42kv60uwVIPjLw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-hulKeREDdLFesGQjl96+4aoJSHY5b2GRjagzzcqCfIrWhe5vkCqIvrLbqzBaI1q94Vg8DNJZZqTR5ocdWmWclg=="
     },
     "node_modules/@types/node": {
-      "version": "20.11.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
-      "integrity": "sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==",
+      "version": "20.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -569,36 +579,36 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
     },
     "node_modules/@vaadin/a11y-base": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.3.7.tgz",
-      "integrity": "sha512-gcuCsSf+dH84HRJCQyZj3dqqyxVhKKYqGiMHAjNtQhRqojvNFH/YHk/ZLpBhiq/qI2VHfqeEbz2gJ2RMdIqFCA==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.3.18.tgz",
+      "integrity": "sha512-qa8oduy74CCPEe1ORF03ZSV91cCWePD/6dFuFkPn1t6oX2CZzsCm9vu0S0fGIbAIYfoJ4W0eVXnuEGwYdmIDQQ==",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.3.7",
+        "@vaadin/component-base": "~24.3.18",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/checkbox": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.3.7.tgz",
-      "integrity": "sha512-kVe5uoR4eRZAwNon+D2y0CYUHondFB799ajj7BGFuk2+rcbx1IQiv3PAq3TZ5YZ68rl++FcRMFbybuQBxBHJpw==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.3.18.tgz",
+      "integrity": "sha512-bRJT6/hYODuue5mfE9D2eHiciEO6C69nFjo7ZoUM70+A66mTQ1DXX/8BujvjLAlH8jzmeHeS/AejmudowiC7Lg==",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.3.7",
-        "@vaadin/component-base": "~24.3.7",
-        "@vaadin/field-base": "~24.3.7",
-        "@vaadin/vaadin-lumo-styles": "~24.3.7",
-        "@vaadin/vaadin-material-styles": "~24.3.7",
-        "@vaadin/vaadin-themable-mixin": "~24.3.7",
+        "@vaadin/a11y-base": "~24.3.18",
+        "@vaadin/component-base": "~24.3.18",
+        "@vaadin/field-base": "~24.3.18",
+        "@vaadin/vaadin-lumo-styles": "~24.3.18",
+        "@vaadin/vaadin-material-styles": "~24.3.18",
+        "@vaadin/vaadin-themable-mixin": "~24.3.18",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/component-base": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.3.7.tgz",
-      "integrity": "sha512-r5fvuR381Musi1JH9xMzvajw2l4vzefZlvGHMg0ywb72pDS8ZmtizDaIMioNYHWAoe4kBdJ1xdzlygPyqU63Og==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.3.18.tgz",
+      "integrity": "sha512-PINsCNytvoysWL/oBe7HBIEJL1lcc3ihFVTwDM0PB/uVMTRcM0JPMkP4/A1f/qZbTKjZnF2RIXIotexHxumZAg==",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -608,115 +618,115 @@
       }
     },
     "node_modules/@vaadin/field-base": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.3.7.tgz",
-      "integrity": "sha512-t3I9yrFNIsYd8ysB6d/DOISy5BrbsQwXZjNECRJ9WnuordQPgyRBmUO1wPKjK0/2qvwwiyON+8IavQXoOPLXUg==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.3.18.tgz",
+      "integrity": "sha512-nVHXkaqT1LJVVjsAiWpg9bdEA3OAfERxA4fvKqkuFUK55aAVeQxCw3P8jWmVKRVd3m9UCmlLHnHuXmuD2R6ZwQ==",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.3.7",
-        "@vaadin/component-base": "~24.3.7",
+        "@vaadin/a11y-base": "~24.3.18",
+        "@vaadin/component-base": "~24.3.18",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/grid": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.3.7.tgz",
-      "integrity": "sha512-CAHi0N4t2ua7X5NLlvC3Yqfl6Q7CrTaYRPkHW7Hv4YJ+Z3erDJeUKOFE48Q4TZryEUMzZ0CNB3xL3UK/PvJiAQ==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.3.18.tgz",
+      "integrity": "sha512-Cvg+D4mizhs5Wh4JdX+wkWfJzHD/Jp1CeahhjLxUD13BKrgtgwNj1IofFQD47lMMufK/5wi2ppeeD/MaINaE5A==",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.3.7",
-        "@vaadin/checkbox": "~24.3.7",
-        "@vaadin/component-base": "~24.3.7",
-        "@vaadin/lit-renderer": "~24.3.7",
-        "@vaadin/text-field": "~24.3.7",
-        "@vaadin/vaadin-lumo-styles": "~24.3.7",
-        "@vaadin/vaadin-material-styles": "~24.3.7",
-        "@vaadin/vaadin-themable-mixin": "~24.3.7"
+        "@vaadin/a11y-base": "~24.3.18",
+        "@vaadin/checkbox": "~24.3.18",
+        "@vaadin/component-base": "~24.3.18",
+        "@vaadin/lit-renderer": "~24.3.18",
+        "@vaadin/text-field": "~24.3.18",
+        "@vaadin/vaadin-lumo-styles": "~24.3.18",
+        "@vaadin/vaadin-material-styles": "~24.3.18",
+        "@vaadin/vaadin-themable-mixin": "~24.3.18"
       }
     },
     "node_modules/@vaadin/icon": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.3.7.tgz",
-      "integrity": "sha512-qsOww+kuyZFsG+4JOlQmnsmljsGrgedZEvafPPwFEO6RG7XWUSwrJtY7u6FWBHHKAjVLaSEs4B4UrdWYRKaq+A==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.3.18.tgz",
+      "integrity": "sha512-S0Vh8SgtpBrdWSB+dGUGtvku9Avj8PZ4e3CY+U9A8L1ArdS+X20Jwag5cY4I5d9GY/NOcoSkYBcJqgAMTem2kQ==",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.3.7",
-        "@vaadin/vaadin-lumo-styles": "~24.3.7",
-        "@vaadin/vaadin-themable-mixin": "~24.3.7",
+        "@vaadin/component-base": "~24.3.18",
+        "@vaadin/vaadin-lumo-styles": "~24.3.18",
+        "@vaadin/vaadin-themable-mixin": "~24.3.18",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/input-container": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.3.7.tgz",
-      "integrity": "sha512-fTKxWEvDmiBUAA2IviVPFXc1UMeb+r0JkMHVNe5E8HBXKbjf6j7Vo+cpWkZ3wfWLcduwXRR6m+KL8PSnafF0Hg==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.3.18.tgz",
+      "integrity": "sha512-UwTOLa72UXHh9sTNqNwrfbKvUwcXTDM6naEh+tO/l+tbXXVcC+Bo8FnTKBugYVnlQQOpzC4jLvxMma3XUlSAuA==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.3.7",
-        "@vaadin/vaadin-lumo-styles": "~24.3.7",
-        "@vaadin/vaadin-material-styles": "~24.3.7",
-        "@vaadin/vaadin-themable-mixin": "~24.3.7",
+        "@vaadin/component-base": "~24.3.18",
+        "@vaadin/vaadin-lumo-styles": "~24.3.18",
+        "@vaadin/vaadin-material-styles": "~24.3.18",
+        "@vaadin/vaadin-themable-mixin": "~24.3.18",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/lit-renderer": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.3.7.tgz",
-      "integrity": "sha512-jlj3xd0CJWtbIsZCSon4BPxkOSTRkQgGY3cGspPk2v0eyHjm9+qtqPhMq7n2vu21V5ZLpaBG51/5jObHVq9rJQ==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.3.18.tgz",
+      "integrity": "sha512-HlYrhVwagnYcbGuOJ3IP6YRxSaV6l7qbRfsZsTl+Xpt/ElaWRktwATzvGgYd0zvnvgAut555lja9/dl0T33yOg==",
       "dependencies": {
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/text-field": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.3.7.tgz",
-      "integrity": "sha512-N/jVZLJwzxhUrclvM1nxdUwRRooWP0yZCgK9Ndj//xI+NS6zk1AsZkGwiBBBUXShCn4Xbptcuhlk/y3G/QEPqA==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.3.18.tgz",
+      "integrity": "sha512-k7u7CKeLOg4RUZ94TGfXJ7DpU1GJJLxfAqPbG2YP5tDYL4g3XyVfILpW4jDUQr5gJhPJyS7L9roNadc0Q3Mp4g==",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.3.7",
-        "@vaadin/component-base": "~24.3.7",
-        "@vaadin/field-base": "~24.3.7",
-        "@vaadin/input-container": "~24.3.7",
-        "@vaadin/vaadin-lumo-styles": "~24.3.7",
-        "@vaadin/vaadin-material-styles": "~24.3.7",
-        "@vaadin/vaadin-themable-mixin": "~24.3.7",
+        "@vaadin/a11y-base": "~24.3.18",
+        "@vaadin/component-base": "~24.3.18",
+        "@vaadin/field-base": "~24.3.18",
+        "@vaadin/input-container": "~24.3.18",
+        "@vaadin/vaadin-lumo-styles": "~24.3.18",
+        "@vaadin/vaadin-material-styles": "~24.3.18",
+        "@vaadin/vaadin-themable-mixin": "~24.3.18",
         "lit": "^3.0.0"
       }
     },
     "node_modules/@vaadin/vaadin-development-mode-detector": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.6.tgz",
-      "integrity": "sha512-N6a5nLT/ytEUlpPo+nvdCKIGoyNjPsj3rzPGvGYK8x9Ceg76OTe1xI/GtN71mRW9e2HUScR0kCNOkl1Z63YDjw=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.7.tgz",
+      "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA=="
     },
     "node_modules/@vaadin/vaadin-lumo-styles": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.3.7.tgz",
-      "integrity": "sha512-JyB41TsQxb0/9oUanc6X4d6SlCfQptkm0k88jWoPJ4l7OvCvlNWg1h780xpO/AbMKZIfo19QlWvls8DAvxGduQ==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.3.18.tgz",
+      "integrity": "sha512-cgzVOnmBiqlGQIAoQs/k2iFSsgTfckUcmGScouCbTUx2AUWbTvVYPjGlac1dkO4CsSZELE3uf2WPdPVQPSw1dw==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.3.7",
-        "@vaadin/icon": "~24.3.7",
-        "@vaadin/vaadin-themable-mixin": "~24.3.7"
+        "@vaadin/component-base": "~24.3.18",
+        "@vaadin/icon": "~24.3.18",
+        "@vaadin/vaadin-themable-mixin": "~24.3.18"
       }
     },
     "node_modules/@vaadin/vaadin-material-styles": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.3.7.tgz",
-      "integrity": "sha512-qmjbL8/PBmCkQ0MF95ajj65JLPHoa7kAi42XAIh8m/YFK8hjRMcVb/RdpWi2ZVHaiz1dUHbrrwq8vGMBVD752w==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.3.18.tgz",
+      "integrity": "sha512-vNJ1fjuVpneqodh6uOSAlUWbZ6V2S2mxdwr++VsdPgDtNhqxwpOhY4X700XQhObbk28q6hvrNpSyvSRkhyLkEg==",
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.3.7",
-        "@vaadin/vaadin-themable-mixin": "~24.3.7"
+        "@vaadin/component-base": "~24.3.18",
+        "@vaadin/vaadin-themable-mixin": "~24.3.18"
       }
     },
     "node_modules/@vaadin/vaadin-themable-mixin": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.3.7.tgz",
-      "integrity": "sha512-XPncXpmpimWXZcvWByQDUjM4M5laLO3NF38qhb+C3b3xb7xCwGoUw90eU7RilYRm4WPWNMn5YiA8gfz2s1ig+w==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.3.18.tgz",
+      "integrity": "sha512-4P9tjpyfRIXW+FKlnrjK0zSgguhIv1mKVjqEb55GnT9XXMZeAfYMkSBp8asWf6tLcKAVqYEq0/9cuPa5UmZBpQ==",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "lit": "^3.0.0"
@@ -740,9 +750,9 @@
       "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw=="
     },
     "node_modules/@zip.js/zip.js": {
-      "version": "2.7.36",
-      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.36.tgz",
-      "integrity": "sha512-u11fkedhUmMYIH1RRiVJM7fVw4CY+VPl0k6BxLBgngsIml70gGvbTHLhbXcN+BMBmQbZWL3DGEVxIo2xXVkLWg==",
+      "version": "2.7.47",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.47.tgz",
+      "integrity": "sha512-jmtJMA3/Jl4rMzo/DZ79s6g0CJ1AZcNAO6emTy/vHfIKAB/iiFY7PLs6KmbRTJ+F8GnK2eCLnjQfCCneRxXgzg==",
       "engines": {
         "bun": ">=0.7.0",
         "deno": ">=1.0.0",
@@ -802,45 +812,46 @@
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
     },
     "node_modules/dayjs": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "node_modules/esbuild": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
-      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.0.tgz",
+      "integrity": "sha512-1lvV17H2bMYda/WaFb2jLPeHU3zml2k4/yagNMG8Q/YtfMjCwEUZa2eXXMgZTVSL5q1n4H7sQ0X6CdJDqqeCFA==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.20.2",
-        "@esbuild/android-arm": "0.20.2",
-        "@esbuild/android-arm64": "0.20.2",
-        "@esbuild/android-x64": "0.20.2",
-        "@esbuild/darwin-arm64": "0.20.2",
-        "@esbuild/darwin-x64": "0.20.2",
-        "@esbuild/freebsd-arm64": "0.20.2",
-        "@esbuild/freebsd-x64": "0.20.2",
-        "@esbuild/linux-arm": "0.20.2",
-        "@esbuild/linux-arm64": "0.20.2",
-        "@esbuild/linux-ia32": "0.20.2",
-        "@esbuild/linux-loong64": "0.20.2",
-        "@esbuild/linux-mips64el": "0.20.2",
-        "@esbuild/linux-ppc64": "0.20.2",
-        "@esbuild/linux-riscv64": "0.20.2",
-        "@esbuild/linux-s390x": "0.20.2",
-        "@esbuild/linux-x64": "0.20.2",
-        "@esbuild/netbsd-x64": "0.20.2",
-        "@esbuild/openbsd-x64": "0.20.2",
-        "@esbuild/sunos-x64": "0.20.2",
-        "@esbuild/win32-arm64": "0.20.2",
-        "@esbuild/win32-ia32": "0.20.2",
-        "@esbuild/win32-x64": "0.20.2"
+        "@esbuild/aix-ppc64": "0.23.0",
+        "@esbuild/android-arm": "0.23.0",
+        "@esbuild/android-arm64": "0.23.0",
+        "@esbuild/android-x64": "0.23.0",
+        "@esbuild/darwin-arm64": "0.23.0",
+        "@esbuild/darwin-x64": "0.23.0",
+        "@esbuild/freebsd-arm64": "0.23.0",
+        "@esbuild/freebsd-x64": "0.23.0",
+        "@esbuild/linux-arm": "0.23.0",
+        "@esbuild/linux-arm64": "0.23.0",
+        "@esbuild/linux-ia32": "0.23.0",
+        "@esbuild/linux-loong64": "0.23.0",
+        "@esbuild/linux-mips64el": "0.23.0",
+        "@esbuild/linux-ppc64": "0.23.0",
+        "@esbuild/linux-riscv64": "0.23.0",
+        "@esbuild/linux-s390x": "0.23.0",
+        "@esbuild/linux-x64": "0.23.0",
+        "@esbuild/netbsd-x64": "0.23.0",
+        "@esbuild/openbsd-arm64": "0.23.0",
+        "@esbuild/openbsd-x64": "0.23.0",
+        "@esbuild/sunos-x64": "0.23.0",
+        "@esbuild/win32-arm64": "0.23.0",
+        "@esbuild/win32-ia32": "0.23.0",
+        "@esbuild/win32-x64": "0.23.0"
       }
     },
     "node_modules/focus-trap": {
@@ -857,9 +868,9 @@
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/lit": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.2.tgz",
-      "integrity": "sha512-VZx5iAyMtX7CV4K8iTLdCkMaYZ7ipjJZ0JcSdJ0zIdGxxyurjIn7yuuSxNBD7QmjvcNJwr0JS4cAdAtsy7gZ6w==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.4.tgz",
+      "integrity": "sha512-q6qKnKXHy2g1kjBaNfcoLlgbI3+aSOZ9Q4tiGa9bGYXq5RBXxkVTqTIVmP2VWMp29L4GyvCFm8ZQ2o56eUAMyA==",
       "dependencies": {
         "@lit/reactive-element": "^2.0.4",
         "lit-element": "^4.0.4",
@@ -867,9 +878,9 @@
       }
     },
     "node_modules/lit-element": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.4.tgz",
-      "integrity": "sha512-98CvgulX6eCPs6TyAIQoJZBCQPo80rgXR+dVBs61cstJXqtI+USQZAbA4gFHh6L/mxBx9MrgPLHLsUgDUHAcCQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.6.tgz",
+      "integrity": "sha512-U4sdJ3CSQip7sLGZ/uJskO5hGiqtlpxndsLr6mt3IQIjheg93UKYeGQjWMRql1s/cXNOaRrCzC2FQwjIwSUqkg==",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.2.0",
         "@lit/reactive-element": "^2.0.4",
@@ -877,9 +888,9 @@
       }
     },
     "node_modules/lit-html": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.2.tgz",
-      "integrity": "sha512-3OBZSUrPnAHoKJ9AMjRL/m01YJxQMf+TMHanNtTHG68ubjnZxK0RFl102DPzsw4mWnHibfZIBJm3LWCZ/LmMvg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.4.tgz",
+      "integrity": "sha512-yKKO2uVv7zYFHlWMfZmqc+4hkmSbFp8jgjdZY9vvR9jr4J8fH6FUMXhr+ljfELgmjpvlF7Z1SJ5n5/Jeqtc9YA==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -902,10 +913,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/protobufjs": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
-      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
+      "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -951,6 +973,17 @@
         "timezone-groups": "dist/cli.cjs"
       }
     },
+    "node_modules/type-fest": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+      "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -974,162 +1007,168 @@
   },
   "dependencies": {
     "@arcgis/core": {
-      "version": "4.29.10",
-      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.29.10.tgz",
-      "integrity": "sha512-EMJOJkeXG7sYeKLrjEWvF3cKWCFB4CFEjcsfRi0j9UlULv9NV9IarVryG1oLCg17CtEzcKjl7EZXiPnZsX5M2Q==",
+      "version": "4.30.9",
+      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.30.9.tgz",
+      "integrity": "sha512-tOM6QmXRikmD26uqIsFk2yxBwUpmAYJjp4vd9tl+VEfAXaLyArjHC8/op/OvyJZtfHNiL5zcSR7/YsiUddHPXA==",
       "requires": {
-        "@esri/arcgis-html-sanitizer": "~3.0.1",
+        "@esri/arcgis-html-sanitizer": "~4.0.3",
         "@esri/calcite-colors": "~6.1.0",
-        "@esri/calcite-components": "^2.4.0",
-        "@popperjs/core": "~2.11.8",
-        "@vaadin/grid": "~24.3.6",
-        "@zip.js/zip.js": "~2.7.34",
+        "@esri/calcite-components": "^2.8.5",
+        "@vaadin/grid": "~24.3.13",
+        "@zip.js/zip.js": "~2.7.44",
         "luxon": "~3.4.4",
+        "marked": "~12.0.2",
         "sortablejs": "~1.15.2"
       }
     },
     "@esbuild/aix-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
-      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.0.tgz",
+      "integrity": "sha512-3sG8Zwa5fMcA9bgqB8AfWPQ+HFke6uD3h1s3RIwUNK8EG7a4buxvuFTs3j1IMs2NXAk9F30C/FF4vxRgQCcmoQ==",
       "optional": true
     },
     "@esbuild/android-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
-      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.0.tgz",
+      "integrity": "sha512-+KuOHTKKyIKgEEqKbGTK8W7mPp+hKinbMBeEnNzjJGyFcWsfrXjSTNluJHCY1RqhxFurdD8uNXQDei7qDlR6+g==",
       "optional": true
     },
     "@esbuild/android-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
-      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.0.tgz",
+      "integrity": "sha512-EuHFUYkAVfU4qBdyivULuu03FhJO4IJN9PGuABGrFy4vUuzk91P2d+npxHcFdpUnfYKy0PuV+n6bKIpHOB3prQ==",
       "optional": true
     },
     "@esbuild/android-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
-      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.0.tgz",
+      "integrity": "sha512-WRrmKidLoKDl56LsbBMhzTTBxrsVwTKdNbKDalbEZr0tcsBgCLbEtoNthOW6PX942YiYq8HzEnb4yWQMLQuipQ==",
       "optional": true
     },
     "@esbuild/darwin-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
-      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.0.tgz",
+      "integrity": "sha512-YLntie/IdS31H54Ogdn+v50NuoWF5BDkEUFpiOChVa9UnKpftgwzZRrI4J132ETIi+D8n6xh9IviFV3eXdxfow==",
       "optional": true
     },
     "@esbuild/darwin-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
-      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.0.tgz",
+      "integrity": "sha512-IMQ6eme4AfznElesHUPDZ+teuGwoRmVuuixu7sv92ZkdQcPbsNHzutd+rAfaBKo8YK3IrBEi9SLLKWJdEvJniQ==",
       "optional": true
     },
     "@esbuild/freebsd-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
-      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.0.tgz",
+      "integrity": "sha512-0muYWCng5vqaxobq6LB3YNtevDFSAZGlgtLoAc81PjUfiFz36n4KMpwhtAd4he8ToSI3TGyuhyx5xmiWNYZFyw==",
       "optional": true
     },
     "@esbuild/freebsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
-      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.0.tgz",
+      "integrity": "sha512-XKDVu8IsD0/q3foBzsXGt/KjD/yTKBCIwOHE1XwiXmrRwrX6Hbnd5Eqn/WvDekddK21tfszBSrE/WMaZh+1buQ==",
       "optional": true
     },
     "@esbuild/linux-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
-      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.0.tgz",
+      "integrity": "sha512-SEELSTEtOFu5LPykzA395Mc+54RMg1EUgXP+iw2SJ72+ooMwVsgfuwXo5Fn0wXNgWZsTVHwY2cg4Vi/bOD88qw==",
       "optional": true
     },
     "@esbuild/linux-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
-      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.0.tgz",
+      "integrity": "sha512-j1t5iG8jE7BhonbsEg5d9qOYcVZv/Rv6tghaXM/Ug9xahM0nX/H2gfu6X6z11QRTMT6+aywOMA8TDkhPo8aCGw==",
       "optional": true
     },
     "@esbuild/linux-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
-      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.0.tgz",
+      "integrity": "sha512-P7O5Tkh2NbgIm2R6x1zGJJsnacDzTFcRWZyTTMgFdVit6E98LTxO+v8LCCLWRvPrjdzXHx9FEOA8oAZPyApWUA==",
       "optional": true
     },
     "@esbuild/linux-loong64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
-      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.0.tgz",
+      "integrity": "sha512-InQwepswq6urikQiIC/kkx412fqUZudBO4SYKu0N+tGhXRWUqAx+Q+341tFV6QdBifpjYgUndV1hhMq3WeJi7A==",
       "optional": true
     },
     "@esbuild/linux-mips64el": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
-      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.0.tgz",
+      "integrity": "sha512-J9rflLtqdYrxHv2FqXE2i1ELgNjT+JFURt/uDMoPQLcjWQA5wDKgQA4t/dTqGa88ZVECKaD0TctwsUfHbVoi4w==",
       "optional": true
     },
     "@esbuild/linux-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
-      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.0.tgz",
+      "integrity": "sha512-cShCXtEOVc5GxU0fM+dsFD10qZ5UpcQ8AM22bYj0u/yaAykWnqXJDpd77ublcX6vdDsWLuweeuSNZk4yUxZwtw==",
       "optional": true
     },
     "@esbuild/linux-riscv64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
-      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.0.tgz",
+      "integrity": "sha512-HEtaN7Y5UB4tZPeQmgz/UhzoEyYftbMXrBCUjINGjh3uil+rB/QzzpMshz3cNUxqXN7Vr93zzVtpIDL99t9aRw==",
       "optional": true
     },
     "@esbuild/linux-s390x": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
-      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.0.tgz",
+      "integrity": "sha512-WDi3+NVAuyjg/Wxi+o5KPqRbZY0QhI9TjrEEm+8dmpY9Xir8+HE/HNx2JoLckhKbFopW0RdO2D72w8trZOV+Wg==",
       "optional": true
     },
     "@esbuild/linux-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
-      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.0.tgz",
+      "integrity": "sha512-a3pMQhUEJkITgAw6e0bWA+F+vFtCciMjW/LPtoj99MhVt+Mfb6bbL9hu2wmTZgNd994qTAEw+U/r6k3qHWWaOQ==",
       "optional": true
     },
     "@esbuild/netbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.0.tgz",
+      "integrity": "sha512-cRK+YDem7lFTs2Q5nEv/HHc4LnrfBCbH5+JHu6wm2eP+d8OZNoSMYgPZJq78vqQ9g+9+nMuIsAO7skzphRXHyw==",
+      "optional": true
+    },
+    "@esbuild/openbsd-arm64": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.0.tgz",
+      "integrity": "sha512-suXjq53gERueVWu0OKxzWqk7NxiUWSUlrxoZK7usiF50C6ipColGR5qie2496iKGYNLhDZkPxBI3erbnYkU0rQ==",
       "optional": true
     },
     "@esbuild/openbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.0.tgz",
+      "integrity": "sha512-6p3nHpby0DM/v15IFKMjAaayFhqnXV52aEmv1whZHX56pdkK+MEaLoQWj+H42ssFarP1PcomVhbsR4pkz09qBg==",
       "optional": true
     },
     "@esbuild/sunos-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
-      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.0.tgz",
+      "integrity": "sha512-BFelBGfrBwk6LVrmFzCq1u1dZbG4zy/Kp93w2+y83Q5UGYF1d8sCzeLI9NXjKyujjBBniQa8R8PzLFAUrSM9OA==",
       "optional": true
     },
     "@esbuild/win32-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
-      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.0.tgz",
+      "integrity": "sha512-lY6AC8p4Cnb7xYHuIxQ6iYPe6MfO2CC43XXKo9nBXDb35krYt7KGhQnOkRGar5psxYkircpCqfbNDB4uJbS2jQ==",
       "optional": true
     },
     "@esbuild/win32-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
-      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.0.tgz",
+      "integrity": "sha512-7L1bHlOTcO4ByvI7OXVI5pNN6HSu6pUQq9yodga8izeuB1KcT2UkHaH6118QJwopExPn0rMHIseCTx1CRo/uNA==",
       "optional": true
     },
     "@esbuild/win32-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
-      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.0.tgz",
+      "integrity": "sha512-Arm+WgUFLUATuoxCJcahGuk6Yj9Pzxd6l11Zb/2aAuv5kWWvvfhLFo2fni4uSK5vzlUdCGZ/BdV5tH8klj8p8g==",
       "optional": true
     },
     "@esri/arcgis-html-sanitizer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-3.0.1.tgz",
-      "integrity": "sha512-cwZJwsYCJZwtBQU2AmaiIVFg5nZcVwInPYja1/OgC9iKYO+ytZRoc5h+0S9/ygbFNoS8Nd0RX9A85stLX/BgiA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-4.0.3.tgz",
+      "integrity": "sha512-B06V4Spjhcy2zcKH9SaTrZwRGjUTlsCSGImdCpe7fN/Q3HxLa4QosMgrRJQ+Q8guLhBA177+6Fjwzl/xIrmY7A==",
       "requires": {
         "xss": "1.0.13"
       }
@@ -1140,20 +1179,21 @@
       "integrity": "sha512-wHQYWFtDa6c328EraXEVZvgOiaQyYr0yuaaZ0G3cB4C3lSkWefW34L/e5TLAhtuG3zJ/wR6pl5X1YYNfBc0/4Q=="
     },
     "@esri/calcite-components": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.6.0.tgz",
-      "integrity": "sha512-GbpascF/mI3TvC5EQejzMi8zDG/wv0pzGU5HzUsrzHqIkIwRruuIe7qdg/srjaEQkXwwpJKxfd8r5QaBXjlQWw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.10.1.tgz",
+      "integrity": "sha512-8M2ZBYcEk20x34TDxZ6H5rLCWtGrOJLtHA/k6yWL/GJTC85/gvY153XxbGN8F1ywJb/3imvhy/SlfNRPnVPQNQ==",
       "requires": {
-        "@floating-ui/dom": "1.6.3",
-        "@stencil/core": "4.9.0",
+        "@floating-ui/dom": "1.6.5",
+        "@stencil/core": "4.18.3",
         "@types/color": "3.0.6",
         "color": "4.2.3",
         "composed-offset-position": "0.0.4",
-        "dayjs": "1.11.10",
+        "dayjs": "1.11.11",
         "focus-trap": "7.5.4",
         "lodash-es": "4.17.21",
         "sortablejs": "1.15.1",
-        "timezone-groups": "0.8.0"
+        "timezone-groups": "0.8.0",
+        "type-fest": "4.18.2"
       },
       "dependencies": {
         "sortablejs": {
@@ -1164,26 +1204,26 @@
       }
     },
     "@floating-ui/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.4.tgz",
+      "integrity": "sha512-a4IowK4QkXl4SCWTGUR0INAfEOX3wtsYw3rKK5InQEHMGObkR8Xk44qYQD9P4r6HHw0iIfK6GUKECmY8sTkqRA==",
       "requires": {
-        "@floating-ui/utils": "^0.2.1"
+        "@floating-ui/utils": "^0.2.4"
       }
     },
     "@floating-ui/dom": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
-      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.5.tgz",
+      "integrity": "sha512-Nsdud2X65Dz+1RHjAIP0t8z5e2ff/IRbei6BqFrl1urT8sDVzM1HMQ+R0XcU5ceRfyO3I6ayeqIfh+6Wb8LGTw==",
       "requires": {
         "@floating-ui/core": "^1.0.0",
         "@floating-ui/utils": "^0.2.0"
       }
     },
     "@floating-ui/utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
-      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.4.tgz",
+      "integrity": "sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA=="
     },
     "@lit-labs/ssr-dom-shim": {
       "version": "1.2.0",
@@ -1210,11 +1250,6 @@
       "requires": {
         "@webcomponents/shadycss": "^1.9.1"
       }
-    },
-    "@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -1271,9 +1306,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@stencil/core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.9.0.tgz",
-      "integrity": "sha512-aWSkhBmk3yPwRAkUwBbzRwmdhb8hKiQ/JMr9m5jthpBZLjtppYbzz6PN2MhSMDfRp6K93eQw5WogSEH4HHuB6w=="
+      "version": "4.18.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.18.3.tgz",
+      "integrity": "sha512-8yoG5AFQYEPocVtuoc5kvRS0Hku0MoDWDUpADRaXPVHsOFLmxR16LJENj25ucCz5GEfeTGQ/tCE8JAypPmr/fQ=="
     },
     "@types/color": {
       "version": "3.0.6",
@@ -1292,14 +1327,14 @@
       }
     },
     "@types/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-87W6MJCKZYDhLAx/J1ikW8niMvmGRyY+rpUxWpL1cO7F8Uu5CHuQoFv+R0/L5pgNdW4jTyda42kv60uwVIPjLw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-hulKeREDdLFesGQjl96+4aoJSHY5b2GRjagzzcqCfIrWhe5vkCqIvrLbqzBaI1q94Vg8DNJZZqTR5ocdWmWclg=="
     },
     "@types/node": {
-      "version": "20.11.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.24.tgz",
-      "integrity": "sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==",
+      "version": "20.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -1310,36 +1345,36 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
     },
     "@vaadin/a11y-base": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.3.7.tgz",
-      "integrity": "sha512-gcuCsSf+dH84HRJCQyZj3dqqyxVhKKYqGiMHAjNtQhRqojvNFH/YHk/ZLpBhiq/qI2VHfqeEbz2gJ2RMdIqFCA==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.3.18.tgz",
+      "integrity": "sha512-qa8oduy74CCPEe1ORF03ZSV91cCWePD/6dFuFkPn1t6oX2CZzsCm9vu0S0fGIbAIYfoJ4W0eVXnuEGwYdmIDQQ==",
       "requires": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.3.7",
+        "@vaadin/component-base": "~24.3.18",
         "lit": "^3.0.0"
       }
     },
     "@vaadin/checkbox": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.3.7.tgz",
-      "integrity": "sha512-kVe5uoR4eRZAwNon+D2y0CYUHondFB799ajj7BGFuk2+rcbx1IQiv3PAq3TZ5YZ68rl++FcRMFbybuQBxBHJpw==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.3.18.tgz",
+      "integrity": "sha512-bRJT6/hYODuue5mfE9D2eHiciEO6C69nFjo7ZoUM70+A66mTQ1DXX/8BujvjLAlH8jzmeHeS/AejmudowiC7Lg==",
       "requires": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.3.7",
-        "@vaadin/component-base": "~24.3.7",
-        "@vaadin/field-base": "~24.3.7",
-        "@vaadin/vaadin-lumo-styles": "~24.3.7",
-        "@vaadin/vaadin-material-styles": "~24.3.7",
-        "@vaadin/vaadin-themable-mixin": "~24.3.7",
+        "@vaadin/a11y-base": "~24.3.18",
+        "@vaadin/component-base": "~24.3.18",
+        "@vaadin/field-base": "~24.3.18",
+        "@vaadin/vaadin-lumo-styles": "~24.3.18",
+        "@vaadin/vaadin-material-styles": "~24.3.18",
+        "@vaadin/vaadin-themable-mixin": "~24.3.18",
         "lit": "^3.0.0"
       }
     },
     "@vaadin/component-base": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.3.7.tgz",
-      "integrity": "sha512-r5fvuR381Musi1JH9xMzvajw2l4vzefZlvGHMg0ywb72pDS8ZmtizDaIMioNYHWAoe4kBdJ1xdzlygPyqU63Og==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.3.18.tgz",
+      "integrity": "sha512-PINsCNytvoysWL/oBe7HBIEJL1lcc3ihFVTwDM0PB/uVMTRcM0JPMkP4/A1f/qZbTKjZnF2RIXIotexHxumZAg==",
       "requires": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -1349,115 +1384,115 @@
       }
     },
     "@vaadin/field-base": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.3.7.tgz",
-      "integrity": "sha512-t3I9yrFNIsYd8ysB6d/DOISy5BrbsQwXZjNECRJ9WnuordQPgyRBmUO1wPKjK0/2qvwwiyON+8IavQXoOPLXUg==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.3.18.tgz",
+      "integrity": "sha512-nVHXkaqT1LJVVjsAiWpg9bdEA3OAfERxA4fvKqkuFUK55aAVeQxCw3P8jWmVKRVd3m9UCmlLHnHuXmuD2R6ZwQ==",
       "requires": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.3.7",
-        "@vaadin/component-base": "~24.3.7",
+        "@vaadin/a11y-base": "~24.3.18",
+        "@vaadin/component-base": "~24.3.18",
         "lit": "^3.0.0"
       }
     },
     "@vaadin/grid": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.3.7.tgz",
-      "integrity": "sha512-CAHi0N4t2ua7X5NLlvC3Yqfl6Q7CrTaYRPkHW7Hv4YJ+Z3erDJeUKOFE48Q4TZryEUMzZ0CNB3xL3UK/PvJiAQ==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.3.18.tgz",
+      "integrity": "sha512-Cvg+D4mizhs5Wh4JdX+wkWfJzHD/Jp1CeahhjLxUD13BKrgtgwNj1IofFQD47lMMufK/5wi2ppeeD/MaINaE5A==",
       "requires": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.3.7",
-        "@vaadin/checkbox": "~24.3.7",
-        "@vaadin/component-base": "~24.3.7",
-        "@vaadin/lit-renderer": "~24.3.7",
-        "@vaadin/text-field": "~24.3.7",
-        "@vaadin/vaadin-lumo-styles": "~24.3.7",
-        "@vaadin/vaadin-material-styles": "~24.3.7",
-        "@vaadin/vaadin-themable-mixin": "~24.3.7"
+        "@vaadin/a11y-base": "~24.3.18",
+        "@vaadin/checkbox": "~24.3.18",
+        "@vaadin/component-base": "~24.3.18",
+        "@vaadin/lit-renderer": "~24.3.18",
+        "@vaadin/text-field": "~24.3.18",
+        "@vaadin/vaadin-lumo-styles": "~24.3.18",
+        "@vaadin/vaadin-material-styles": "~24.3.18",
+        "@vaadin/vaadin-themable-mixin": "~24.3.18"
       }
     },
     "@vaadin/icon": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.3.7.tgz",
-      "integrity": "sha512-qsOww+kuyZFsG+4JOlQmnsmljsGrgedZEvafPPwFEO6RG7XWUSwrJtY7u6FWBHHKAjVLaSEs4B4UrdWYRKaq+A==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.3.18.tgz",
+      "integrity": "sha512-S0Vh8SgtpBrdWSB+dGUGtvku9Avj8PZ4e3CY+U9A8L1ArdS+X20Jwag5cY4I5d9GY/NOcoSkYBcJqgAMTem2kQ==",
       "requires": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.3.7",
-        "@vaadin/vaadin-lumo-styles": "~24.3.7",
-        "@vaadin/vaadin-themable-mixin": "~24.3.7",
+        "@vaadin/component-base": "~24.3.18",
+        "@vaadin/vaadin-lumo-styles": "~24.3.18",
+        "@vaadin/vaadin-themable-mixin": "~24.3.18",
         "lit": "^3.0.0"
       }
     },
     "@vaadin/input-container": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.3.7.tgz",
-      "integrity": "sha512-fTKxWEvDmiBUAA2IviVPFXc1UMeb+r0JkMHVNe5E8HBXKbjf6j7Vo+cpWkZ3wfWLcduwXRR6m+KL8PSnafF0Hg==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.3.18.tgz",
+      "integrity": "sha512-UwTOLa72UXHh9sTNqNwrfbKvUwcXTDM6naEh+tO/l+tbXXVcC+Bo8FnTKBugYVnlQQOpzC4jLvxMma3XUlSAuA==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.3.7",
-        "@vaadin/vaadin-lumo-styles": "~24.3.7",
-        "@vaadin/vaadin-material-styles": "~24.3.7",
-        "@vaadin/vaadin-themable-mixin": "~24.3.7",
+        "@vaadin/component-base": "~24.3.18",
+        "@vaadin/vaadin-lumo-styles": "~24.3.18",
+        "@vaadin/vaadin-material-styles": "~24.3.18",
+        "@vaadin/vaadin-themable-mixin": "~24.3.18",
         "lit": "^3.0.0"
       }
     },
     "@vaadin/lit-renderer": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.3.7.tgz",
-      "integrity": "sha512-jlj3xd0CJWtbIsZCSon4BPxkOSTRkQgGY3cGspPk2v0eyHjm9+qtqPhMq7n2vu21V5ZLpaBG51/5jObHVq9rJQ==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.3.18.tgz",
+      "integrity": "sha512-HlYrhVwagnYcbGuOJ3IP6YRxSaV6l7qbRfsZsTl+Xpt/ElaWRktwATzvGgYd0zvnvgAut555lja9/dl0T33yOg==",
       "requires": {
         "lit": "^3.0.0"
       }
     },
     "@vaadin/text-field": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.3.7.tgz",
-      "integrity": "sha512-N/jVZLJwzxhUrclvM1nxdUwRRooWP0yZCgK9Ndj//xI+NS6zk1AsZkGwiBBBUXShCn4Xbptcuhlk/y3G/QEPqA==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.3.18.tgz",
+      "integrity": "sha512-k7u7CKeLOg4RUZ94TGfXJ7DpU1GJJLxfAqPbG2YP5tDYL4g3XyVfILpW4jDUQr5gJhPJyS7L9roNadc0Q3Mp4g==",
       "requires": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/a11y-base": "~24.3.7",
-        "@vaadin/component-base": "~24.3.7",
-        "@vaadin/field-base": "~24.3.7",
-        "@vaadin/input-container": "~24.3.7",
-        "@vaadin/vaadin-lumo-styles": "~24.3.7",
-        "@vaadin/vaadin-material-styles": "~24.3.7",
-        "@vaadin/vaadin-themable-mixin": "~24.3.7",
+        "@vaadin/a11y-base": "~24.3.18",
+        "@vaadin/component-base": "~24.3.18",
+        "@vaadin/field-base": "~24.3.18",
+        "@vaadin/input-container": "~24.3.18",
+        "@vaadin/vaadin-lumo-styles": "~24.3.18",
+        "@vaadin/vaadin-material-styles": "~24.3.18",
+        "@vaadin/vaadin-themable-mixin": "~24.3.18",
         "lit": "^3.0.0"
       }
     },
     "@vaadin/vaadin-development-mode-detector": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.6.tgz",
-      "integrity": "sha512-N6a5nLT/ytEUlpPo+nvdCKIGoyNjPsj3rzPGvGYK8x9Ceg76OTe1xI/GtN71mRW9e2HUScR0kCNOkl1Z63YDjw=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.7.tgz",
+      "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA=="
     },
     "@vaadin/vaadin-lumo-styles": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.3.7.tgz",
-      "integrity": "sha512-JyB41TsQxb0/9oUanc6X4d6SlCfQptkm0k88jWoPJ4l7OvCvlNWg1h780xpO/AbMKZIfo19QlWvls8DAvxGduQ==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.3.18.tgz",
+      "integrity": "sha512-cgzVOnmBiqlGQIAoQs/k2iFSsgTfckUcmGScouCbTUx2AUWbTvVYPjGlac1dkO4CsSZELE3uf2WPdPVQPSw1dw==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.3.7",
-        "@vaadin/icon": "~24.3.7",
-        "@vaadin/vaadin-themable-mixin": "~24.3.7"
+        "@vaadin/component-base": "~24.3.18",
+        "@vaadin/icon": "~24.3.18",
+        "@vaadin/vaadin-themable-mixin": "~24.3.18"
       }
     },
     "@vaadin/vaadin-material-styles": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.3.7.tgz",
-      "integrity": "sha512-qmjbL8/PBmCkQ0MF95ajj65JLPHoa7kAi42XAIh8m/YFK8hjRMcVb/RdpWi2ZVHaiz1dUHbrrwq8vGMBVD752w==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.3.18.tgz",
+      "integrity": "sha512-vNJ1fjuVpneqodh6uOSAlUWbZ6V2S2mxdwr++VsdPgDtNhqxwpOhY4X700XQhObbk28q6hvrNpSyvSRkhyLkEg==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/component-base": "~24.3.7",
-        "@vaadin/vaadin-themable-mixin": "~24.3.7"
+        "@vaadin/component-base": "~24.3.18",
+        "@vaadin/vaadin-themable-mixin": "~24.3.18"
       }
     },
     "@vaadin/vaadin-themable-mixin": {
-      "version": "24.3.7",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.3.7.tgz",
-      "integrity": "sha512-XPncXpmpimWXZcvWByQDUjM4M5laLO3NF38qhb+C3b3xb7xCwGoUw90eU7RilYRm4WPWNMn5YiA8gfz2s1ig+w==",
+      "version": "24.3.18",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.3.18.tgz",
+      "integrity": "sha512-4P9tjpyfRIXW+FKlnrjK0zSgguhIv1mKVjqEb55GnT9XXMZeAfYMkSBp8asWf6tLcKAVqYEq0/9cuPa5UmZBpQ==",
       "requires": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "lit": "^3.0.0"
@@ -1477,9 +1512,9 @@
       "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw=="
     },
     "@zip.js/zip.js": {
-      "version": "2.7.36",
-      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.36.tgz",
-      "integrity": "sha512-u11fkedhUmMYIH1RRiVJM7fVw4CY+VPl0k6BxLBgngsIml70gGvbTHLhbXcN+BMBmQbZWL3DGEVxIo2xXVkLWg=="
+      "version": "2.7.47",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.47.tgz",
+      "integrity": "sha512-jmtJMA3/Jl4rMzo/DZ79s6g0CJ1AZcNAO6emTy/vHfIKAB/iiFY7PLs6KmbRTJ+F8GnK2eCLnjQfCCneRxXgzg=="
     },
     "color": {
       "version": "4.2.3",
@@ -1528,38 +1563,39 @@
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
     },
     "dayjs": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "esbuild": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
-      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.0.tgz",
+      "integrity": "sha512-1lvV17H2bMYda/WaFb2jLPeHU3zml2k4/yagNMG8Q/YtfMjCwEUZa2eXXMgZTVSL5q1n4H7sQ0X6CdJDqqeCFA==",
       "requires": {
-        "@esbuild/aix-ppc64": "0.20.2",
-        "@esbuild/android-arm": "0.20.2",
-        "@esbuild/android-arm64": "0.20.2",
-        "@esbuild/android-x64": "0.20.2",
-        "@esbuild/darwin-arm64": "0.20.2",
-        "@esbuild/darwin-x64": "0.20.2",
-        "@esbuild/freebsd-arm64": "0.20.2",
-        "@esbuild/freebsd-x64": "0.20.2",
-        "@esbuild/linux-arm": "0.20.2",
-        "@esbuild/linux-arm64": "0.20.2",
-        "@esbuild/linux-ia32": "0.20.2",
-        "@esbuild/linux-loong64": "0.20.2",
-        "@esbuild/linux-mips64el": "0.20.2",
-        "@esbuild/linux-ppc64": "0.20.2",
-        "@esbuild/linux-riscv64": "0.20.2",
-        "@esbuild/linux-s390x": "0.20.2",
-        "@esbuild/linux-x64": "0.20.2",
-        "@esbuild/netbsd-x64": "0.20.2",
-        "@esbuild/openbsd-x64": "0.20.2",
-        "@esbuild/sunos-x64": "0.20.2",
-        "@esbuild/win32-arm64": "0.20.2",
-        "@esbuild/win32-ia32": "0.20.2",
-        "@esbuild/win32-x64": "0.20.2"
+        "@esbuild/aix-ppc64": "0.23.0",
+        "@esbuild/android-arm": "0.23.0",
+        "@esbuild/android-arm64": "0.23.0",
+        "@esbuild/android-x64": "0.23.0",
+        "@esbuild/darwin-arm64": "0.23.0",
+        "@esbuild/darwin-x64": "0.23.0",
+        "@esbuild/freebsd-arm64": "0.23.0",
+        "@esbuild/freebsd-x64": "0.23.0",
+        "@esbuild/linux-arm": "0.23.0",
+        "@esbuild/linux-arm64": "0.23.0",
+        "@esbuild/linux-ia32": "0.23.0",
+        "@esbuild/linux-loong64": "0.23.0",
+        "@esbuild/linux-mips64el": "0.23.0",
+        "@esbuild/linux-ppc64": "0.23.0",
+        "@esbuild/linux-riscv64": "0.23.0",
+        "@esbuild/linux-s390x": "0.23.0",
+        "@esbuild/linux-x64": "0.23.0",
+        "@esbuild/netbsd-x64": "0.23.0",
+        "@esbuild/openbsd-arm64": "0.23.0",
+        "@esbuild/openbsd-x64": "0.23.0",
+        "@esbuild/sunos-x64": "0.23.0",
+        "@esbuild/win32-arm64": "0.23.0",
+        "@esbuild/win32-ia32": "0.23.0",
+        "@esbuild/win32-x64": "0.23.0"
       }
     },
     "focus-trap": {
@@ -1576,9 +1612,9 @@
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "lit": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.2.tgz",
-      "integrity": "sha512-VZx5iAyMtX7CV4K8iTLdCkMaYZ7ipjJZ0JcSdJ0zIdGxxyurjIn7yuuSxNBD7QmjvcNJwr0JS4cAdAtsy7gZ6w==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.4.tgz",
+      "integrity": "sha512-q6qKnKXHy2g1kjBaNfcoLlgbI3+aSOZ9Q4tiGa9bGYXq5RBXxkVTqTIVmP2VWMp29L4GyvCFm8ZQ2o56eUAMyA==",
       "requires": {
         "@lit/reactive-element": "^2.0.4",
         "lit-element": "^4.0.4",
@@ -1586,9 +1622,9 @@
       }
     },
     "lit-element": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.4.tgz",
-      "integrity": "sha512-98CvgulX6eCPs6TyAIQoJZBCQPo80rgXR+dVBs61cstJXqtI+USQZAbA4gFHh6L/mxBx9MrgPLHLsUgDUHAcCQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.6.tgz",
+      "integrity": "sha512-U4sdJ3CSQip7sLGZ/uJskO5hGiqtlpxndsLr6mt3IQIjheg93UKYeGQjWMRql1s/cXNOaRrCzC2FQwjIwSUqkg==",
       "requires": {
         "@lit-labs/ssr-dom-shim": "^1.2.0",
         "@lit/reactive-element": "^2.0.4",
@@ -1596,9 +1632,9 @@
       }
     },
     "lit-html": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.2.tgz",
-      "integrity": "sha512-3OBZSUrPnAHoKJ9AMjRL/m01YJxQMf+TMHanNtTHG68ubjnZxK0RFl102DPzsw4mWnHibfZIBJm3LWCZ/LmMvg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.4.tgz",
+      "integrity": "sha512-yKKO2uVv7zYFHlWMfZmqc+4hkmSbFp8jgjdZY9vvR9jr4J8fH6FUMXhr+ljfELgmjpvlF7Z1SJ5n5/Jeqtc9YA==",
       "requires": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -1618,10 +1654,15 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
       "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA=="
     },
+    "marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q=="
+    },
     "protobufjs": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
-      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
+      "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -1659,6 +1700,11 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.8.0.tgz",
       "integrity": "sha512-t7E/9sPfCU0m0ZbS7Cqw52D6CB/UyeaiIBmyJCokI1SyOyOgA/ESiQ/fbreeFaUG9QSenGlZSSk/7rEbkipbOA=="
+    },
+    "type-fest": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+      "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg=="
     },
     "undici-types": {
       "version": "5.26.5",

--- a/src/dymaptic.GeoBlazor.Core/package-lock.json
+++ b/src/dymaptic.GeoBlazor.Core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dymaptic.GeoBlazor.Core",
       "license": "ISC",
       "dependencies": {
-        "@arcgis/core": "4.29.7",
+        "@arcgis/core": "4.29.10",
         "esbuild": "0.20.2",
         "protobufjs": "7.2.6"
       },
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@arcgis/core": {
-      "version": "4.29.7",
-      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.29.7.tgz",
-      "integrity": "sha512-3GV5Xv3e/WKEcmvHuD2Tl9jB8aowWXH1Hwz4Lg6ZokWTlkUupRXzSiR898LkRDTL8CWise3xVCknhCyFPUZu5w==",
+      "version": "4.29.10",
+      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.29.10.tgz",
+      "integrity": "sha512-EMJOJkeXG7sYeKLrjEWvF3cKWCFB4CFEjcsfRi0j9UlULv9NV9IarVryG1oLCg17CtEzcKjl7EZXiPnZsX5M2Q==",
       "dependencies": {
         "@esri/arcgis-html-sanitizer": "~3.0.1",
         "@esri/calcite-colors": "~6.1.0",
@@ -974,9 +974,9 @@
   },
   "dependencies": {
     "@arcgis/core": {
-      "version": "4.29.7",
-      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.29.7.tgz",
-      "integrity": "sha512-3GV5Xv3e/WKEcmvHuD2Tl9jB8aowWXH1Hwz4Lg6ZokWTlkUupRXzSiR898LkRDTL8CWise3xVCknhCyFPUZu5w==",
+      "version": "4.29.10",
+      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.29.10.tgz",
+      "integrity": "sha512-EMJOJkeXG7sYeKLrjEWvF3cKWCFB4CFEjcsfRi0j9UlULv9NV9IarVryG1oLCg17CtEzcKjl7EZXiPnZsX5M2Q==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "~3.0.1",
         "@esri/calcite-colors": "~6.1.0",

--- a/src/dymaptic.GeoBlazor.Core/package.json
+++ b/src/dymaptic.GeoBlazor.Core/package.json
@@ -11,11 +11,11 @@
   "author": "dymaptic",
   "license": "ISC",
   "dependencies": {
-    "@arcgis/core": "4.29.10",
-    "esbuild": "0.20.2",
-    "protobufjs": "7.2.6"
+    "@arcgis/core": "4.30.9",
+    "esbuild": "0.23.0",
+    "protobufjs": "7.3.2"
   },
   "devDependencies": {
-    "@types/node": "^20.11.24"
+    "@types/node": "^20.14.11"
   }
 }

--- a/src/dymaptic.GeoBlazor.Core/package.json
+++ b/src/dymaptic.GeoBlazor.Core/package.json
@@ -3,15 +3,15 @@
   "description": "https://www.geoblazor.com",
   "main": "arcGisInterop.js",
   "scripts": {
-    "debugBuild": "esbuild ./Scripts/arcGisJsInterop.ts ./Scripts/abortController.ts --format=esm --bundle --sourcemap --outdir=wwwroot/js",
-    "watchBuild": "esbuild ./Scripts/arcGisJsInterop.ts ./Scripts/abortController.ts --format=esm --bundle --sourcemap --outdir=wwwroot/js --watch",
-    "releaseBuild": "esbuild ./Scripts/arcGisJsInterop.ts ./Scripts/abortController.ts --format=esm --bundle --minify --sourcemap --outdir=wwwroot/js"
+    "debugBuild": "esbuild ./Scripts/arcGisJsInterop.ts ./Scripts/abortController.ts --format=esm --bundle --sourcemap --outdir=wwwroot/js --splitting",
+    "watchBuild": "esbuild ./Scripts/arcGisJsInterop.ts ./Scripts/abortController.ts --format=esm --bundle --sourcemap --outdir=wwwroot/js --watch --splitting",
+    "releaseBuild": "esbuild ./Scripts/arcGisJsInterop.ts ./Scripts/abortController.ts --format=esm --bundle --minify --sourcemap --outdir=wwwroot/js --splitting"
   },
   "keywords": [],
   "author": "dymaptic",
   "license": "ISC",
   "dependencies": {
-    "@arcgis/core": "4.29.7",
+    "@arcgis/core": "4.29.10",
     "esbuild": "0.20.2",
     "protobufjs": "7.2.6"
   },

--- a/templates/content/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp.Client/dymaptic.GeoBlazor.Template.WebApp.Client.csproj
+++ b/templates/content/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp.Client/dymaptic.GeoBlazor.Template.WebApp.Client.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.3-beta-4" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0-0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.7" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/templates/content/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp.csproj
+++ b/templates/content/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp/dymaptic.GeoBlazor.Template.WebApp.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\dymaptic.GeoBlazor.Template.WebApp.Client\dymaptic.GeoBlazor.Template.WebApp.Client.csproj" />
 		<PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.3-beta-4" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.7" />
 	</ItemGroup>
 
 </Project>

--- a/templates/content/dymaptic.GeoBlazor.Template.WebAssembly/dymaptic.GeoBlazor.Template.WebAssembly.csproj
+++ b/templates/content/dymaptic.GeoBlazor.Template.WebAssembly/dymaptic.GeoBlazor.Template.WebAssembly.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="dymaptic.GeoBlazor.Core" Version="3.0.3-beta-4" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.7" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/dymaptic.GeoBlazor.Core.Test.Blazor.Shared.csproj
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/dymaptic.GeoBlazor.Core.Test.Blazor.Shared.csproj
@@ -12,9 +12,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.7"/>
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0"/>
-        <PackageReference Include="MSTest.TestFramework" Version="3.1.1"/>
+        <PackageReference Include="MSTest.TestFramework" Version="3.5.0"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -25,18 +25,18 @@
         <AdditionalFiles Include="Components\WidgetTests.razor"/>
     </ItemGroup>
 
-    <Choose>
-        <When Condition="$(Configuration) == 'RELEASE' AND '$(UsePackageReferences)' == 'true'">
-            <ItemGroup Condition="$(Configuration) == 'RELEASE'">
-                <PackageReference Include="dymaptic.GeoBlazor.Core"  Version="$(CoreVersion)" />
-            </ItemGroup>
-        </When>
-        <Otherwise>
-            <ItemGroup Condition="$(Configuration) == 'DEBUG'">
-                <ProjectReference Include="..\..\src\dymaptic.GeoBlazor.Core\dymaptic.GeoBlazor.Core.csproj"/>
-            </ItemGroup>
-        </Otherwise>
-    </Choose>
+    <Target Name="ReferenceType" BeforeTargets="Build" Condition="$(Configuration) == 'DEBUG' OR $(UseProjectReference) == 'true'">
+        <Message Importance="high" Text="Using GeoBlazor Core Project Reference" />
+    </Target>
+    <ItemGroup Condition="$(Configuration) == 'DEBUG' OR $(UseProjectReference) == 'true'">
+        <ProjectReference Include="..\..\src\dymaptic.GeoBlazor.Core\dymaptic.GeoBlazor.Core.csproj" />
+    </ItemGroup>
+    <Target Name="ReferenceType" BeforeTargets="Build" Condition="$(Configuration) == 'RELEASE' AND $(UseProjectReference) != 'true'">
+        <Message Importance="high" Text="Using GeoBlazor Core Nuget Package" />
+    </Target>
+    <ItemGroup Condition="$(Configuration) == 'RELEASE' AND $(UseProjectReference) != 'true'">
+        <PackageReference Include="dymaptic.GeoBlazor.Core" Version="$(CoreVersion)" />
+    </ItemGroup>
     
     
     

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Wasm/dymaptic.GeoBlazor.Core.Test.Blazor.Wasm.csproj
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Wasm/dymaptic.GeoBlazor.Core.Test.Blazor.Wasm.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.7" />
   </ItemGroup>
   
   <ItemGroup>

--- a/test/dymaptic.GeoBlazor.Core.Test/dymaptic.GeoBlazor.Core.Test.csproj
+++ b/test/dymaptic.GeoBlazor.Core.Test/dymaptic.GeoBlazor.Core.Test.csproj
@@ -9,13 +9,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Codeuctivity.ImageSharpCompare" Version="3.0.183"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
-        <PackageReference Include="Microsoft.Playwright" Version="1.38.0"/>
-        <PackageReference Include="Microsoft.Playwright.MSTest" Version="1.38.0"/>
-        <PackageReference Include="MSTest.TestAdapter" Version="3.1.1"/>
-        <PackageReference Include="MSTest.TestFramework" Version="3.1.1"/>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="Codeuctivity.ImageSharpCompare" Version="4.0.273"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
+        <PackageReference Include="Microsoft.Playwright" Version="1.45.1"/>
+        <PackageReference Include="Microsoft.Playwright.MSTest" Version="1.45.1"/>
+        <PackageReference Include="MSTest.TestAdapter" Version="3.5.0"/>
+        <PackageReference Include="MSTest.TestFramework" Version="3.5.0"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
Closes #346
 
While I don't see any immediate performance improvement by splitting the bundled JS, I think this is the right step forward, and makes future performance improvements possible.

In this PR
- Split bundled JS files
- Bumped all nuget and npm dependencies, including ArcGIS JS 4.30.9
- Added `MapView.PopupEnabled` and deprecated `PopupWidget.AutoOpenEnabled` to follow ArcGIS changes
- Added `ScaleUnit.Imperial` and deprecated `ScaleUnit.NonMetric` in `ScaleBarWidget` options to follow ArcGIS changes
- Added support for round-trip JSON serializing graphics using System.Text.Json.
- Implemented `IEquatable` and equality operators on `Dimension`
- Minor testing bug fixes in TypeScript

- Build Fixes
  - `assetCopy.ps1` - rather than continuing to fight powershell about the path, which sometimes produces `wwwroot/assets` and sometimes `wwwroot/assets/assets` based on environment running the script, I updated it to check for the duplicate folder and move everything at the end if it finds that.
  - Added environment variables to build test and sample projects with nuget packages or project references