### PR TITLE
Add fontsUrl support to AuthenticationManager

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <CoreVersion>3.1.1</CoreVersion>
+        <CoreVersion>3.1.2-beta1</CoreVersion>
     </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <CoreVersion>3.1.2-beta-1</CoreVersion>
+        <CoreVersion>3.1.2-beta-2</CoreVersion>
     </PropertyGroup>
 </Project>

--- a/src/dymaptic.GeoBlazor.Core/Model/AuthenticationManager.cs
+++ b/src/dymaptic.GeoBlazor.Core/Model/AuthenticationManager.cs
@@ -1,5 +1,4 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Views;
-using dymaptic.GeoBlazor.Core.Objects;
 using Microsoft.Extensions.Configuration;
 using Microsoft.JSInterop;
 
@@ -116,6 +115,29 @@ public class AuthenticationManager
     }
 
     /// <summary>
+    ///     Get or set the ArcGIS Fonts URL. This would only be used in disconnected scenarios where you want to point to a local ArcGIS Portal.
+    /// </summary>
+    public string? FontsUrl
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(_fontsUrl))
+            {
+                _fontsUrl = _configuration["ArcGISFontsUrl"];
+            }
+
+            return _fontsUrl;
+        }
+        set
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                _fontsUrl = value;
+            }
+        }
+    }
+
+    /// <summary>
     ///     Initializes authentication based on either an OAuth App ID or an API Key. This is called automatically by <see cref="MapView" /> on first render, but can also be called manually for other actions such as rest calls.
     /// </summary>
     public async Task<bool> Initialize()
@@ -125,7 +147,8 @@ public class AuthenticationManager
             IJSObjectReference arcGisJsInterop = await GetArcGisJsInterop();
 
             _module = await arcGisJsInterop.InvokeAsync<IJSObjectReference>("getAuthenticationManager",
-                _cancellationTokenSource.Token, DotNetObjectReference.Create(this), ApiKey, AppId, PortalUrl, TrustedServers);
+                _cancellationTokenSource.Token, DotNetObjectReference.Create(this), ApiKey, AppId, PortalUrl, 
+                TrustedServers, FontsUrl);
         }
 
         return true;
@@ -186,8 +209,6 @@ public class AuthenticationManager
     /// </summary>
     public async Task<IJSObjectReference> GetArcGisJsInterop()
     {
-        LicenseType licenseType = Licensing.GetLicenseType();
-
         var token = new CancellationToken();
         IJSObjectReference? arcGisPro = await JsModuleManager.GetArcGisJsPro(_jsRuntime, token);
         IJSObjectReference arcGisJsInterop = await JsModuleManager.GetArcGisJsCore(_jsRuntime, arcGisPro, token);
@@ -203,4 +224,5 @@ public class AuthenticationManager
     private List<string>? _trustedServers;
     private string? _portalUrl;
     private IJSObjectReference? _module;
+    private string? _fontsUrl;
 }

--- a/src/dymaptic.GeoBlazor.Core/ReadMe.md
+++ b/src/dymaptic.GeoBlazor.Core/ReadMe.md
@@ -1,7 +1,7 @@
 ﻿# GeoBlazor
 
 # *.NET 9 NOTICE*
-*Version 3.1.2-beta-1 fixes a [breaking change](https://github.com/dotnet/aspnetcore/issues/58004) that Microsoft introduced in how constructors are used in .NET 9 Razor Components.*
+*Version 3.1.2-beta-2 fixes a [breaking change](https://github.com/dotnet/aspnetcore/issues/58004) that Microsoft introduced in how constructors are used in .NET 9 Razor Components.*
 
 *Even with that fix, you will still experience __very slow__ build times when targeting .NET 9 or even just using the .NET 9 SDK to build previous versions. We have an open request for a fix [here](https://github.com/dotnet/aspnetcore/issues/59014)*
 

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -158,7 +158,7 @@ export let dotNetRefs = {};
 export let queryLayer: FeatureLayer;
 export let blazorServer: boolean = false;
 import normalizeUtils from "@arcgis/core/geometry/support/normalizeUtils";
-export { projection, geometryEngine, Graphic, Color, Point, Polyline, Polygon, normalizeUtils };
+export { projection, geometryEngine, Graphic, Color, Point, Polyline, Polygon, normalizeUtils, esriConfig };
 let notifyExtentChanged: boolean = true;
 let uploadingLayers: Array<string> = [];
 let userChangedViewExtent: boolean = false;
@@ -3315,9 +3315,9 @@ function updateGeometryForProtobuf(geometry) {
 let _authenticationManager: AuthenticationManager | null = null;
 
 export function getAuthenticationManager(dotNetRef: any, apiKey: string | null, appId: string | null,
-    portalUrl: string | null, trustedServers: string[] | null): AuthenticationManager {
+    portalUrl: string | null, trustedServers: string[] | null, fontsUrl: string | null): AuthenticationManager {
     if (_authenticationManager === null) {
-        _authenticationManager = new AuthenticationManager(dotNetRef, apiKey, appId, portalUrl, trustedServers);
+        _authenticationManager = new AuthenticationManager(dotNetRef, apiKey, appId, portalUrl, trustedServers, fontsUrl);
     }
     return _authenticationManager;
 }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/authenticationManager.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/authenticationManager.ts
@@ -7,7 +7,7 @@ export default class AuthenticationManager {
     private info: OAuthInfo | undefined;
     private dotNetRef: any;
 
-    constructor(dotNetReference, apiKey, appId, portalUrl, trustedServers) {
+    constructor(dotNetReference, apiKey, appId, portalUrl, trustedServers, fontsUrl) {
         if (appId !== null) {
             this.appId = appId;
             this.info = new OAuthInfo({
@@ -25,6 +25,10 @@ export default class AuthenticationManager {
         
         if (trustedServers !== null) {
             esriConfig.request.trustedServers = esriConfig.request.trustedServers !== undefined ? esriConfig.request.trustedServers.concat(trustedServers) : trustedServers;
+        }
+        
+        if (fontsUrl !== null) {
+            esriConfig.fontsUrl = fontsUrl;
         }
 
         this.dotNetRef = dotNetReference;

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/dymaptic.GeoBlazor.Core.Test.Blazor.Shared.csproj
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/dymaptic.GeoBlazor.Core.Test.Blazor.Shared.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.11" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
         <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
     </ItemGroup>

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Wasm/dymaptic.GeoBlazor.Core.Test.Blazor.Wasm.csproj
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Wasm/dymaptic.GeoBlazor.Core.Test.Blazor.Wasm.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -11,8 +11,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.11" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Closes #367 

Adds `FontsUrl` to `AuthenticationManager`, and exposes support for `ArcGISFontsUrl` in appsettings. This supports internet-disconnected deployments.