### PR TITLE
Updating SpatialReference class

### DIFF
--- a/samples/dymaptic.GeoBlazor.Core.Sample.ServerOAuth/Pages/AutoLogin.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.ServerOAuth/Pages/AutoLogin.razor
@@ -4,7 +4,11 @@
 <MapView Latitude="0" Longitude="0" Zoom="2"
          PromptForOAuthLogin="true"
          Style="height: 500px; width: 100%;">
-    <Map ArcGISDefaultBasemap="arcgis-topographic"></Map>
+    <Map >
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
     <SearchWidget Position="OverlayPosition.TopRight" />
 </MapView>
 

--- a/samples/dymaptic.GeoBlazor.Core.Sample.ServerOAuth/Pages/Index.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.ServerOAuth/Pages/Index.razor
@@ -20,7 +20,11 @@
         <div>Your token is: @_token</div>
 
         <MapView Latitude="0" Longitude="0" Zoom="2" Style="height: 500px; width: 100%;">
-            <Map ArcGISDefaultBasemap="arcgis-topographic"></Map>
+            <Map>
+                <Basemap>
+                    <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+                </Basemap>
+            </Map>
             <SearchWidget Position="OverlayPosition.TopRight" />
         </MapView>
     }

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/BingMapsLayers.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/BingMapsLayers.razor
@@ -36,7 +36,10 @@
 
 <MapView @ref="_view" OnViewRendered="OnViewRendered"
          Longitude="-107.95166" Latitude="43.18083" Zoom="4" Class="map-view">
-    <Map ArcGISDefaultBasemap="arcgis-topographic">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
     </Map>
 </MapView>
 

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/FeatureLayers.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/FeatureLayers.razor
@@ -43,7 +43,10 @@
 </div>
 
 <MapView Longitude="-118.80543" Latitude="34.02700" Zoom="13" Class="map-view">
-    <Map ArcGISDefaultBasemap="arcgis-topographic">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
         @if (_showPolygonLayer)
         {
             <FeatureLayer Url="https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Parks_and_Open_Space/FeatureServer/0" />
@@ -95,25 +98,13 @@
                 </SimpleRenderer>
                 <Field Name="ObjectID" Type="FieldType.Oid" />
                 <Field Name="url" Type="FieldType.String" />
-                <Graphic Attributes="@(new AttributesDictionary(new Dictionary<string, object?>
-                                     {
-                                         { "ObjectID", "6" },
-                                         { "url", "https://arcgis.github.io/arcgis-samples-javascript/sample-data/featurelayer-collection/photo-6.jpg" }
-                                     }))">
+                <Graphic Attributes="@(new AttributesDictionary(new Dictionary<string, object?> { { "ObjectID", "6" }, { "url", "https://arcgis.github.io/arcgis-samples-javascript/sample-data/featurelayer-collection/photo-6.jpg" } }))">
                     <Point Longitude="-118.805" Latitude="34.027" />
                 </Graphic>
-                <Graphic Attributes="@(new AttributesDictionary(new Dictionary<string, object?>
-                                     {
-                                         { "ObjectID", "5" },
-                                         { "url", "https://arcgis.github.io/arcgis-samples-javascript/sample-data/featurelayer-collection/photo-5.jpg" }
-                                     }))">
+                <Graphic Attributes="@(new AttributesDictionary(new Dictionary<string, object?> { { "ObjectID", "5" }, { "url", "https://arcgis.github.io/arcgis-samples-javascript/sample-data/featurelayer-collection/photo-5.jpg" } }))">
                     <Point Longitude="-118.815" Latitude="34.017" />
                 </Graphic>
-                <Graphic Attributes="@(new AttributesDictionary(new Dictionary<string, object?>
-                                     {
-                                         { "ObjectID", "4" },
-                                         { "url", "https://arcgis.github.io/arcgis-samples-javascript/sample-data/featurelayer-collection/photo-4.jpg" }
-                                     }))">
+                <Graphic Attributes="@(new AttributesDictionary(new Dictionary<string, object?> { { "ObjectID", "4" }, { "url", "https://arcgis.github.io/arcgis-samples-javascript/sample-data/featurelayer-collection/photo-4.jpg" } }))">
                     <Point Longitude="-118.795" Latitude="34.027" />
                 </Graphic>
             </FeatureLayer>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/GeoRSSLayers.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/GeoRSSLayers.razor
@@ -9,7 +9,10 @@
 </p>
 
 <MapView Longitude="-107.95166" Latitude="43.18083" Zoom="4" Class="map-view">
-    <Map ArcGISDefaultBasemap="arcgis-light-gray">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisLightGray" />
+        </Basemap>
         <GeoRSSLayer
             Url="https://arcgis.github.io/arcgis-samples-javascript/sample-data/layers-georss/sample-georss.xml" />
     </Map>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/HitTests.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/HitTests.razor
@@ -19,7 +19,10 @@
          Latitude="35.863534"
          Zoom="3"
          EventRateLimitInMilliseconds="50">
-    <Map ArcGISDefaultBasemap="dark-gray-vector">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisDarkGray" />
+        </Basemap>
         <FeatureLayer @ref="_hurricaneLayer"
                       OutFields="@(new[] { "*" })"
                       Url="https://sampleserver6.arcgisonline.com/arcgis/rest/services/Hurricanes/MapServer/1">
@@ -60,9 +63,9 @@
         try
         {
             HitTestOptions options = new()
-            {
-                IncludeByGeoBlazorId = new[] { _hurricaneLayer!.Id }
-            };
+                {
+                    IncludeByGeoBlazorId = new[] { _hurricaneLayer!.Id }
+                };
             HitTestResult result = await _mapView!.HitTest(pointerEvent, options);
             Graphic? graphic = result.Results.OfType<GraphicHit>().FirstOrDefault()?.Graphic;
             if (graphic?.Attributes != null)

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ImageryLayers.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ImageryLayers.razor
@@ -13,9 +13,12 @@
 <button disabled="@(!_mapRendered)" @onclick="(()=>AddRemoveImageryLayer())">Add or Remove Imagery Layer in code</button>
 <button disabled="@(!_mapRendered)" @onclick="(()=>_markup = !_markup)">Add new Imagery Layer in Markup</button>
 
-<MapView @ref="_view" class="map-view" 
+<MapView @ref="_view" class="map-view"
          OnViewRendered="OnViewRendered">
-    <Map ArcGISDefaultBasemap="arcgis-light-gray">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisLightGray" />
+        </Basemap>
         @if (_markup)
         {
             <ImageryLayer Url="https://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer" Opacity="0.6"></ImageryLayer>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/KMLLayers.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/KMLLayers.razor
@@ -7,15 +7,18 @@
     <a class="btn btn-primary" target="_blank" href="https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/US_National_Parks_Annual_Visitation/FeatureServer/0">USGS Earthquake Hazards Program Monitoring Center</a>
 </div>
 <Label>The sample KML Layer uses a URL to see major earthquakes for latest 30 days from USGS to the map database :</Label>
-    <InputText @bind-Value="_kmlLayerUrl"></InputText>
-<br/>
+<InputText @bind-Value="_kmlLayerUrl"></InputText>
+<br />
 <Label>Click the buttons below to see the different ways to display a KML layer</Label>
 <button disabled="@(!_mapRendered)" @onclick="(()=>AddRemoveKMLLayer())">Add or Remove KML Layer in code</button>
 <button disabled="@(!_mapRendered)" @onclick="(()=>_markup = !_markup)">Add new KML Layer in Markup</button>
 
 
 <MapView @ref="_view" class="map-view" OnViewRendered="OnViewRendered" Scale="0">
-    <Map ArcGISDefaultBasemap="dark-gray-vector">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisDarkGrayBase" />
+        </Basemap>
         @if (_markup)
         {
             <KMLLayer Url="@_kmlLayerUrl" Title="Major EarthQuakes Query Result"></KMLLayer>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/MarkerRotation.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/MarkerRotation.razor
@@ -12,7 +12,10 @@
     <Extent Xmin="-41525513" Ymin="4969181" Xmax="-36687355" Ymax="9024624">
         <SpatialReference Wkid="3857" />
     </Extent>
-    <Map ArcGISDefaultBasemap="satellite">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisImageryStandard" />
+        </Basemap>
         <FeatureLayer Url="https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/weather_stations_010417/FeatureServer/0">
             <SimpleRenderer>
                 <PictureMarkerSymbol

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Scene.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Scene.razor
@@ -48,7 +48,10 @@
 </div>
 <SceneView @ref="_view" Longitude="_longitude" Latitude="_latitude" Class="map-view"
            ZIndex="2000" Tilt="76" OnViewRendered="OnViewRendered">
-    <Map Ground="world-elevation" ArcGISDefaultBasemap="satellite">
+    <Map Ground="world-elevation">
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisImageryStandard" />
+        </Basemap>
         <GraphicsLayer @ref="_graphicsLayer">
             <Graphic @ref="_polygonGraphic" Attributes="_graphic1Attributes">
                 <Polygon Rings="@(new[] { _mapRings })" />

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/SearchMultipleSources.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/SearchMultipleSources.razor
@@ -14,7 +14,11 @@
 <MapView Class="map-view"
          Center="@(new Point(-97, 38))"
          Scale="10000000">
-    <Map ArcGISDefaultBasemap="dark-gray-vector" />
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisDarkGrayBase" />
+        </Basemap>
+    </Map>
     <SearchWidget AllPlaceholder="District or Senator"
                   IncludeDefaultSources="false"
                   Position="OverlayPosition.TopRight">

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ServerSideQueries.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ServerSideQueries.razor
@@ -15,7 +15,10 @@
          Class="map-view"
          OnClick="OnClick"
          PopupEnabled="false">
-    <Map ArcGISDefaultBasemap="gray-vector">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisDarkGray" />
+        </Basemap>
         <FeatureLayer @ref="_featureLayer" OutFields="@(new[] { "*" })">
             <PortalItem Id="234d2e3f6f554e0e84757662469c26d3" />
         </FeatureLayer>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ServiceAreas.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ServiceAreas.razor
@@ -12,7 +12,11 @@
          Zoom="11"
          Class="map-view"
          OnClick="OnClick">
-    <Map ArcGISDefaultBasemap="arcgis-navigation" />
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisNavigation" />
+        </Basemap>
+    </Map>
 </MapView>
 
 <Graphic @ref="AreaGraphic">

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/SqlQuery.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/SqlQuery.razor
@@ -13,7 +13,11 @@
          Latitude="34.03000"
          Zoom="13"
          Class="map-view">
-    <Map ArcGISDefaultBasemap="arcgis-navigation" />
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisNavigation" />
+        </Basemap>
+    </Map>
 
     <CustomOverlay Position="OverlayPosition.TopRight">
         <select class="esri-widget esri-select demo-select" @onchange="OnSqlQueryChanged">
@@ -53,16 +57,16 @@
         if (whereClause == _parcelLayerSql[0]) return;
 
         var query = new Query
-        {
-            Where = whereClause,
-            OutFields = new HashSet<string>
+            {
+                Where = whereClause,
+                OutFields = new HashSet<string>
             {
                 "APN", "UseType", "TaxRateCity", "Roll_LandValue"
             },
-            ReturnGeometry = true,
-            SpatialRelationship = SpatialRelationship.Intersects,
-            UseViewExtent = true
-        };
+                ReturnGeometry = true,
+                SpatialRelationship = SpatialRelationship.Intersects,
+                UseViewExtent = true
+            };
         await View!.QueryFeatures(query, QueryFeatureLayer!, Symbol!, Popup!);
     }
 

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Tests.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Tests.razor
@@ -18,11 +18,15 @@
     <Extent Xmin="-41525513" Ymin="4969181" Xmax="-36687355" Ymax="9024624">
         <SpatialReference Wkid="102100" />
     </Extent>
-    <Map ArcGISDefaultBasemap="arcgis-topographic">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
         <GraphicsLayer>
             @for (var i = 0; i < _graphicsCount; i++)
             {
                 var index = i;
+
                 <Graphic>
                     <Point Longitude="_longs[index]" Latitude="_lats[index]" />
                 </Graphic>
@@ -35,6 +39,7 @@
                 {
                     double lat = _lats[i];
                     double lon = _longs[i];
+
                     <Graphic>
                         <Point Longitude="@lon" Latitude="@lat" />
                         <SimpleMarkerSymbol Color="@(new MapColor("red"))" Size="6">
@@ -55,13 +60,19 @@
             Ymax="4061566.0769513007" Ymin="4015703.859980177">
         <SpatialReference Wkid="102100" />
     </Extent>
-    <Map ArcGISDefaultBasemap="arcgis-navigation">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisNavigation" />
+        </Basemap>
     </Map>
 </MapView>
 
 <h2>MapRendered Test Map</h2>
 <MapView @ref="_view3" Style="height: 600px; width: 100%;" OnViewRendered="OnMap3Rendered" OnClick="On3Click">
-    <Map ArcGISDefaultBasemap="arcgis-navigation">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisNavigation" />
+        </Basemap>
     </Map>
     <Extent Xmax="4120960.074670904" Xmin="-3412935.278412999" Ymax="8963926.222211033" Ymin="6049459.93475111">
         <SpatialReference Wkid="102100" />
@@ -71,7 +82,10 @@
 
 <h2>Spatial Ref from FeatureLayer Test Map</h2>
 <MapView Style="height: 600px; width: 100%;">
-    <Map ArcGISDefaultBasemap="arcgis-navigation">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisNavigation" />
+        </Basemap>
         <FeatureLayer Url="https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/weather_stations_010417/FeatureServer/0" />
     </Map>
     <Extent Xmax="4120960.074670904" Xmin="-3412935.278412999" Ymax="8963926.222211033" Ymin="6049459.93475111">
@@ -85,7 +99,10 @@
     <Extent Xmax="-12316914.7038" Xmin="-14596572.5354" Ymax="6562278.17835" Ymin="4992526.63148">
         <SpatialReference Wkid="102100" />
     </Extent>
-    <Map ArcGISDefaultBasemap="arcgis-topographic">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
         <FeatureLayer>
             <PortalItem Id="a07b8cd0b3514285ab1ff001befd2288">
                 <Portal Url="https://arcgis.dymaptic.com/portal/" />
@@ -112,7 +129,7 @@
             _longs.Add(_random.NextDouble() * 10 + 11.0);
         }
     }
-    
+
     private Task OnExtentChanged(Extent extent)
     {
         return Task.CompletedTask;

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/VectorLayer.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/VectorLayer.razor
@@ -8,8 +8,10 @@
     A simple demo of loading a Vector Tile Layer from ArcGIS Online.
 </p>
 <MapView Longitude="-118.80543" Latitude="34.02700" Zoom="13" Class="map-view">
-    <Map ArcGISDefaultBasemap="arcgis-light-gray">
-        <VectorTileLayer
-            Url="https://vectortileservices3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Santa_Monica_Mountains_Parcels_VTL/VectorTileServer/" />
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisLightGrayBase" />
+        </Basemap>
+        <VectorTileLayer Url="https://vectortileservices3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Santa_Monica_Mountains_Parcels_VTL/VectorTileServer/" />
     </Map>
 </MapView>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/WCSLayers.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/WCSLayers.razor
@@ -13,7 +13,10 @@
 <button disabled="@(!_mapRendered)" @onclick="(()=>_markup = !_markup)">Add/Remove new WCS Layer in Markup without colorizing</button>
 
 <MapView @ref="_view" class="map-view" OnViewRendered="OnViewRendered">
-    <Map ArcGISDefaultBasemap="arcgis-light-gray">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisLightGray" />
+        </Basemap>
         @if (_markup)
         {
             <WCSLayer Url="https://sampleserver6.arcgisonline.com/arcgis/services/ScientificData/SeaTemperature/ImageServer/WCSServer?request=GetCapabilities&service=WCS"></WCSLayer>
@@ -46,7 +49,7 @@
         // initializes the dimensional filter for the raster display
         List<DimensionalDefinition> multidimensionalDefinition = new()
             {
-                new(dimensionName: "StdZ", variableName: "water_temp", values: new List<long> { 0 }), 
+                new(dimensionName: "StdZ", variableName: "water_temp", values: new List<long> { 0 }),
                 new(dimensionName: "Std_Time", variableName: "temperature", values: new List<long>{ 1396828800000 } )
             };
         return multidimensionalDefinition;
@@ -61,12 +64,12 @@
 
         var toFromColor3 = new AlgorithmicColorRamp(algorithm: Algorithm.Hsv, fromColor: new MapColor(255, 255, 0), toColor: new MapColor(255, 0, 0));
 
-        List<AlgorithmicColorRamp> wcsLayerColorRamps = new() {toFromColor1,toFromColor2,toFromColor3};
+        List<AlgorithmicColorRamp> wcsLayerColorRamps = new() { toFromColor1, toFromColor2, toFromColor3 };
 
         MultipartColorRamp wcsLayercolorRamp = new(wcsLayerColorRamps);
         RasterStatistics wcsLayerStatistics = new(-3, 37, 1, 1);
-        RasterStretchRenderer displayRenderer = new(colorRamp: wcsLayercolorRamp, 
-            stretchType: StretchType.StandardDeviation, statistics: [wcsLayerStatistics], 
+        RasterStretchRenderer displayRenderer = new(colorRamp: wcsLayercolorRamp,
+            stretchType: StretchType.StandardDeviation, statistics: [wcsLayerStatistics],
             numberOfStandardDeviations: 3);
 
         return displayRenderer;

--- a/samples/dymaptic.GeoBlazor.Core.Sample.WasmOAuth/Pages/AutoLogin.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.WasmOAuth/Pages/AutoLogin.razor
@@ -4,7 +4,11 @@
 <MapView Latitude="0" Longitude="0" Zoom="2"
          PromptForOAuthLogin="true"
          Style="height: 500px; width: 100%;">
-    <Map ArcGISDefaultBasemap="arcgis-topographic"></Map>
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
     <SearchWidget Position="OverlayPosition.TopRight" />
 </MapView>
 

--- a/samples/dymaptic.GeoBlazor.Core.Sample.WasmOAuth/Pages/Index.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.WasmOAuth/Pages/Index.razor
@@ -20,7 +20,11 @@
         <div>Your token is: @_token</div>
 
         <MapView Latitude="0" Longitude="0" Zoom="2" Style="height: 500px; width: 100%;">
-            <Map ArcGISDefaultBasemap="arcgis-topographic"></Map>
+            <Map>
+                <Basemap>
+                    <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+                </Basemap>
+            </Map>
             <SearchWidget Position="OverlayPosition.TopRight" />
         </MapView>
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/SpatialReference.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/SpatialReference.cs
@@ -97,7 +97,14 @@ public class SpatialReference : MapComponent
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [Parameter]
     public string? Wkt { get; set; }
-    
+
+    /// <summary>
+    ///    The well-known text of the coordinate system as defined by OGC standard for well-known text strings.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Parameter]
+    public string? Wkt2 { get; set; }
+
     /// <summary>
     ///     Returns a deep clone of the Spatial Reference.
     /// </summary>
@@ -114,6 +121,8 @@ public class SpatialReference : MapComponent
 
 internal class SpatialReferenceConverter : JsonConverter<SpatialReference>
 {
+    public override bool HandleNull => true;
+
     public override SpatialReference? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var spatialReference = new SpatialReference();
@@ -134,6 +143,10 @@ internal class SpatialReferenceConverter : JsonConverter<SpatialReference>
                             break;
                         case "wkt":
                             spatialReference.Wkt = reader.GetString();
+
+                            break;
+                        case "wkt2":
+                            spatialReference.Wkt2 = reader.GetString();
 
                             break;
                         case "isGeographic":
@@ -181,9 +194,13 @@ internal class SpatialReferenceConverter : JsonConverter<SpatialReference>
         {
             writer.WriteString("wkt", value.Wkt);
         }
+        else if (!string.IsNullOrWhiteSpace(value.Wkt2))
+        {
+            writer.WriteString("wkt2", value.Wkt2);
+        }
         else
         {
-            throw new ArgumentException("SpatialReference must have either a Wkid or Wkt");
+            throw new ArgumentException("SpatialReference must have either a Wkid, Wkt, or Wkt2");
         }
 
         writer.WriteEndObject();
@@ -196,7 +213,7 @@ internal record SpatialReferenceSerializationRecord : MapComponentSerializationR
     public SpatialReferenceSerializationRecord()
     {
     }
-    
+
     public SpatialReferenceSerializationRecord(int? Wkid,
         string? Wkt = null)
     {

--- a/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/definitions.d.ts
@@ -168,6 +168,7 @@ export interface DotNetSpatialReference {
     isWrappable: boolean;
     wkid: number;
     wkt: string;
+    wkt2: string;
     imageCoordinateSystem: any;
 }
 

--- a/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/dotNetBuilder.ts
@@ -350,6 +350,7 @@ export function buildDotNetSpatialReference(spatialReference: SpatialReference):
         isWrappable: spatialReference.isWrappable,
         wkid: spatialReference.wkid,
         wkt: spatialReference.wkt,
+        wkt2: spatialReference.wkt2,
         imageCoordinateSystem: spatialReference.imageCoordinateSystem
     } as DotNetSpatialReference;
 }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -179,10 +179,12 @@ export function buildJsSpatialReference(dotNetSpatialReference: DotNetSpatialRef
         return new SpatialReference({ wkid: 4326 });
     }
     let jsSpatialRef = new SpatialReference();
-    if (dotNetSpatialReference.wkid !== null && dotNetSpatialReference.wkid !== undefined) {
+    if (hasValue(dotNetSpatialReference.wkid)) {
         jsSpatialRef.wkid = dotNetSpatialReference.wkid;
-    } else if (dotNetSpatialReference.wkt !== null && dotNetSpatialReference.wkt !== undefined) {
-        jsSpatialRef.wkt = dotNetSpatialReference.wkt;
+    } else if (hasValue(dotNetSpatialReference.wkt)) {
+        jsSpatialRef.wkt = dotNetSpatialReference.wkt
+    } else if (hasValue(dotNetSpatialReference.wkt2)) {
+        jsSpatialRef.wkt2 = dotNetSpatialReference.wkt2
     } else {
         jsSpatialRef.wkid = 4326;
     }

--- a/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/jsBuilder.ts
@@ -179,9 +179,9 @@ export function buildJsSpatialReference(dotNetSpatialReference: DotNetSpatialRef
         return new SpatialReference({ wkid: 4326 });
     }
     let jsSpatialRef = new SpatialReference();
-    if (dotNetSpatialReference.wkid !== null) {
+    if (dotNetSpatialReference.wkid !== null && dotNetSpatialReference.wkid !== undefined) {
         jsSpatialRef.wkid = dotNetSpatialReference.wkid;
-    } else if (dotNetSpatialReference.wkt !== null) {
+    } else if (dotNetSpatialReference.wkt !== null && dotNetSpatialReference.wkt !== undefined) {
         jsSpatialRef.wkt = dotNetSpatialReference.wkt;
     } else {
         jsSpatialRef.wkid = 4326;
@@ -193,7 +193,7 @@ export function buildJsSpatialReference(dotNetSpatialReference: DotNetSpatialRef
 export function buildJsExtent(dotNetExtent: DotNetExtent, currentSpatialReference: SpatialReference | null): Extent {
     let extent = new Extent();
     copyValuesIfExists(dotNetExtent, extent, 'xmax', 'xmin', 'ymax', 'ymin', 'zmax', 'zmin', 'mmax', 'mmin');
-    
+
     if (hasValue(dotNetExtent.spatialReference)) {
         extent.spatialReference = buildJsSpatialReference(dotNetExtent.spatialReference)
     } else if (currentSpatialReference !== null) {
@@ -216,13 +216,13 @@ export function buildJsGraphic(graphicObject: any, viewId: string | null)
             symbol: buildJsSymbol(graphicObject.symbol) as Symbol ?? null,
         });
     }
-    
+
     graphic.attributes = buildJsAttributes(graphicObject.attributes);
 
     if (hasValue(graphicObject.popupTemplate)) {
         graphic.popupTemplate = buildJsPopupTemplate(graphicObject.popupTemplate, viewId) as PopupTemplate;
     }
-    
+
     copyValuesIfExists(graphicObject, graphic, 'visible');
 
     return graphic;
@@ -262,7 +262,7 @@ export function buildJsAttributes(attributes: any): any {
 
 export function buildJsPopupTemplate(popupTemplateObject: DotNetPopupTemplate, viewId: string | null): PopupTemplate | null {
     if (!hasValue(popupTemplateObject)) return null;
-    
+
     let content;
     if (hasValue(popupTemplateObject.stringContent)) {
         content = popupTemplateObject.stringContent;
@@ -282,7 +282,7 @@ export function buildJsPopupTemplate(popupTemplateObject: DotNetPopupTemplate, v
                         dotNetRefs[popupTemplateObject.id] = popupRef;
                     }
                 }
-                
+
                 if (!hasValue(popupRef)) return null;
                 let results: DotNetPopupContent[] | null = await popupRef
                     .invokeMethodAsync("OnContentFunction", buildDotNetGraphic(featureSelection.graphic));
@@ -314,14 +314,14 @@ export function buildJsPopupTemplate(popupTemplateObject: DotNetPopupTemplate, v
     }
 
     popupTemplateRefs[popupTemplateObject.id] = template;
-    
+
     return template;
 }
 
 export function buildJsAction(dnAction: any): ActionButton | ActionToggle {
     if (dnAction.type === "button") {
         let jsAction = new ActionButton();
-        copyValuesIfExists(dnAction, jsAction, 'active', 'className', 'disabled', 'icon', 'id', 'image', 'title', 
+        copyValuesIfExists(dnAction, jsAction, 'active', 'className', 'disabled', 'icon', 'id', 'image', 'title',
             'visible');
         return jsAction;
     }
@@ -442,7 +442,7 @@ export function buildJsSymbol(symbol: DotNetSymbol | null): Symbol | null {
                 width: dnPictureMarkerSymbol.width ?? 12,
                 url: dnPictureMarkerSymbol.url
             });
-            
+
         case "picture-fill":
             let dnPictureFillSymbol = symbol as DotNetPictureFillSymbol;
             let jsFillSymbol = new PictureFillSymbol({
@@ -457,7 +457,7 @@ export function buildJsSymbol(symbol: DotNetSymbol | null): Symbol | null {
             if (hasValue(dnPictureFillSymbol.outline)) {
                 jsFillSymbol.outline = buildJsSymbol(dnPictureFillSymbol.outline) as any;
             }
-            
+
             return jsFillSymbol;
 
         case "simple-fill":
@@ -478,7 +478,7 @@ export function buildJsSymbol(symbol: DotNetSymbol | null): Symbol | null {
             });
             copyValuesIfExists(dotNetTextSymbol, jsTextSymbol, 'angle', 'borderLineSize', 'haloSize',
                 'horizontalAlignment', 'kerning', 'lineHeight', 'lineWidth', 'rotated', 'text', 'verticalAlignment');
-            
+
             if (hasValue(dotNetTextSymbol.backgroundColor)) {
                 jsTextSymbol.backgroundColor = buildJsColor(dotNetTextSymbol.backgroundColor);
             }
@@ -532,7 +532,7 @@ export function buildJsBookmark(dnBookmark: DotNetBookmark): Bookmark | null {
 
     if (!(dnBookmark.thumbnail == null)) {
         //ESRI has this as an "object" with url property
-        bookmark.thumbnail = {url: dnBookmark.thumbnail};
+        bookmark.thumbnail = { url: dnBookmark.thumbnail };
     }
 
     if (hasValue(dnBookmark.viewpoint)) {
@@ -648,7 +648,7 @@ export function buildJsRenderer(dotNetRenderer: any): Renderer | null {
                 pieChartRenderer.visualVariables = dotNetRenderer.visualVariables.map(buildVisualVariable);
             }
             copyValuesIfExists(dotNetRenderer, pieChartRenderer, 'defaultLabel', 'holePercentage', 'size');
-            
+
             return pieChartRenderer;
         case 'unique-value':
             return buildJsUniqueValueRenderer(dotNetRenderer);
@@ -721,7 +721,7 @@ export function buildJsImageryRenderer(dnRenderer: any) {
         case 'raster-stretch':
             return buildJsRasterStretchRenderer(dnRenderer);
     }
-    
+
     return null;
 }
 
@@ -734,14 +734,14 @@ export function buildJsUniqueValueRenderer(dnUniqueValueRenderer: DotNetUniqueVa
         }
         // Note: The PolygonSymbol3d is not currently supported
     }
-    
+
     copyValuesIfExists(dnUniqueValueRenderer, uniqueValueRenderer, 'defaultLabel', 'field', 'field2', 'field3',
         'fieldDelimiter', 'legendOptions', 'orderByClassesEnabled', 'valueExpression', 'valueExpressionTitle');
-    
+
     if (hasValue(dnUniqueValueRenderer.defaultSymbol?.symbol)) {
         uniqueValueRenderer.defaultSymbol = buildJsSymbol(dnUniqueValueRenderer.defaultSymbol.symbol) as Symbol;
     }
-    
+
     if (hasValue(dnUniqueValueRenderer.uniqueValueInfos) && dnUniqueValueRenderer.uniqueValueInfos.length > 0) {
         for (let i = 0; i < dnUniqueValueRenderer.uniqueValueInfos.length; i++) {
             let dnUniqueValueInfo = dnUniqueValueRenderer.uniqueValueInfos[i];
@@ -753,7 +753,7 @@ export function buildJsUniqueValueRenderer(dnUniqueValueRenderer: DotNetUniqueVa
             uniqueValueRenderer.uniqueValueInfos.push(uniqueValueInfo);
         }
     }
-    
+
     if (hasValue(dnUniqueValueRenderer.visualVariables) && dnUniqueValueRenderer.visualVariables.length > 0) {
         uniqueValueRenderer.visualVariables = dnUniqueValueRenderer.visualVariables.map(buildJsVisualVariable) as VisualVariable[];
     }
@@ -873,12 +873,12 @@ export function buildJsFlowRenderer(dotNetFlowRenderer: DotNetFlowRenderer): Flo
 }
 
 function buildJsAttributeColorInfo(dnColorInfo: any): AttributeColorInfo {
-  
+
     let attributeColorInfo = new AttributeColorInfo();
     if (hasValue(dnColorInfo.color)) {
         attributeColorInfo.color = buildJsColor(dnColorInfo.color);
     }
-    copyValuesIfExists(dnColorInfo, attributeColorInfo, 'field', 'label', 'valueExpression', 
+    copyValuesIfExists(dnColorInfo, attributeColorInfo, 'field', 'label', 'valueExpression',
         'valueExpressionTitle');
     return attributeColorInfo;
 }
@@ -886,7 +886,7 @@ function buildJsAttributeColorInfo(dnColorInfo: any): AttributeColorInfo {
 function buildJsAuthoringInfo(dnAuthoringInfo: any): AuthoringInfo {
     let authoringInfo = new AuthoringInfo();
     copyValuesIfExists(dnAuthoringInfo, authoringInfo, 'classificationMethod', 'fadeRatio', 'fields',
-        'flowTheme', 'focus', 'isAutoGenerated', 'lengthUnit', 'maxSliderValue', 'minSliderValue', 
+        'flowTheme', 'focus', 'isAutoGenerated', 'lengthUnit', 'maxSliderValue', 'minSliderValue',
         'standardDeviationInterval', 'type', 'univariateSymbolStyle', 'univariateTheme');
     if (hasValue(dnAuthoringInfo.colorRamp)) {
         authoringInfo.colorRamp = buildJsColorRamp(dnAuthoringInfo.colorRamp) as ColorRamp;
@@ -917,18 +917,18 @@ function buildJsAuthoringInfo(dnAuthoringInfo: any): AuthoringInfo {
             label: dnAuthoringInfo.field2.label
         }
     }
-    
+
     if (hasValue(dnAuthoringInfo.statistics)) {
         authoringInfo.statistics = {
             max: dnAuthoringInfo.statistics.max,
             min: dnAuthoringInfo.statistics.min
         };
     }
-    
+
     if (hasValue(dnAuthoringInfo.visualVariables)) {
         authoringInfo.visualVariables = dnAuthoringInfo.visualVariables.map(buildAuthoringVisualVariable);
     }
-    
+
     return authoringInfo;
 }
 
@@ -980,7 +980,7 @@ export function buildVisualVariable(dnVV: any): VisualVariable | null {
                     return dnStop;
                 });
             }
-            
+
             return colorVariable;
         case "rotation":
             let rotationVariable = variable as RotationVariable;
@@ -990,7 +990,7 @@ export function buildVisualVariable(dnVV: any): VisualVariable | null {
             let sizeVariable = variable as SizeVariable;
             copyValuesIfExists(dnVV, sizeVariable, 'axis', 'maxDataValue', 'minDataValue', 'minSize', 'maxSize',
                 'normalizationField', 'target', 'useSymbolValue', 'valueUnit');
-            
+
             if (hasValue(dnVV.stops) && dnVV.stops.length > 0) {
                 sizeVariable.stops = dnVV.stops.map((stop: any) => {
                     let dnStop = {};
@@ -1013,7 +1013,7 @@ export function buildVisualVariable(dnVV: any): VisualVariable | null {
             }
             return opacityVariable;
     }
-    
+
     return null;
 }
 
@@ -1024,13 +1024,13 @@ export function buildJsRasterStretchRenderer(dotNetRasterStretchRenderer: DotNet
     if (hasValue(dotNetRasterStretchRenderer.colorRamp)) {
         rasterStretchRenderer.colorRamp = buildJsColorRamp(dotNetRasterStretchRenderer.colorRamp) as ColorRamp;
     }
-    
+
     copyValuesIfExists(dotNetRasterStretchRenderer, rasterStretchRenderer, 'computeGamma',
         'dynamicRangeAdjustment', 'gamma', 'useGamma', 'outputMax', 'outputMin', 'stretchType',
         'statistics', 'numberOfStandardDeviations');
-    
+
     arcGisObjectRefs[dotNetRasterStretchRenderer.id] = rasterStretchRenderer;
-    
+
     return rasterStretchRenderer;
 }
 
@@ -1143,7 +1143,7 @@ export function buildJsViewClickEvent(dotNetClickEvent: any): ViewClickEvent {
 }
 
 export async function buildJsPopup(dotNetPopup: any, viewId: string): Promise<Popup> {
-    
+
     let popup = new Popup({
         alignment: dotNetPopup.alignment ?? "auto",
         content: dotNetPopup.content ?? null,
@@ -1158,14 +1158,14 @@ export async function buildJsPopup(dotNetPopup: any, viewId: string): Promise<Po
         label: dotNetPopup.label ?? '',
         spinnerEnabled: dotNetPopup.spinnerEnabled ?? true
     });
-    
+
     if (hasValue(dotNetPopup.autoOpenEnabled)) {
         let view = arcGisObjectRefs[viewId] as MapView;
         if (hasValue(view)) {
             view.popupEnabled = dotNetPopup.autoOpenEnabled;
         }
     }
-    
+
     if (hasValue(dotNetPopup.actions)) {
         popup.actions = dotNetPopup.actions.map(buildJsAction) as any;
     }
@@ -1917,7 +1917,7 @@ function buildJsSearchSourceFilter(dotNetFilter: any): SearchSourceFilter | null
     return filter;
 }
 
-export function buildJsFeatureReduction(dnFeatureReduction: any, viewId: string | null) : any {
+export function buildJsFeatureReduction(dnFeatureReduction: any, viewId: string | null): any {
     if (!hasValue(dnFeatureReduction)) return null;
     switch (dnFeatureReduction.type) {
         case 'cluster':
@@ -1937,7 +1937,7 @@ export function buildJsFeatureReduction(dnFeatureReduction: any, viewId: string 
             if (hasValue(dnFeatureReduction.symbol)) {
                 cluster.symbol = buildJsSymbol(dnFeatureReduction.symbol) as any;
             }
-            copyValuesIfExists(dnFeatureReduction, cluster, 'clusterMaxSize', 'clusterMinSize', 'clusterRadius', 
+            copyValuesIfExists(dnFeatureReduction, cluster, 'clusterMaxSize', 'clusterMinSize', 'clusterRadius',
                 'labelsVisible', 'maxScale', 'popupEnabled');
             return cluster;
         case 'binning':
@@ -2013,36 +2013,36 @@ export function buildJsSublayer(dotNetSublayer: any): Sublayer {
     let sublayer = new Sublayer({
         id: dotNetSublayer.sublayerId
     });
-    
+
     copyValuesIfExists(dotNetSublayer, sublayer, 'maxScale', 'minScale', 'visible', 'labelsVisible',
         'legendEnabled', 'listMode', 'opacity', 'popupEnabled', 'title', 'definitionExpression', 'url');
-    
+
     if (hasValue(dotNetSublayer.floorInfo)) {
         sublayer.floorInfo = {
             floorField: dotNetSublayer.floorInfo.floorField ?? undefined
         } as any;
     }
-    
+
     if (hasValue(dotNetSublayer.labelingInfo) && dotNetSublayer.labelingInfo.length > 0) {
         sublayer.labelingInfo = dotNetSublayer.labelingInfo.map(buildJsLabelClass);
     }
-    
+
     if (hasValue(dotNetSublayer.sublayers) && dotNetSublayer.sublayers.length > 0) {
         sublayer.sublayers = dotNetSublayer.sublayers.map(buildJsSublayer);
     }
-    
+
     if (hasValue(dotNetSublayer.renderer)) {
         sublayer.renderer = buildJsRenderer(dotNetSublayer.renderer) as Renderer;
     }
-    
+
     if (hasValue(dotNetSublayer.popupTemplate)) {
         sublayer.popupTemplate = buildJsPopupTemplate(dotNetSublayer.popupTemplate, null) as PopupTemplate;
     }
-    
+
     if (hasValue(dotNetSublayer.source)) {
         sublayer.source = buildJsDynamicLayer(dotNetSublayer.source);
     }
-    
+
     arcGisObjectRefs[dotNetSublayer.id] = sublayer;
     return sublayer;
 }
@@ -2062,7 +2062,7 @@ function buildJsDynamicLayer(dotNetSource: any): DynamicMapLayer | DynamicDataLa
             if (hasValue(dotNetSource?.dataSource)) {
                 dataLayer.dataSource = buildJsDynamicDataSource(dotNetSource.dataSource);
             }
-            
+
             if (hasValue(dotNetSource?.fields) && dotNetSource.fields.length > 0) {
                 dataLayer.fields = dotNetSource.fields.map(buildJsDynamicDataLayerField);
             }
@@ -2105,14 +2105,14 @@ function buildJsDynamicDataSource(dotNetSource: any): any {
                 rightTableKey: dotNetSource.rightTableKey,
                 joinType: dotNetSource.joinType
             } as JoinTableDataSource;
-            
+
             if (hasValue(dotNetSource?.leftTableSource)) {
                 joinTable.leftTableSource = buildJsDynamicLayer(dotNetSource.leftTableSource);
             }
             if (hasValue(dotNetSource?.rightTableSource)) {
                 joinTable.rightTableSource = buildJsDynamicLayer(dotNetSource.rightTableSource);
             }
-            
+
             return joinTable;
     }
 }
@@ -2140,7 +2140,7 @@ export function buildJsTickConfig(dnTickConfig: any): TickConfig {
             return new Function('value', 'type', 'index', dnTickConfig.labelFormatFunction)(value, type, index);
         };
     }
-    
+
     return tickConfig;
 }
 

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/AttributesTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/AttributesTests.razor
@@ -1,7 +1,7 @@
 @inherits TestRunnerBase
 
 @{
-base.BuildRenderTree(__builder);
+    base.BuildRenderTree(__builder);
 }
 
 @code {
@@ -9,21 +9,25 @@ base.BuildRenderTree(__builder);
     public async Task TestCanSerializeAndDeserializeGuidAttributes(Action renderHandler)
     {
         MapView? mapView = null;
-        AddMapRenderFragment( 
-            @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-            </MapView>);
+        AddMapRenderFragment(
+    @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+    </MapView>);
 
         await WaitForMapToRender();
 
         Point point = new(0, 0);
         Guid testGuid = Guid.NewGuid();
         Graphic testGraphic = new Graphic(point,
-            new SimpleMarkerSymbol(color: new MapColor("red"), size: 10),
-            attributes: new AttributesDictionary(new Dictionary<string, object?>
-            {
+    new SimpleMarkerSymbol(color: new MapColor("red"), size: 10),
+    attributes: new AttributesDictionary(new Dictionary<string, object?>
+                            {
                 {"GUID_ID", testGuid}
-            }));
+                            }));
         await mapView!.AddGraphic(testGraphic);
         await Task.Yield();
         ScreenPoint screenPoint = await mapView.ToScreen(point);
@@ -40,8 +44,8 @@ base.BuildRenderTree(__builder);
 
         Graphic[] features =
         [
-            new Graphic(new Point(0, 0), 
-                attributes: new AttributesDictionary(new Dictionary<string, object?>
+    new Graphic(new Point(0, 0),
+    attributes: new AttributesDictionary(new Dictionary<string, object?>
                 {
                     {"OBJECTID", 1},
                     {"GUID", Guid.NewGuid()},
@@ -63,28 +67,31 @@ base.BuildRenderTree(__builder);
                 layerView = evt.LayerView as FeatureLayerView;
             }
         }
-        
+
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler"
-                      OnLayerViewCreate="onLayerCreated">
-                <Map ArcGISDefaultBasemap="topo-vector">
-                    <FeatureLayer @ref="layer" Source="features"
-                                  GeometryType="GeometryType.Point"
-                                  ObjectIdField="OBJECTID">
-                        <Field Name="OBJECTID" Type="FieldType.Oid" />
-                        <Field Name="GUID" Type="FieldType.Guid" />
-                        <Field Name="INT" Type="FieldType.Integer" />
-                        <Field Name="DOUBLE" Type="FieldType.Double" />
-                        <Field Name="STRING" Type="FieldType.String" />
-                        <Field Name="DATETIME" Type="FieldType.Date" />
-                        <Field Name="DATE" Type="FieldType.DateOnly" />
-                        <Field Name="TIME" Type="FieldType.TimeOnly" />
-                        <Field Name="TIMESTAMP" Type="FieldType.TimestampOffset" />
-                        <Field Name="DATETIMESTAMP" Type="FieldType.Date" />
-                    </FeatureLayer>
-                </Map>
-            </MapView>);
-        
+    @<MapView class="map-view" OnViewRendered="renderHandler"
+                  OnLayerViewCreate="onLayerCreated">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" />
+            </Basemap>
+            <FeatureLayer @ref="layer" Source="features"
+                          GeometryType="GeometryType.Point"
+                          ObjectIdField="OBJECTID">
+                <Field Name="OBJECTID" Type="FieldType.Oid" />
+                <Field Name="GUID" Type="FieldType.Guid" />
+                <Field Name="INT" Type="FieldType.Integer" />
+                <Field Name="DOUBLE" Type="FieldType.Double" />
+                <Field Name="STRING" Type="FieldType.String" />
+                <Field Name="DATETIME" Type="FieldType.Date" />
+                <Field Name="DATE" Type="FieldType.DateOnly" />
+                <Field Name="TIME" Type="FieldType.TimeOnly" />
+                <Field Name="TIMESTAMP" Type="FieldType.TimestampOffset" />
+                <Field Name="DATETIMESTAMP" Type="FieldType.Date" />
+            </FeatureLayer>
+        </Map>
+    </MapView>);
+
         await WaitForMapToRender();
         int tries = 100;
         while (layerView is null && tries > 0)
@@ -113,30 +120,33 @@ base.BuildRenderTree(__builder);
         Assert.IsInstanceOfType<TimeOnly>(queriedFeature.Attributes["TIME"]);
         Assert.AreEqual(features[0].Attributes["TIME"], queriedFeature.Attributes["TIME"]);
         Assert.IsInstanceOfType<DateTime>(queriedFeature.Attributes["TIMESTAMP"]);
-        Assert.AreEqual(DateTimeOffset.FromUnixTimeMilliseconds((long)features[0].Attributes["TIMESTAMP"]!).DateTime, queriedFeature.Attributes["TIMESTAMP"]);   
+        Assert.AreEqual(DateTimeOffset.FromUnixTimeMilliseconds((long)features[0].Attributes["TIMESTAMP"]!).DateTime, queriedFeature.Attributes["TIMESTAMP"]);
         Assert.IsInstanceOfType<DateTime>(queriedFeature.Attributes["DATETIMESTAMP"]);
         Assert.AreEqual(DateTimeOffset.FromUnixTimeMilliseconds((long)features[0].Attributes["DATETIMESTAMP"]!).DateTime, queriedFeature.Attributes["DATETIMESTAMP"]);
     }
-    
+
     [TestMethod]
     public async Task TestCanHitTestGraphicsWithAttributes(Action renderHandler)
     {
         MapView? view = null;
         GraphicsLayer? layer = null;
-        AddMapRenderFragment( 
-            @<MapView @ref="view"
-                      class="map-view" 
-                      OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery">
-                    <GraphicsLayer @ref="layer" />
-                </Map>
-            </MapView>);
+        AddMapRenderFragment(
+    @<MapView @ref="view"
+                  class="map-view"
+                  OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+            <GraphicsLayer @ref="layer" />
+        </Map>
+    </MapView>);
 
         await WaitForMapToRender();
         Graphic[] features =
         [
-            new Graphic(new Point(0, 0), 
-                attributes: new AttributesDictionary(new Dictionary<string, object?>
+            new Graphic(new Point(0, 0),
+    attributes: new AttributesDictionary(new Dictionary<string, object?>
                 {
                     {"OBJECTID", 1},
                     {"GUID", Guid.NewGuid()},

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/BaseMapTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/BaseMapTests.razor
@@ -10,9 +10,13 @@
     public async Task TestCanRenderArcGisDefaultBasemap(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+    </MapView>);
         await WaitForMapToRender();
     }
 
@@ -20,13 +24,13 @@
     public async Task TestCanRenderBasemapFromPortalId(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map>
-                    <Basemap>
-                        <PortalItem Id="55ebf90799fa4a3fa57562700a68c405" />
-                    </Basemap>
-                </Map>
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <PortalItem Id="55ebf90799fa4a3fa57562700a68c405" />
+            </Basemap>
+        </Map>
+    </MapView>);
 
         await WaitForMapToRender();
     }
@@ -35,18 +39,18 @@
     public async Task TestCanRenderBasemapFromTileLayers(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map>
-                    <Basemap>
-                        <TileLayer>
-                            <PortalItem Id="1b243539f4514b6ba35e7d995890db1d" />
-                        </TileLayer>
-                        <VectorTileLayer Opacity="0.75">
-                            <PortalItem Id="6976148c11bd497d8624206f9ee03e30" />
-                        </VectorTileLayer>
-                    </Basemap>
-                </Map>
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <TileLayer>
+                    <PortalItem Id="1b243539f4514b6ba35e7d995890db1d" />
+                </TileLayer>
+                <VectorTileLayer Opacity="0.75">
+                    <PortalItem Id="6976148c11bd497d8624206f9ee03e30" />
+                </VectorTileLayer>
+            </Basemap>
+        </Map>
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertBasemapHasTwoLayers");
@@ -59,19 +63,19 @@
         async Task OnViewInitialized()
         {
             await mapView!.AddLayer(new ImageryTileLayer(
-                "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"), 
-                isBasemapLayer: true );
+            "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"),
+            isBasemapLayer: true);
         }
         AddMapRenderFragment(
-            @<MapView OnViewInitialized="@OnViewInitialized" 
-                      @ref="@mapView" class="map-view" 
-                      OnViewRendered="renderHandler">
-                <Map>
-                    <Basemap>
-                        <PortalItem Id="55ebf90799fa4a3fa57562700a68c405" />
-                    </Basemap>
-                </Map>
-            </MapView>);
+    @<MapView OnViewInitialized="@OnViewInitialized"
+                          @ref="@mapView" class="map-view"
+                          OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <PortalItem Id="55ebf90799fa4a3fa57562700a68c405" />
+            </Basemap>
+        </Map>
+    </MapView>);
 
         await WaitForMapToRender();
 

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/ExpandWidgetTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/ExpandWidgetTests.razor
@@ -10,84 +10,100 @@
     {
         LayerListWidget? layerList = null;
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <ExpandWidget Position="OverlayPosition.TopLeft" Expanded="true" Mode="Mode.Floating">
-                    <LayerListWidget @ref="layerList" />
-                </ExpandWidget>
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <ExpandWidget Position="OverlayPosition.TopLeft" Expanded="true" Mode="Mode.Floating">
+            <LayerListWidget @ref="layerList" />
+        </ExpandWidget>
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Expand");
         await AssertJavaScript("expandWidgetAsserts.assertContentByClassName", args: "esri-layer-list");
         Assert.IsNotNull(layerList);
     }
-    
+
     [TestMethod]
     public async Task TestCanRenderExpandWidgetWithHtmlContent(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
-    
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <ExpandWidget Position="OverlayPosition.TopLeft" Expanded="true" Mode="Mode.Floating">
-                    <button id="test-button" type="button">Click Me</button>
-                </ExpandWidget>
-    
-            </MapView>);
-    
+    @<MapView class="map-view" OnViewRendered="renderHandler">
+
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <ExpandWidget Position="OverlayPosition.TopLeft" Expanded="true" Mode="Mode.Floating">
+            <button id="test-button" type="button">Click Me</button>
+        </ExpandWidget>
+
+    </MapView>);
+
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Expand");
         await AssertJavaScript("expandWidgetAsserts.assertContentById", args: "test-button");
     }
-    
+
     [TestMethod]
     public async Task TestCanRenderExpandWidgetWithWidgetAfterHtmlContent(Action renderHandler)
     {
         LegendWidget? legend = null;
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <ExpandWidget Position="OverlayPosition.TopLeft" Expanded="true" Mode="Mode.Floating">
-                    <button id="test-button-1" type="button">Click Me</button>
-                    <LegendWidget @ref="legend" />
-                </ExpandWidget>
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <ExpandWidget Position="OverlayPosition.TopLeft" Expanded="true" Mode="Mode.Floating">
+            <button id="test-button-1" type="button">Click Me</button>
+            <LegendWidget @ref="legend" />
+        </ExpandWidget>
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Expand");
         await AssertJavaScript("expandWidgetAsserts.assertContentByClassName", args: "esri-legend");
         await AssertJavaScript("expandWidgetAsserts.assertContentById", args: "test-button-1");
-        await AssertJavaScript("expandWidgetAsserts.assertContentOrder", 
-            args: new object[] {"test-button-1", $"widget-container-{legend!.Id}"});
+        await AssertJavaScript("expandWidgetAsserts.assertContentOrder",
+    args: new object[] { "test-button-1", $"widget-container-{legend!.Id}" });
         Assert.IsNotNull(legend);
     }
-    
+
     [TestMethod]
     public async Task TestCanRenderExpandWidgetWithWidgetBeforeHtmlContent(Action renderHandler)
     {
         LegendWidget? legend = null;
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <ExpandWidget Position="OverlayPosition.TopLeft" Expanded="true" Mode="Mode.Floating">
-                    <LegendWidget @ref="legend" />
-                    <button id="test-button-2" type="button">Click Me</button>
-                </ExpandWidget>
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <ExpandWidget Position="OverlayPosition.TopLeft" Expanded="true" Mode="Mode.Floating">
+            <LegendWidget @ref="legend" />
+            <button id="test-button-2" type="button">Click Me</button>
+        </ExpandWidget>
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Expand");
         await AssertJavaScript("expandWidgetAsserts.assertContentByClassName", args: "esri-legend");
         await AssertJavaScript("expandWidgetAsserts.assertContentById", args: "test-button-2");
-        await AssertJavaScript("expandWidgetAsserts.assertContentOrder", 
-            args: new object[] {$"widget-container-{legend!.Id}", "test-button-2"});
+        await AssertJavaScript("expandWidgetAsserts.assertContentOrder",
+            args: new object[] { $"widget-container-{legend!.Id}", "test-button-2" });
         Assert.IsNotNull(legend);
     }
 }

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerTests.razor
@@ -13,19 +13,22 @@
         async Task OnViewInitialized()
         {
             await mapView!.AddLayer(
-                new FeatureLayer("https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/TrailRuns/FeatureServer/0", 
-                    title: "Test"));
+    new FeatureLayer("https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/TrailRuns/FeatureServer/0",
+        title: "Test"));
         }
         AddMapRenderFragment(
-            @<MapView OnViewInitialized="@OnViewInitialized" @ref="@mapView" class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="topo-vector">
-                </Map>
-            </MapView>);
+    @<MapView OnViewInitialized="@OnViewInitialized" @ref="@mapView" class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" />
+            </Basemap>
+        </Map>
+    </MapView>);
         await WaitForMapToRender();
         await AssertJavaScript("assertLayerExists", args: "feature");
 
         FeatureLayer? featureLayer = mapView!.Map!.Layers.OfType<FeatureLayer>().SingleOrDefault();
-        
+
         Assert.IsNotNull(featureLayer);
         Assert.IsNotNull(featureLayer.JsModule);
 
@@ -38,15 +41,15 @@
     public async Task TestCanRenderFeatureLayer(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map>
-                    <FeatureLayer Url="https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/TrailRuns/FeatureServer/0" />
-                </Map>
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <FeatureLayer Url="https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/TrailRuns/FeatureServer/0" />
+        </Map>
+    </MapView>);
         await WaitForMapToRender();
         await AssertJavaScript("assertLayerExists", args: "feature");
     }
-    
+
     [TestMethod]
     public async Task TestCanRenderFeatureLayerWithSource(Action renderHandler)
     {
@@ -57,20 +60,23 @@
         {
             Point point = new Point(random.Next(-180, 180), random.Next(-80, 80));
             Graphic graphic = new(point, attributes: new AttributesDictionary(new Dictionary<string, object?>()
-            {
+                                {
                 { "OBJECT_ID", i }
-            }));
+                                }));
             graphics.Add(graphic);
         }
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="topo-vector">
-                    <FeatureLayer @ref="layer" Source="graphics" 
-                                  GeometryType="GeometryType.Point"
-                                  ObjectIdField="OBJECT_ID">
-                    </FeatureLayer>
-                </Map>
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" />
+            </Basemap>
+            <FeatureLayer @ref="layer" Source="graphics"
+                          GeometryType="GeometryType.Point"
+                          ObjectIdField="OBJECT_ID">
+            </FeatureLayer>
+        </Map>
+    </MapView>);
         await WaitForMapToRender();
         await AssertJavaScript("assertLayerExists", args: "feature");
         await AssertJavaScript("assertGraphicExistsInLayer", args: [layer!.Id, "point", 2000]);
@@ -90,13 +96,13 @@
         }
 
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler" OnLayerViewCreate="OnLayerViewCreate">
-                <Map>
-                    <FeatureLayer @ref="layer">
-                        <PortalItem Id="449887ea7d60429fbf6f0c67881f2758" />
-                    </FeatureLayer>
-                </Map>
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler" OnLayerViewCreate="OnLayerViewCreate">
+        <Map>
+            <FeatureLayer @ref="layer">
+                <PortalItem Id="449887ea7d60429fbf6f0c67881f2758" />
+            </FeatureLayer>
+        </Map>
+    </MapView>);
 
         await WaitForMapToRender();
 
@@ -132,60 +138,70 @@
     {
         FeatureLayer? layer = null;
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="topo-vector">
-                    <FeatureLayer @ref="layer" Source="@([])" 
-                                  GeometryType="GeometryType.Point"
-                                  ObjectIdField="OBJECT_ID">
-                    </FeatureLayer>
-                </Map>
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" />
+            </Basemap>
+            <FeatureLayer @ref="layer" Source="@([])"
+                          GeometryType="GeometryType.Point"
+                          ObjectIdField="OBJECT_ID">
+            </FeatureLayer>
+        </Map>
+    </MapView>);
         await WaitForMapToRender();
         await AssertJavaScript("assertLayerExists", args: "feature");
-        FeatureEdits edits = new() { 
-            AddFeatures = [
-                new Graphic(new Point(0, 0), 
+        FeatureEdits edits = new()
+                {
+                    AddFeatures = [
+                                    new Graphic(new Point(0, 0),
                     new SimpleMarkerSymbol(color: new MapColor("black")))
-            ] 
-        };
+                                ]
+                };
         await layer!.ApplyEdits(edits);
         await AssertJavaScript("assertGraphicExistsInLayer", args: [layer!.Id, "point", 1]);
     }
-    
+
     [TestMethod]
     public async Task TestCanAddFeaturesWithAddMethodAfterRender(Action renderHandler)
     {
         FeatureLayer? layer = null;
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="topo-vector">
-                    <FeatureLayer @ref="layer" Source="@([])" 
-                                  GeometryType="GeometryType.Point"
-                                  ObjectIdField="OBJECT_ID">
-                    </FeatureLayer>
-                </Map>
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" />
+            </Basemap>
+            <FeatureLayer @ref="layer" Source="@([])"
+                          GeometryType="GeometryType.Point"
+                          ObjectIdField="OBJECT_ID">
+            </FeatureLayer>
+        </Map>
+    </MapView>);
         await WaitForMapToRender();
         await AssertJavaScript("assertLayerExists", args: "feature");
 
         await layer!.Add(new Graphic(new Point(0, 0),
-            new SimpleMarkerSymbol(color: new MapColor("black"))));
+        new SimpleMarkerSymbol(color: new MapColor("black"))));
         await AssertJavaScript("assertGraphicExistsInLayer", args: [layer!.Id, "point", 1]);
     }
-    
+
     [TestMethod]
     public async Task TestCanAddManyFeaturesWithApplyEdits(Action renderHandler)
     {
         FeatureLayer? layer = null;
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="topo-vector">
-                    <FeatureLayer @ref="layer" Source="@([])" 
-                                  GeometryType="GeometryType.Point"
-                                  ObjectIdField="OBJECT_ID">
-                    </FeatureLayer>
-                </Map>
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" />
+            </Basemap>
+            <FeatureLayer @ref="layer" Source="@([])"
+                          GeometryType="GeometryType.Point"
+                          ObjectIdField="OBJECT_ID">
+            </FeatureLayer>
+        </Map>
+    </MapView>);
         await WaitForMapToRender();
         await AssertJavaScript("assertLayerExists", args: "feature");
 
@@ -198,9 +214,9 @@
             graphics.Add(graphic);
         }
         FeatureEdits edits = new()
-        {
-            AddFeatures = graphics
-        };
+                {
+                    AddFeatures = graphics
+                };
         FeatureEditsResult result = await layer!.ApplyEdits(edits);
         await AssertJavaScript("assertGraphicExistsInLayer", args: [layer!.Id, "point", 2000]);
         Assert.AreEqual(2000, result.AddFeatureResults.Length);
@@ -212,14 +228,17 @@
     {
         FeatureLayer? layer = null;
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="topo-vector">
-                    <FeatureLayer @ref="layer" Source="@([])" 
-                                  GeometryType="GeometryType.Point"
-                                  ObjectIdField="OBJECT_ID">
-                    </FeatureLayer>
-                </Map>
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" />
+            </Basemap>
+            <FeatureLayer @ref="layer" Source="@([])"
+                          GeometryType="GeometryType.Point"
+                          ObjectIdField="OBJECT_ID">
+            </FeatureLayer>
+        </Map>
+    </MapView>);
         await WaitForMapToRender();
         await AssertJavaScript("assertLayerExists", args: "feature");
 
@@ -232,9 +251,9 @@
             graphics.Add(graphic);
         }
         FeatureEdits edits = new()
-        {
-            AddFeatures = graphics
-        };
+                {
+                    AddFeatures = graphics
+                };
         FeatureEditsResult result = await layer!.ApplyEdits(edits);
         await AssertJavaScript("assertGraphicExistsInLayer", args: [layer!.Id, "point", 2000]);
         Assert.AreEqual(2000, result.AddFeatureResults.Length);
@@ -245,11 +264,11 @@
             ((Point)graphic.Geometry!).Y += 1;
         }
 #pragma warning restore BL0005
-        
+
         edits = new()
-        {
-            UpdateFeatures = graphics
-        };
+                {
+                    UpdateFeatures = graphics
+                };
         result = await layer!.ApplyEdits(edits);
         await AssertJavaScript("assertGraphicExistsInLayer", args: [layer!.Id, "point", 2000]);
         Assert.AreEqual(2000, result.UpdateFeatureResults.Length);
@@ -260,14 +279,17 @@
     {
         FeatureLayer? layer = null;
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="topo-vector">
-                    <FeatureLayer @ref="layer" Source="@([])" 
-                                  GeometryType="GeometryType.Point"
-                                  ObjectIdField="OBJECT_ID">
-                    </FeatureLayer>
-                </Map>
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" />
+            </Basemap>
+            <FeatureLayer @ref="layer" Source="@([])"
+                          GeometryType="GeometryType.Point"
+                          ObjectIdField="OBJECT_ID">
+            </FeatureLayer>
+        </Map>
+    </MapView>);
         await WaitForMapToRender();
         await AssertJavaScript("assertLayerExists", args: "feature");
 
@@ -282,20 +304,20 @@
             graphics.Add(graphic);
         }
         FeatureEdits edits = new()
-        {
-            AddFeatures = graphics
-        };
+                {
+                    AddFeatures = graphics
+                };
         FeatureEditsResult result = await layer!.ApplyEdits(edits);
         await AssertJavaScript("assertGraphicExistsInLayer", args: [layer!.Id, "point", 2000]);
         Assert.AreEqual(2000, result.AddFeatureResults.Length);
-        
+
         edits = new()
-        {
-            DeleteFeatures = graphics
-        };
+                {
+                    DeleteFeatures = graphics
+                };
         result = await layer!.ApplyEdits(edits);
-        await Assert.ThrowsExceptionAsync<JSException>(async() =>
-            await AssertJavaScript("assertGraphicExistsInLayer", args: [layer!.Id, "point", 2000]));
+        await Assert.ThrowsExceptionAsync<JSException>(async () =>
+        await AssertJavaScript("assertGraphicExistsInLayer", args: [layer!.Id, "point", 2000]));
         Assert.AreEqual(2000, result.DeleteFeatureResults.Length);
     }
 
@@ -304,31 +326,34 @@
     {
         FeatureLayer? layer = null;
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="topo-vector">
-                    <FeatureLayer @ref="layer" OutFields="@(new[] { "*" })">
-                        <PortalItem Id="234d2e3f6f554e0e84757662469c26d3" />
-                    </FeatureLayer>
-                </Map>
-                <Extent Xmax="-13620669.8431"
-                        Xmin="-13640432.281"
-                        Ymax="4556710.618000001"
-                        Ymin="4536523.6511999965">
-                    <SpatialReference Wkid="102100" />
-                </Extent>
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" />
+            </Basemap>
+            <FeatureLayer @ref="layer" OutFields="@(new[] { "*" })">
+                <PortalItem Id="234d2e3f6f554e0e84757662469c26d3" />
+            </FeatureLayer>
+        </Map>
+        <Extent Xmax="-13620669.8431"
+                Xmin="-13640432.281"
+                Ymax="4556710.618000001"
+                Ymin="4536523.6511999965">
+            <SpatialReference Wkid="102100" />
+        </Extent>
+    </MapView>);
         await WaitForMapToRender();
         Point point = new(x: -13627933.093831237, y: 4547153.388126561, spatialReference: new(102100));
         var query = new Query
-        {
-            Geometry = point,
-            Distance = 0.5,
-            Units = LinearUnit.Miles,
-            SpatialRelationship = SpatialRelationship.Intersects,
-            ReturnGeometry = false,
-            ReturnQueryGeometry = true,
-            OutFields = new HashSet<string> { "*" }
-        };
+                {
+                    Geometry = point,
+                    Distance = 0.5,
+                    Units = LinearUnit.Miles,
+                    SpatialRelationship = SpatialRelationship.Intersects,
+                    ReturnGeometry = false,
+                    ReturnQueryGeometry = true,
+                    OutFields = new HashSet<string> { "*" }
+                };
         FeatureSet? result = await layer!.QueryFeatures(query);
         Assert.IsNotNull(result);
         Assert.IsTrue(result.Features!.Length > 0);
@@ -339,63 +364,69 @@
     {
         FeatureLayer? layer = null;
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler" Longitude="-98.5795" Latitude="39.8282">
-                <Map ArcGISDefaultBasemap="topo-vector">
-                    <FeatureLayer @ref="layer" OutFields="@(new[] { "*" })">
-                        <PortalItem Id="7a301e848a7c4bfcaefdac4fe98a7f99" />
-                    </FeatureLayer>
-                </Map>
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler" Longitude="-98.5795" Latitude="39.8282">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" />
+            </Basemap>
+            <FeatureLayer @ref="layer" OutFields="@(new[] { "*" })">
+                <PortalItem Id="7a301e848a7c4bfcaefdac4fe98a7f99" />
+            </FeatureLayer>
+        </Map>
+    </MapView>);
         await WaitForMapToRender();
         Point point = new(x: -10469946.852199763, y: 4738582.470785314, spatialReference: new(102100));
         var query = new Query
-        {
-            Geometry = point,
-            OutFields = ["*"],
-            SpatialRelationship = SpatialRelationship.Intersects,
-            ReturnGeometry = false
-        };
+                {
+                    Geometry = point,
+                    OutFields = ["*"],
+                    SpatialRelationship = SpatialRelationship.Intersects,
+                    ReturnGeometry = false
+                };
         int[] objectIds = await layer!.QueryObjectIds(query);
         Assert.IsTrue(objectIds.Length > 0);
         var relationshipQuery = new RelationshipQuery
-        {
-            OutFields = ["NAME", "SUM_POPULATION"],
-            RelationshipId = layer.Relationships?.FirstOrDefault()?.Id,
-            ObjectIds = objectIds
-        };
+                {
+                    OutFields = ["NAME", "SUM_POPULATION"],
+                    RelationshipId = layer.Relationships?.FirstOrDefault()?.Id,
+                    ObjectIds = objectIds
+                };
         Dictionary<int, FeatureSet?>? result = await layer.QueryRelatedFeatures(relationshipQuery);
         Assert.IsNotNull(result);
         Assert.IsTrue(result.Count > 0);
     }
-    
+
     [TestMethod]
     public async Task TestCanQueryTopFeatures(Action renderHandler)
     {
         FeatureLayer? layer = null;
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler" Longitude="-97.75188" Latitude="37.23308">
-                <Map ArcGISDefaultBasemap="topo-vector">
-                    <FeatureLayer @ref="layer" OutFields="@(new[] { "*" })"
-                                  Url="https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/US_National_Parks_Annual_Visitation/FeatureServer/0">
-                    </FeatureLayer>
-                </Map>
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler" Longitude="-97.75188" Latitude="37.23308">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" />
+            </Basemap>
+            <FeatureLayer @ref="layer" OutFields="@(new[] { "*" })"
+                          Url="https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/US_National_Parks_Annual_Visitation/FeatureServer/0">
+            </FeatureLayer>
+        </Map>
+    </MapView>);
         await WaitForMapToRender();
         string[] orderByField = ["TOTAL DESC"];
         TopFeaturesQuery query = new()
-        {
-            TopFilter = new TopFilter
             {
-                TopCount = 3,
-                GroupByFields = ["State"],
-                OrderByFields = orderByField
-            },
-            ReturnGeometry = true,
-            OutFields = ["State, TOTAL, F2018, F2019, F2020, Park"],
-            OrderByFields = orderByField,
-            CacheHint = false
-        };
-        
+                TopFilter = new TopFilter
+                {
+                    TopCount = 3,
+                    GroupByFields = ["State"],
+                    OrderByFields = orderByField
+                },
+                ReturnGeometry = true,
+                OutFields = ["State, TOTAL, F2018, F2019, F2020, Park"],
+                OrderByFields = orderByField,
+                CacheHint = false
+            };
+
         FeatureSet? results = await layer!.QueryTopFeatures(query);
         Assert.IsNotNull(results);
         Assert.IsTrue(results.Features!.Length > 0);

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerViewTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerViewTests.razor
@@ -20,7 +20,10 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler"
                       OnLayerViewCreate="OnLayerViewCreate">
-                <Map ArcGISDefaultBasemap="topo-vector">
+                <Map>
+                    <Basemap>
+                        <BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" />
+                    </Basemap>
                     <FeatureLayer OutFields="@(new[] { "*" })">
                         <PortalItem Id="234d2e3f6f554e0e84757662469c26d3" />
                     </FeatureLayer>

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/GeometryTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/GeometryTests.razor
@@ -12,7 +12,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+                    <Basemap>
+                        <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+                    </Basemap>
+                </Map>
                 <Graphic Attributes="_attributes">
                     <Point Latitude="100" Longitude="12" />
                     <SimpleMarkerSymbol Color="@(new MapColor("green"))">
@@ -32,7 +36,11 @@
     {
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+                    <Basemap>
+                        <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+                    </Basemap>
+                </Map>
                 <Graphic Attributes="_attributes">
                     <PolyLine Paths="_paths" />
                     <SimpleLineSymbol Color="@(new MapColor("ffffff"))"></SimpleLineSymbol>
@@ -49,7 +57,11 @@
     {
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+                    <Basemap>
+                        <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+                    </Basemap>
+                </Map>
                 <Graphic Attributes="_attributes">
                     <Polygon Rings="_rings" />
                     <SimpleFillSymbol Color="@(new MapColor("ffffff"))">
@@ -69,7 +81,11 @@
     {
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+                    <Basemap>
+                        <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+                    </Basemap>
+                </Map>
                 <Graphic>
                     <Point Latitude="100" Longitude="12" />
                 </Graphic>
@@ -94,7 +110,11 @@
         MapView? mapView = null;        
         AddMapRenderFragment( 
             @<MapView @ref=" mapView" class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+                    <Basemap>
+                        <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+                    </Basemap>
+                </Map>
             </MapView>);
         await WaitForMapToRender();
 
@@ -111,7 +131,11 @@
         MapView? mapView = null;
         AddMapRenderFragment(
             @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+                    <Basemap>
+                        <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+                    </Basemap>
+                </Map>
             </MapView>);
         await WaitForMapToRender();
 
@@ -128,7 +152,11 @@
         MapView? mapView = null;
         AddMapRenderFragment(
             @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+                    <Basemap>
+                        <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+                    </Basemap>
+                </Map>
             </MapView>);
         await WaitForMapToRender();
 

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/GraphicsTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/GraphicsTests.razor
@@ -16,13 +16,13 @@
             await mapView!.AddLayer(graphicsLayer);
         }
         AddMapRenderFragment(
-        @<MapView OnViewInitialized="@OnViewInitialized" @ref="mapView" class="map-view" OnViewRendered="renderHandler">
-            <Map>
-                <Basemap>
-                    <PortalItem Id="55ebf90799fa4a3fa57562700a68c405" />
-                </Basemap>
-            </Map>
-        </MapView>);
+    @<MapView OnViewInitialized="@OnViewInitialized" @ref="mapView" class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <PortalItem Id="55ebf90799fa4a3fa57562700a68c405" />
+            </Basemap>
+        </Map>
+    </MapView>);
 
         await WaitForMapToRender();
 
@@ -39,23 +39,26 @@
         GraphicsLayer? graphicsLayer = null;
 
         AddMapRenderFragment(
-            @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery">
-                    <GraphicsLayer @ref="graphicsLayer">
-                        <Graphic @ref="graphic">
-                            <Point X="0" Y="0" />
-                        </Graphic>
-                    </GraphicsLayer>
-                </Map>
-            </MapView>
-            );
+    @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+            <GraphicsLayer @ref="graphicsLayer">
+                <Graphic @ref="graphic">
+                    <Point X="0" Y="0" />
+                </Graphic>
+            </GraphicsLayer>
+        </Map>
+    </MapView>
+        );
 
         await WaitForMapToRender();
 
         var hitTestOptions = new HitTestOptions
-        {
-            IncludeByGeoBlazorId = [ graphicsLayer!.Id ]
-        };
+                {
+                    IncludeByGeoBlazorId = [graphicsLayer!.Id]
+                };
 
         var hitTestResult = await mapView!.HitTest((Point)graphic!.Geometry!, hitTestOptions);
 
@@ -79,13 +82,17 @@
         MapView? mapView = null;
         AddMapRenderFragment(
     @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
-        <Map ArcGISDefaultBasemap="arcgis-imagery" />
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
     </MapView>);
 
         await WaitForMapToRender();
 
         var testGraphic = new Graphic(new Point(0, 0),
-        new SimpleMarkerSymbol(color: new MapColor("red"), size: 10));
+    new SimpleMarkerSymbol(color: new MapColor("red"), size: 10));
         await mapView!.AddGraphic(testGraphic);
         await testGraphic.SetGeometry(new Point(1, 1));
         await mapView.RemoveGraphic(testGraphic);
@@ -99,15 +106,18 @@
         GraphicsLayer? graphicsLayer = null;
 
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery">
-                    <GraphicsLayer @ref="graphicsLayer">
-                        <Graphic @ref="graphic">
-                            <Point X="0" Y="0" />
-                        </Graphic>
-                    </GraphicsLayer>
-                </Map>
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+            <GraphicsLayer @ref="graphicsLayer">
+                <Graphic @ref="graphic">
+                    <Point X="0" Y="0" />
+                </Graphic>
+            </GraphicsLayer>
+        </Map>
+    </MapView>);
 
         await WaitForMapToRender();
         Assert.AreEqual(1, graphicsLayer!.Graphics.Count);
@@ -119,15 +129,19 @@
     public async Task TestCanAddGraphicsToRenderedMap(Action renderHandler)
     {
         MapView? mapView = null;
-        AddMapRenderFragment( 
-            @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-            </MapView>);
+        AddMapRenderFragment(
+    @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+    </MapView>);
 
         await WaitForMapToRender();
 
         var testGraphic = new Graphic(new Point(0, 0),
-            new SimpleMarkerSymbol(color: new MapColor("red"), size: 10));
+        new SimpleMarkerSymbol(color: new MapColor("red"), size: 10));
         await mapView!.AddGraphic(testGraphic);
         await AssertJavaScript("assertGraphicExistsInView", args: new object[] { "point", 1 });
     }
@@ -136,80 +150,89 @@
     public async Task TestCanContinueWithBrokenGraphicUrl(Action renderHandler)
     {
         GraphicsLayer? layer = null;
-        AddMapRenderFragment( 
-            @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery">
-                    <GraphicsLayer @ref="layer" />
-                </Map>
-            </MapView>);
+        AddMapRenderFragment(
+    @<MapView class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+            <GraphicsLayer @ref="layer" />
+        </Map>
+    </MapView>);
 
         await WaitForMapToRender();
 
         List<Graphic> newGraphics = [];
-        
+
         Point point = new(0, 0);
         Graphic graphic = new Graphic(point);
         newGraphics.Add(graphic);
         // invalid url
-        PictureMarkerSymbol ps = new PictureMarkerSymbol("https://github.githubassets.com/anything.png", 
-            15, 15, 0, 0, 0);
+        PictureMarkerSymbol ps = new PictureMarkerSymbol("https://github.githubassets.com/anything.png",
+        15, 15, 0, 0, 0);
         await graphic.SetSymbol(ps);
-    
+
         point = new Point(point.Longitude - 0.1, point.Latitude);
         Graphic graphic2 = new Graphic(point);
         newGraphics.Add(graphic2);
         PictureMarkerSymbol ps2 = new PictureMarkerSymbol(
-            "https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png", 
-            15, 15, 0, 0, 0);
+        "https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png",
+        15, 15, 0, 0, 0);
         await graphic2.SetSymbol(ps2);
-        
+
         await layer!.Add(newGraphics);
         await Task.Yield();
         await AssertJavaScript("assertGraphicExistsInLayer", args: [layer.Id, "point", 2]);
     }
-    
+
     [TestMethod]
     public async Task TestCanRenderPictureMarkerWithJpg(Action renderHandler)
     {
         GraphicsLayer? layer = null;
-        AddMapRenderFragment( 
-            @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery">
-                    <GraphicsLayer @ref="layer" />
-                </Map>
-            </MapView>);
+        AddMapRenderFragment(
+    @<MapView class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+            <GraphicsLayer @ref="layer" />
+        </Map>
+    </MapView>);
 
         await WaitForMapToRender();
-        
+
         Point point = new(0, 0);
         Graphic graphic = new Graphic(point);
-        PictureMarkerSymbol ps = new PictureMarkerSymbol("./_content/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/images/homeicon.jpg", 
-            15, 15, 0, 0, 0);
+        PictureMarkerSymbol ps = new PictureMarkerSymbol("./_content/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/images/homeicon.jpg",
+        15, 15, 0, 0, 0);
         await graphic.SetSymbol(ps);
 
         await layer!.Add(graphic);
         await Task.Yield();
         await AssertJavaScript("assertGraphicExistsInLayer", args: [layer.Id, "point", 1]);
     }
-    
+
     [TestMethod]
     public async Task TestCanRenderGraphicWithTextSymbol(Action renderHandler)
     {
         GraphicsLayer? layer = null;
-        AddMapRenderFragment( 
-            @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery">
-                    <GraphicsLayer @ref="layer" />
-                </Map>
-            </MapView>);
+        AddMapRenderFragment(
+    @<MapView class="map-view" OnViewRendered="renderHandler">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+            <GraphicsLayer @ref="layer" />
+        </Map>
+    </MapView>);
 
         await WaitForMapToRender();
-        
+
         Point point = new(0, 0);
         Graphic graphic = new Graphic(point);
-        TextSymbol symbol = new( "Hello", color: new MapColor("red"), 
-            backgroundColor: new MapColor("transparent") , 
-            font: new MapFont(12, "Arial", "normal", "bold") );
+        TextSymbol symbol = new("Hello", color: new MapColor("red"),
+            backgroundColor: new MapColor("transparent"),
+            font: new MapFont(12, "Arial", "normal", "bold"));
         await graphic.SetSymbol(symbol);
 
         await layer!.Add(graphic);

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/LegendWidgetTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/LegendWidgetTests.razor
@@ -10,15 +10,18 @@
     public async Task TestLegendHasContentFromLayer(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery">
-                    <GeoJSONLayer Title="Earthquakes from the last month"
-                                  Url="https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_month.geojson" />
-                </Map>
-                <LegendWidget />
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+            <GeoJSONLayer Title="Earthquakes from the last month"
+                          Url="https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_month.geojson" />
+        </Map>
+        <LegendWidget />
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("legendWidgetAsserts.assertHasContent");

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/MapViewTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/MapViewTests.razor
@@ -12,7 +12,11 @@
         MapView? view = null;
         AddMapRenderFragment(
         @<MapView @ref="view" class="map-view" OnViewRendered="renderHandler">
-            <Map ArcGISDefaultBasemap="arcgis-imagery" />
+            <Map>
+                <Basemap>
+                    <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+                </Basemap>
+            </Map>
         </MapView>);
         await WaitForMapToRender();
 

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/SpatialReferenceTests.cs
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/SpatialReferenceTests.cs
@@ -1,13 +1,16 @@
-﻿@inherits TestRunnerBase
+﻿using dymaptic.GeoBlazor.Core.Components.Geometries;
+using dymaptic.GeoBlazor.Core.Model;
+using dymaptic.GeoBlazor.Core.Objects;
+using Microsoft.AspNetCore.Components;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-@inject Projection projection
+namespace dymaptic.GeoBlazor.Core.Test.Blazor.Shared.Components;
 
-@{
-    base.BuildRenderTree(__builder);
-}
+public class SpatialReferenceTests : TestRunnerBase
+{
+    [Inject]
+    public Projection Projection { get; set; } = default!;
 
-@code {
-    
     [TestMethod]
     public async Task ConvertWktToJSAndBack(Action renderHandler)
     {
@@ -18,7 +21,7 @@
          ], SpatialReference.Wgs84
          );
 
-        var result = await projection.Project(polyLine, wktSpatialReference);
+        var result = await Projection.Project(polyLine, wktSpatialReference);
 
         Assert.IsNotNull(result);
         Assert.IsNotNull(result.SpatialReference?.Wkt);
@@ -34,7 +37,7 @@
             ], SpatialReference.Wgs84
         );
 
-        var result = await projection.Project(polyLine, wktSpatialReference);
+        var result = await Projection.Project(polyLine, wktSpatialReference);
 
         Assert.IsNotNull(result);
         Assert.IsNotNull(result.SpatialReference?.Wkt2);
@@ -50,7 +53,7 @@
             ], SpatialReference.Wgs84
         );
 
-        var result = await projection.Project(polyLine, wkidSpatialReference);
+        var result = await Projection.Project(polyLine, wkidSpatialReference);
 
         Assert.IsNotNull(result);
         Assert.IsNotNull(result.SpatialReference?.Wkid);

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/SpatialReferenceTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/SpatialReferenceTests.razor
@@ -1,17 +1,58 @@
 ﻿@inherits TestRunnerBase
 
+@inject Projection projection
+
 @{
     base.BuildRenderTree(__builder);
 }
 
 @code {
-
-    /*"spatialReference":{"wkt":"PROJCS[\\"NAD_1983_Contiguous_USA_Albers\\",GEOGCS[\\"GCS_North_American_1983\\",DATUM[\\"D_North_American_1983\\",SPHEROID[\\"GRS_1980\\",6378137.0,298.257222101]],PRIMEM[\\"Greenwich\\",0.0],UNIT[\\"Degree\\",0.0174532925199433]],PROJECTION[\\"Albers\\"],PARAMETER[\\"False_Easting\\",0.0],PARAMETER[\\"False_Northing\\",0.0],PARAMETER[\\"Central_Meridian\\",-96.0],PARAMETER[\\"Standard_Parallel_1\\",29.5],PARAMETER[\\"Standard_Parallel_2\\",45.5],PARAMETER[\\"Latitude_Of_Origin\\",23.0],UNIT[\\"Meter\\",1.0]],VERTCS[\\"Unknown VCS\\",VDATUM[\\"Unknown\\"],PARAMETER[\\"Vertical_Shift\\",0.0],PARAMETER[\\"Direction\\",1.0],UNIT[\\"User_Defined_Unit\\",0.01]]"}*/
+    
     [TestMethod]
-    public async Task ConvertToJSAndBack(Action renderHandler)
+    public async Task ConvertWktToJSAndBack(Action renderHandler)
     {
-        SpatialReference sr = new SpatialReference() { Wkt = """PROJCS[\\"NAD_1983_Contiguous_USA_Albers\\",GEOGCS[\\"GCS_North_American_1983\\",DATUM[\\"D_North_American_1983\\",SPHEROID[\\"GRS_1980\\",6378137.0,298.257222101]],PRIMEM[\\"Greenwich\\",0.0],UNIT[\\"Degree\\",0.0174532925199433]],PROJECTION[\\"Albers\\"],PARAMETER[\\"False_Easting\\",0.0],PARAMETER[\\"False_Northing\\",0.0],PARAMETER[\\"Central_Meridian\\",-96.0],PARAMETER[\\"Standard_Parallel_1\\",29.5],PARAMETER[\\"Standard_Parallel_2\\",45.5],PARAMETER[\\"Latitude_Of_Origin\\",23.0],UNIT[\\"Meter\\",1.0]],VERTCS[\\"Unknown VCS\\",VDATUM[\\"Unknown\\"],PARAMETER[\\"Vertical_Shift\\",0.0],PARAMETER[\\"Direction\\",1.0],UNIT[\\"User_Defined_Unit\\",0.01]]""" };
+        SpatialReference wktSpatialReference = new SpatialReference() { Wkt = """PROJCS["NAD_1983_Contiguous_USA_Albers",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137.0,298.257222101]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Albers"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-96.0],PARAMETER["Standard_Parallel_1",29.5],PARAMETER["Standard_Parallel_2",45.5],PARAMETER["Latitude_Of_Origin",23.0],UNIT["Meter",1.0]],VERTCS["Unknown VCS",VDATUM["Unknown"],PARAMETER["Vertical_Shift",0.0],PARAMETER["Direction",1.0],UNIT["User_Defined_Unit",0.01]]""" };
+        var polyLine = new PolyLine(
+         [
+         new MapPath( new MapPoint(-113.8147338,  48.0944495 ),new MapPoint( - 113.2431702,  48.0384702 ) )
+         ], SpatialReference.Wgs84
+         );
 
-        await JsRuntime.InvokeVoidAsync("buildJsSpatialReference", sr);
+        var result = await projection.Project(polyLine, wktSpatialReference);
+
+        Assert.IsNotNull(result);
+        Assert.IsNotNull(result.SpatialReference?.Wkt);
+    }
+
+    [TestMethod]
+    public async Task ConvertWkt2ToJSAndBack(Action renderHandler)
+    {
+        SpatialReference wktSpatialReference = new SpatialReference() { Wkt2 = """PROJCS["NAD_1983_Contiguous_USA_Albers",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137.0,298.257222101]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Albers"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-96.0],PARAMETER["Standard_Parallel_1",29.5],PARAMETER["Standard_Parallel_2",45.5],PARAMETER["Latitude_Of_Origin",23.0],UNIT["Meter",1.0]],VERTCS["Unknown VCS",VDATUM["Unknown"],PARAMETER["Vertical_Shift",0.0],PARAMETER["Direction",1.0],UNIT["User_Defined_Unit",0.01]]""" };
+        var polyLine = new PolyLine(
+            [
+                new MapPath( new MapPoint(-113.8147338,  48.0944495 ),new MapPoint( - 113.2431702,  48.0384702 ) )
+            ], SpatialReference.Wgs84
+        );
+
+        var result = await projection.Project(polyLine, wktSpatialReference);
+
+        Assert.IsNotNull(result);
+        Assert.IsNotNull(result.SpatialReference?.Wkt2);
+    }
+
+    [TestMethod]
+    public async Task ConvertWkidToJSAndBack(Action renderHandler)
+    {
+        SpatialReference wkidSpatialReference = new SpatialReference() { Wkid = 3857 };
+        var polyLine = new PolyLine(
+            [
+                new MapPath( new MapPoint(-113.8147338,  48.0944495 ),new MapPoint( - 113.2431702,  48.0384702 ) )
+            ], SpatialReference.Wgs84
+        );
+
+        var result = await projection.Project(polyLine, wkidSpatialReference);
+
+        Assert.IsNotNull(result);
+        Assert.IsNotNull(result.SpatialReference?.Wkid);
     }
 }

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/SpatialReferenceTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/SpatialReferenceTests.razor
@@ -1,0 +1,17 @@
+﻿@inherits TestRunnerBase
+
+@{
+    base.BuildRenderTree(__builder);
+}
+
+@code {
+
+    /*"spatialReference":{"wkt":"PROJCS[\\"NAD_1983_Contiguous_USA_Albers\\",GEOGCS[\\"GCS_North_American_1983\\",DATUM[\\"D_North_American_1983\\",SPHEROID[\\"GRS_1980\\",6378137.0,298.257222101]],PRIMEM[\\"Greenwich\\",0.0],UNIT[\\"Degree\\",0.0174532925199433]],PROJECTION[\\"Albers\\"],PARAMETER[\\"False_Easting\\",0.0],PARAMETER[\\"False_Northing\\",0.0],PARAMETER[\\"Central_Meridian\\",-96.0],PARAMETER[\\"Standard_Parallel_1\\",29.5],PARAMETER[\\"Standard_Parallel_2\\",45.5],PARAMETER[\\"Latitude_Of_Origin\\",23.0],UNIT[\\"Meter\\",1.0]],VERTCS[\\"Unknown VCS\\",VDATUM[\\"Unknown\\"],PARAMETER[\\"Vertical_Shift\\",0.0],PARAMETER[\\"Direction\\",1.0],UNIT[\\"User_Defined_Unit\\",0.01]]"}*/
+    [TestMethod]
+    public async Task ConvertToJSAndBack(Action renderHandler)
+    {
+        SpatialReference sr = new SpatialReference() { Wkt = """PROJCS[\\"NAD_1983_Contiguous_USA_Albers\\",GEOGCS[\\"GCS_North_American_1983\\",DATUM[\\"D_North_American_1983\\",SPHEROID[\\"GRS_1980\\",6378137.0,298.257222101]],PRIMEM[\\"Greenwich\\",0.0],UNIT[\\"Degree\\",0.0174532925199433]],PROJECTION[\\"Albers\\"],PARAMETER[\\"False_Easting\\",0.0],PARAMETER[\\"False_Northing\\",0.0],PARAMETER[\\"Central_Meridian\\",-96.0],PARAMETER[\\"Standard_Parallel_1\\",29.5],PARAMETER[\\"Standard_Parallel_2\\",45.5],PARAMETER[\\"Latitude_Of_Origin\\",23.0],UNIT[\\"Meter\\",1.0]],VERTCS[\\"Unknown VCS\\",VDATUM[\\"Unknown\\"],PARAMETER[\\"Vertical_Shift\\",0.0],PARAMETER[\\"Direction\\",1.0],UNIT[\\"User_Defined_Unit\\",0.01]]""" };
+
+        await JsRuntime.InvokeVoidAsync("buildJsSpatialReference", sr);
+    }
+}

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/SymbolTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/SymbolTests.razor
@@ -13,19 +13,22 @@
         FeatureLayer? layer = null;
 
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler"
-                      Latitude="34.02700"
-                      Longitude="-118.80543"
-                      Zoom="13">
-                <Map ArcGISDefaultBasemap="arcgis-topographic">
-                    <FeatureLayer @ref="layer"
-                                  Url="https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trailheads/FeatureServer/0">
-                        <SimpleRenderer>
-                            <TextSymbol Text="Hello" />
-                        </SimpleRenderer>
-                    </FeatureLayer>
-                </Map>
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler"
+                          Latitude="34.02700"
+                          Longitude="-118.80543"
+                          Zoom="13">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+            </Basemap>
+            <FeatureLayer @ref="layer"
+                          Url="https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trailheads/FeatureServer/0">
+                <SimpleRenderer>
+                    <TextSymbol Text="Hello" />
+                </SimpleRenderer>
+            </FeatureLayer>
+        </Map>
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertSymbolOnLayer", nameof(CanRenderTextSymbol), layer!.Id, "text");
@@ -38,35 +41,38 @@
         TextSymbol? textSymbol = null;
 
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler"
-                      Latitude="34.02700"
-                      Longitude="-118.80543"
-                      Zoom="13">
-                <Map ArcGISDefaultBasemap="arcgis-topographic">
-                    <FeatureLayer @ref="layer"
-                                  Url="https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trailheads/FeatureServer/0">
-                        <SimpleRenderer>
-                            <TextSymbol @ref="textSymbol" Text="Hello"
-                                        Angle="39"
-                                        BackgroundColor="@(new MapColor("red"))"
-                                        BorderLineColor="@(new MapColor("blue"))"
-                                        BorderLineSize="2"
-                                        HaloColor="@(new MapColor("green"))"
-                                        HaloSize="4"
-                                        HorizontalAlignment="HorizontalAlignment.Left"
-                                        VerticalAlignment="VerticalAlignment.Top"
-                                        Kerning="false"
-                                        LineHeight="2.3"
-                                        LineWidth="@(new Dimension("120px"))"
-                                        Rotated="true"
-                                        XOffset="@("23pt")"
-                                        YOffset="@("23pt")">
-                                <MapFont Family="San Serif" />
-                            </TextSymbol>
-                        </SimpleRenderer>
-                    </FeatureLayer>
-                </Map>
-            </MapView>);
+    @<MapView class="map-view" OnViewRendered="renderHandler"
+                          Latitude="34.02700"
+                          Longitude="-118.80543"
+                          Zoom="13">
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+            </Basemap>
+            <FeatureLayer @ref="layer"
+                          Url="https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trailheads/FeatureServer/0">
+                <SimpleRenderer>
+                    <TextSymbol @ref="textSymbol" Text="Hello"
+                                Angle="39"
+                                BackgroundColor="@(new MapColor("red"))"
+                                BorderLineColor="@(new MapColor("blue"))"
+                                BorderLineSize="2"
+                                HaloColor="@(new MapColor("green"))"
+                                HaloSize="4"
+                                HorizontalAlignment="HorizontalAlignment.Left"
+                                VerticalAlignment="VerticalAlignment.Top"
+                                Kerning="false"
+                                LineHeight="2.3"
+                                LineWidth="@(new Dimension("120px"))"
+                                Rotated="true"
+                                XOffset="@("23pt")"
+                                YOffset="@("23pt")">
+                        <MapFont Family="San Serif" />
+                    </TextSymbol>
+                </SimpleRenderer>
+            </FeatureLayer>
+        </Map>
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertSymbolOnLayer", nameof(CanSetPropertiesOnTextSymbol), layer!.Id, "text", textSymbol!);

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/WidgetTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/WidgetTests.razor
@@ -10,12 +10,16 @@
     public async Task TestCanRenderBasemapGalleryWidget(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <BasemapGalleryWidget />
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <BasemapGalleryWidget />
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.BasemapGallery");
@@ -34,21 +38,21 @@
         }
 
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map>
-                    <Basemap>
-                        <TileLayer>
-                            <PortalItem Id="1b243539f4514b6ba35e7d995890db1d" />
-                        </TileLayer>
-                        <VectorTileLayer Opacity="0.75">
-                            <PortalItem Id="6976148c11bd497d8624206f9ee03e30" />
-                        </VectorTileLayer>
-                    </Basemap>
-                </Map>
-                <BasemapLayerListWidget OnReferenceListItemCreatedHandler="OnReferenceListItemCreatedHandler" />
+        <Map>
+            <Basemap>
+                <TileLayer>
+                    <PortalItem Id="1b243539f4514b6ba35e7d995890db1d" />
+                </TileLayer>
+                <VectorTileLayer Opacity="0.75">
+                    <PortalItem Id="6976148c11bd497d8624206f9ee03e30" />
+                </VectorTileLayer>
+            </Basemap>
+        </Map>
+        <BasemapLayerListWidget OnReferenceListItemCreatedHandler="OnReferenceListItemCreatedHandler" />
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.BasemapLayerList");
@@ -59,21 +63,21 @@
     public async Task TestCanRenderBasemapLayerListWidgetWithoutHandler(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map>
-                    <Basemap>
-                        <TileLayer>
-                            <PortalItem Id="1b243539f4514b6ba35e7d995890db1d" />
-                        </TileLayer>
-                        <VectorTileLayer Opacity="0.75">
-                            <PortalItem Id="6976148c11bd497d8624206f9ee03e30" />
-                        </VectorTileLayer>
-                    </Basemap>
-                </Map>
-                <BasemapLayerListWidget />
+        <Map>
+            <Basemap>
+                <TileLayer>
+                    <PortalItem Id="1b243539f4514b6ba35e7d995890db1d" />
+                </TileLayer>
+                <VectorTileLayer Opacity="0.75">
+                    <PortalItem Id="6976148c11bd497d8624206f9ee03e30" />
+                </VectorTileLayer>
+            </Basemap>
+        </Map>
+        <BasemapLayerListWidget />
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.BasemapLayerList");
@@ -83,27 +87,35 @@
     public async Task TestBasemapToggleFailsWithoutNextBasemap(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <BasemapToggleWidget />
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <BasemapToggleWidget />
 
-            </MapView>);
+    </MapView>);
 
         await Assert.ThrowsExceptionAsync<AggregateException>(async () =>
-            await WaitForMapToRender());
+        await WaitForMapToRender());
     }
 
     [TestMethod]
     public async Task TestCanRenderBasemapToggleWidget(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <BasemapToggleWidget NextBasemapName="arcgis-topographic" />
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <BasemapToggleWidget NextBasemapName="arcgis-topographic" />
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.BasemapToggle");
@@ -113,12 +125,16 @@
     public async Task TestCanRenderCompassWidget(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <CompassWidget />
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <CompassWidget />
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Compass");
@@ -128,12 +144,16 @@
     public async Task TestCanRenderHomeWidget(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <HomeWidget />
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <HomeWidget />
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Home");
@@ -152,14 +172,14 @@
         }
 
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <WebMap>
-                    <PortalItem Id="31cfc5b138e24dee866c457948773ac4" />
-                </WebMap>
-                <LayerListWidget OnListItemCreatedHandler="OnListItemCreatedHandler" />
+        <WebMap>
+            <PortalItem Id="31cfc5b138e24dee866c457948773ac4" />
+        </WebMap>
+        <LayerListWidget OnListItemCreatedHandler="OnListItemCreatedHandler" />
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.LayerList");
@@ -170,12 +190,16 @@
     public async Task TestCanRenderLegendWidget(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <LegendWidget />
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <LegendWidget />
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Legend");
@@ -185,12 +209,16 @@
     public async Task TestCanRenderLocateWidget(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <LocateWidget />
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <LocateWidget />
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Locate");
@@ -200,12 +228,16 @@
     public async Task TestCanRenderPopupWidget(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <PopupWidget />
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <PopupWidget />
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Popup");
@@ -215,12 +247,16 @@
     public async Task TestCanRenderScaleBarWidget(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <ScaleBarWidget />
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <ScaleBarWidget />
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.ScaleBar");
@@ -230,12 +266,16 @@
     public async Task TestCanRenderSearchWidget(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <SearchWidget />
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <SearchWidget />
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Search");
@@ -255,14 +295,18 @@
         }
 
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <SearchWidget @ref="widget">
-                    <SearchSource GetResultsHandler="GetResultsHandler" />
-                </SearchWidget>
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <SearchWidget @ref="widget">
+            <SearchSource GetResultsHandler="GetResultsHandler" />
+        </SearchWidget>
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Search");
@@ -284,14 +328,18 @@
         }
 
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <SearchWidget>
-                    <SearchSource GetSuggestionsHandler="GetSuggestionsHandler" />
-                </SearchWidget>
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <SearchWidget>
+            <SearchSource GetSuggestionsHandler="GetSuggestionsHandler" />
+        </SearchWidget>
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Search");
@@ -312,12 +360,16 @@
         SearchWidget? widget = null;
 
         AddMapRenderFragment(
-            @<MapView class="map-view" OnViewRendered="renderHandler">
+    @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                <SearchWidget @ref="widget" />
+        <Map>
+            <Basemap>
+                <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+            </Basemap>
+        </Map>
+        <SearchWidget @ref="widget" />
 
-            </MapView>);
+    </MapView>);
 
         await WaitForMapToRender();
         await AssertJavaScript("assertWidgetExists", args: "esri.widgets.Search");
@@ -359,13 +411,17 @@
             widgetCreated = true;
         }
         AddMapRenderFragment(
-            @<div>
-                <MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
-                    <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                </MapView>
-                <HomeWidget @ref="homeWidget" MapView="@mapView"
-                            OnWidgetCreated="OnWidgetCreated"/>
-            </div>);
+    @<div>
+        <MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
+            <Map>
+                <Basemap>
+                    <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+                </Basemap>
+            </Map>
+        </MapView>
+        <HomeWidget @ref="homeWidget" MapView="@mapView"
+                    OnWidgetCreated="OnWidgetCreated" />
+    </div>);
 
         await WaitForMapToRender();
         while (!widgetCreated)
@@ -374,21 +430,25 @@
         }
         await AssertJavaScript("elementExists", args: $"widget-container-{homeWidget!.Id}");
     }
-    
+
     [TestMethod]
     public async Task TestRenderOutsideOfMapViewWithoutReferenceThrows(Action renderHandler)
     {
         AddMapRenderFragment(
-            @<div>
-                <MapView class="map-view" OnViewRendered="renderHandler">
-                    <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                </MapView>
-                <HomeWidget />
-            </div>);
+    @<div>
+        <MapView class="map-view" OnViewRendered="renderHandler">
+            <Map>
+                <Basemap>
+                    <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+                </Basemap>
+            </Map>
+        </MapView>
+        <HomeWidget />
+    </div>);
 
         await Assert.ThrowsExceptionAsync<MissingMapViewReferenceException>(async () => await WaitForMapToRender());
     }
-    
+
     [TestMethod]
     public async Task TestCanRenderOutsideOfMapViewWithContainerId(Action renderHandler)
     {
@@ -399,14 +459,18 @@
             widgetCreated = true;
         }
         AddMapRenderFragment(
-            @<div>
-                <div id="external-container" />
-                <MapView class="map-view" OnViewRendered="renderHandler">
-                    <Map ArcGISDefaultBasemap="arcgis-imagery" />
-                    <HomeWidget @ref="homeWidget" ContainerId="external-container"
-                                OnWidgetCreated="OnWidgetCreated" />
-                </MapView>
-            </div>);
+    @<div>
+        <div id="external-container" />
+        <MapView class="map-view" OnViewRendered="renderHandler">
+            <Map>
+                <Basemap>
+                    <BasemapStyle Name="BasemapStyleName.ArcgisImagery" />
+                </Basemap>
+            </Map>
+            <HomeWidget @ref="homeWidget" ContainerId="external-container"
+                        OnWidgetCreated="OnWidgetCreated" />
+        </MapView>
+    </div>);
 
         await WaitForMapToRender();
         while (!widgetCreated)

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/dymaptic.GeoBlazor.Core.Test.Blazor.Shared.csproj
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/dymaptic.GeoBlazor.Core.Test.Blazor.Shared.csproj
@@ -8,21 +8,21 @@
 
 
     <ItemGroup>
-        <SupportedPlatform Include="browser"/>
+        <SupportedPlatform Include="browser" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.7"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0"/>
-        <PackageReference Include="MSTest.TestFramework" Version="3.5.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <AdditionalFiles Include="Components\BaseMapTests.razor"/>
-        <AdditionalFiles Include="Components\GeometryTests.razor"/>
-        <AdditionalFiles Include="Components\GraphicsTests.razor"/>
-        <AdditionalFiles Include="Components\TestRunnerBase.razor"/>
-        <AdditionalFiles Include="Components\WidgetTests.razor"/>
+        <AdditionalFiles Include="Components\BaseMapTests.razor" />
+        <AdditionalFiles Include="Components\GeometryTests.razor" />
+        <AdditionalFiles Include="Components\GraphicsTests.razor" />
+        <AdditionalFiles Include="Components\TestRunnerBase.razor" />
+        <AdditionalFiles Include="Components\WidgetTests.razor" />
     </ItemGroup>
 
     <Target Name="ReferenceType" BeforeTargets="Build" Condition="$(Configuration) == 'DEBUG' OR $(UseProjectReference) == 'true'">


### PR DESCRIPTION
Spatial References support setting WKID or WKT or WKT2.

Fixed a bug in the transition between .net and Javascript with a SpatialReference with only WKT.

Fixed a bug in the in the transition between .net and Javascript with a SpatialReference with a null WKID

Added support WKT2 in GeoBlazor

Added Tests for different SpatialReference types

Updated samples to no longer use a deprecated property.