### PR TITLE
Fix for breaking change in .NET 9

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <CoreVersion>3.1.1</CoreVersion>
+        <CoreVersion>3.1.2-beta-1</CoreVersion>
     </PropertyGroup>
 </Project>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/BingMapsLayers.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/BingMapsLayers.razor
@@ -36,7 +36,10 @@
 
 <MapView @ref="_view" OnViewRendered="OnViewRendered"
          Longitude="-107.95166" Latitude="43.18083" Zoom="4" Class="map-view">
-    <Map ArcGISDefaultBasemap="arcgis-topographic">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
     </Map>
 </MapView>
 

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/FeatureLayers.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/FeatureLayers.razor
@@ -43,7 +43,10 @@
 </div>
 
 <MapView Longitude="-118.80543" Latitude="34.02700" Zoom="13" Class="map-view">
-    <Map ArcGISDefaultBasemap="arcgis-topographic">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
         @if (_showPolygonLayer)
         {
             <FeatureLayer Url="https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Parks_and_Open_Space/FeatureServer/0" />

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/GeoRSSLayers.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/GeoRSSLayers.razor
@@ -9,7 +9,10 @@
 </p>
 
 <MapView Longitude="-107.95166" Latitude="43.18083" Zoom="4" Class="map-view">
-    <Map ArcGISDefaultBasemap="arcgis-light-gray">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
         <GeoRSSLayer
             Url="https://arcgis.github.io/arcgis-samples-javascript/sample-data/layers-georss/sample-georss.xml" />
     </Map>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/HitTests.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/HitTests.razor
@@ -19,7 +19,10 @@
          Latitude="35.863534"
          Zoom="3"
          EventRateLimitInMilliseconds="50">
-    <Map ArcGISDefaultBasemap="dark-gray-vector">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
         <FeatureLayer @ref="_hurricaneLayer"
                       OutFields="@(new[] { "*" })"
                       Url="https://sampleserver6.arcgisonline.com/arcgis/rest/services/Hurricanes/MapServer/1">

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ImageryLayers.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ImageryLayers.razor
@@ -15,7 +15,10 @@
 
 <MapView @ref="_view" class="map-view" 
          OnViewRendered="OnViewRendered">
-    <Map ArcGISDefaultBasemap="arcgis-light-gray">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
         @if (_markup)
         {
             <ImageryLayer Url="https://sampleserver6.arcgisonline.com/arcgis/rest/services/NLCDLandCover2001/ImageServer" Opacity="0.6"></ImageryLayer>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/KMLLayers.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/KMLLayers.razor
@@ -15,7 +15,10 @@
 
 
 <MapView @ref="_view" class="map-view" OnViewRendered="OnViewRendered" Scale="0">
-    <Map ArcGISDefaultBasemap="dark-gray-vector">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
         @if (_markup)
         {
             <KMLLayer Url="@_kmlLayerUrl" Title="Major EarthQuakes Query Result"></KMLLayer>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/MarkerRotation.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/MarkerRotation.razor
@@ -12,7 +12,10 @@
     <Extent Xmin="-41525513" Ymin="4969181" Xmax="-36687355" Ymax="9024624">
         <SpatialReference Wkid="3857" />
     </Extent>
-    <Map ArcGISDefaultBasemap="satellite">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
         <FeatureLayer Url="https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/weather_stations_010417/FeatureServer/0">
             <SimpleRenderer>
                 <PictureMarkerSymbol

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Scene.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Scene.razor
@@ -48,7 +48,10 @@
 </div>
 <SceneView @ref="_view" Longitude="_longitude" Latitude="_latitude" Class="map-view"
            ZIndex="2000" Tilt="76" OnViewRendered="OnViewRendered">
-    <Map Ground="world-elevation" ArcGISDefaultBasemap="satellite">
+    <Map Ground="world-elevation" >
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
         <GraphicsLayer @ref="_graphicsLayer">
             <Graphic @ref="_polygonGraphic" Attributes="_graphic1Attributes">
                 <Polygon Rings="@(new[] { _mapRings })" />
@@ -59,7 +62,6 @@
             </Graphic>
         </GraphicsLayer>
     </Map>
-
 </SceneView>
 
 

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/SearchMultipleSources.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/SearchMultipleSources.razor
@@ -14,7 +14,11 @@
 <MapView Class="map-view"
          Center="@(new Point(-97, 38))"
          Scale="10000000">
-    <Map ArcGISDefaultBasemap="dark-gray-vector" />
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
     <SearchWidget AllPlaceholder="District or Senator"
                   IncludeDefaultSources="false"
                   Position="OverlayPosition.TopRight">

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ServerSideQueries.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ServerSideQueries.razor
@@ -15,7 +15,10 @@
          Class="map-view"
          OnClick="OnClick"
          PopupEnabled="false">
-    <Map ArcGISDefaultBasemap="gray-vector">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
         <FeatureLayer @ref="_featureLayer" OutFields="@(new[] { "*" })">
             <PortalItem Id="234d2e3f6f554e0e84757662469c26d3" />
         </FeatureLayer>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ServiceAreas.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ServiceAreas.razor
@@ -12,7 +12,11 @@
          Zoom="11"
          Class="map-view"
          OnClick="OnClick">
-    <Map ArcGISDefaultBasemap="arcgis-navigation" />
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
 </MapView>
 
 <Graphic @ref="AreaGraphic">

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/SqlQuery.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/SqlQuery.razor
@@ -13,7 +13,11 @@
          Latitude="34.03000"
          Zoom="13"
          Class="map-view">
-    <Map ArcGISDefaultBasemap="arcgis-navigation" />
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
 
     <CustomOverlay Position="OverlayPosition.TopRight">
         <select class="esri-widget esri-select demo-select" @onchange="OnSqlQueryChanged">

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Tests.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Tests.razor
@@ -18,7 +18,10 @@
     <Extent Xmin="-41525513" Ymin="4969181" Xmax="-36687355" Ymax="9024624">
         <SpatialReference Wkid="102100" />
     </Extent>
-    <Map ArcGISDefaultBasemap="arcgis-topographic">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
         <GraphicsLayer>
             @for (var i = 0; i < _graphicsCount; i++)
             {
@@ -55,13 +58,19 @@
             Ymax="4061566.0769513007" Ymin="4015703.859980177">
         <SpatialReference Wkid="102100" />
     </Extent>
-    <Map ArcGISDefaultBasemap="arcgis-navigation">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
     </Map>
 </MapView>
 
 <h2>MapRendered Test Map</h2>
 <MapView @ref="_view3" Style="height: 600px; width: 100%;" OnViewRendered="OnMap3Rendered" OnClick="On3Click">
-    <Map ArcGISDefaultBasemap="arcgis-navigation">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
     </Map>
     <Extent Xmax="4120960.074670904" Xmin="-3412935.278412999" Ymax="8963926.222211033" Ymin="6049459.93475111">
         <SpatialReference Wkid="102100" />
@@ -71,7 +80,10 @@
 
 <h2>Spatial Ref from FeatureLayer Test Map</h2>
 <MapView Style="height: 600px; width: 100%;">
-    <Map ArcGISDefaultBasemap="arcgis-navigation">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
         <FeatureLayer Url="https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/weather_stations_010417/FeatureServer/0" />
     </Map>
     <Extent Xmax="4120960.074670904" Xmin="-3412935.278412999" Ymax="8963926.222211033" Ymin="6049459.93475111">
@@ -85,7 +97,10 @@
     <Extent Xmax="-12316914.7038" Xmin="-14596572.5354" Ymax="6562278.17835" Ymin="4992526.63148">
         <SpatialReference Wkid="102100" />
     </Extent>
-    <Map ArcGISDefaultBasemap="arcgis-topographic">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
         <FeatureLayer>
             <PortalItem Id="a07b8cd0b3514285ab1ff001befd2288">
                 <Portal Url="https://arcgis.dymaptic.com/portal/" />

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/VectorLayer.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/VectorLayer.razor
@@ -8,7 +8,10 @@
     A simple demo of loading a Vector Tile Layer from ArcGIS Online.
 </p>
 <MapView Longitude="-118.80543" Latitude="34.02700" Zoom="13" Class="map-view">
-    <Map ArcGISDefaultBasemap="arcgis-light-gray">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
         <VectorTileLayer
             Url="https://vectortileservices3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Santa_Monica_Mountains_Parcels_VTL/VectorTileServer/" />
     </Map>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/WCSLayers.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/WCSLayers.razor
@@ -13,7 +13,10 @@
 <button disabled="@(!_mapRendered)" @onclick="(()=>_markup = !_markup)">Add/Remove new WCS Layer in Markup without colorizing</button>
 
 <MapView @ref="_view" class="map-view" OnViewRendered="OnViewRendered">
-    <Map ArcGISDefaultBasemap="arcgis-light-gray">
+    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
         @if (_markup)
         {
             <WCSLayer Url="https://sampleserver6.arcgisonline.com/arcgis/services/ScientificData/SeaTemperature/ImageServer/WCSServer?request=GetCapabilities&service=WCS"></WCSLayer>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/dymaptic.GeoBlazor.Core.Sample.Shared.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/dymaptic.GeoBlazor.Core.Sample.Shared.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="Markdig" Version="0.37.0" />
         <PackageReference Include="MarkdigExtensions.SyntaxHighlighting" Version="1.0.3"/>
         <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.7"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.7"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.11"/>
         <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0"/>
     </ItemGroup>
 

--- a/src/dymaptic.GeoBlazor.Core/Components/ActionBase.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/ActionBase.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using ProtoBuf;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -139,6 +140,7 @@ public class ActionButton : ActionBase
     /// <summary>
     ///     Parameterless constructor for use as a razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public ActionButton()
     {
     }
@@ -222,6 +224,7 @@ public class ActionToggle : ActionBase
     /// <summary>
     ///     Parameterless constructor for use as a razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public ActionToggle()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/Extent.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/Extent.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 
 
 namespace dymaptic.GeoBlazor.Core.Components.Geometries;
@@ -13,6 +14,7 @@ public class Extent : Geometry
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public Extent()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/Point.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/Point.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -13,6 +14,7 @@ public class Point : Geometry
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public Point()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/PolyLine.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/PolyLine.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Objects;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 
 
 namespace dymaptic.GeoBlazor.Core.Components.Geometries;
@@ -14,6 +15,7 @@ public class PolyLine : Geometry
     /// <summary>
     ///     A parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public PolyLine()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/Polygon.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/Polygon.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Objects;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 
 
 namespace dymaptic.GeoBlazor.Core.Components.Geometries;
@@ -14,6 +15,7 @@ public class Polygon : Geometry
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public Polygon()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/SpatialReference.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/SpatialReference.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using ProtoBuf;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -20,6 +21,7 @@ public class SpatialReference : MapComponent
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public SpatialReference()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/BaseTileLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/BaseTileLayer.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Geometries;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using System.Text.Json.Serialization;
 
@@ -15,6 +16,7 @@ public class BaseTileLayer : Layer
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public BaseTileLayer()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/BingMapsLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/BingMapsLayer.cs
@@ -1,6 +1,7 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Geometries;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using System.Globalization;
 using System.Text.Json.Serialization;
@@ -18,6 +19,7 @@ public class BingMapsLayer : BaseTileLayer
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public BingMapsLayer()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/CSVLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/CSVLayer.cs
@@ -1,8 +1,8 @@
-﻿using dymaptic.GeoBlazor.Core.Components.Geometries;
-using dymaptic.GeoBlazor.Core.Components.Popups;
+﻿using dymaptic.GeoBlazor.Core.Components.Popups;
 using dymaptic.GeoBlazor.Core.Components.Renderers;
 using dymaptic.GeoBlazor.Core.Interfaces;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -21,6 +21,7 @@ public class CSVLayer : Layer, IFeatureReductionLayer, IPopupTemplateLayer
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public CSVLayer()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/ColorVariable.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/ColorVariable.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Objects;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -14,6 +15,7 @@ public class ColorVariable : VisualVariable
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public ColorVariable()
     {
     }
@@ -128,6 +130,7 @@ public class ColorStop: MapComponent
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public ColorStop()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayer.cs
@@ -7,10 +7,10 @@ using dymaptic.GeoBlazor.Core.Interfaces;
 using dymaptic.GeoBlazor.Core.Objects;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using ProtoBuf;
 using System.Runtime.Serialization;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -31,6 +31,7 @@ public class FeatureLayer : Layer, IFeatureReductionLayer, IPopupTemplateLayer
     /// <summary>
     ///     Constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public FeatureLayer()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayerView.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/FeatureLayerView.cs
@@ -1,10 +1,9 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Geometries;
 using dymaptic.GeoBlazor.Core.Objects;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using ProtoBuf;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 
 
@@ -455,6 +454,7 @@ public class Effect
     /// <summary>
     ///     Constructor
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public Effect()
     {
         

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/Field.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/Field.cs
@@ -1,6 +1,7 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Widgets;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -16,6 +17,7 @@ public class Field : MapComponent
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public Field()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/GeoJSONLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/GeoJSONLayer.cs
@@ -3,6 +3,7 @@ using dymaptic.GeoBlazor.Core.Components.Popups;
 using dymaptic.GeoBlazor.Core.Components.Renderers;
 using dymaptic.GeoBlazor.Core.Interfaces;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -22,6 +23,7 @@ public class GeoJSONLayer : Layer, IFeatureReductionLayer, IPopupTemplateLayer
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public GeoJSONLayer()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/GeoRSSLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/GeoRSSLayer.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -14,6 +15,7 @@ public class GeoRSSLayer : Layer
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public GeoRSSLayer()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/Graphic.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/Graphic.cs
@@ -3,6 +3,7 @@ using dymaptic.GeoBlazor.Core.Components.Popups;
 using dymaptic.GeoBlazor.Core.Components.Symbols;
 using dymaptic.GeoBlazor.Core.Objects;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using ProtoBuf;
 using System.Text.Json.Serialization;
@@ -21,6 +22,7 @@ public class Graphic : LayerObject
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public Graphic()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/GraphicsLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/GraphicsLayer.cs
@@ -1,6 +1,6 @@
-﻿using dymaptic.GeoBlazor.Core.Components.Views;
-using dymaptic.GeoBlazor.Core.Objects;
+﻿using dymaptic.GeoBlazor.Core.Objects;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using ProtoBuf;
 using System.Text.Json;
@@ -20,6 +20,7 @@ public class GraphicsLayer : Layer
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public GraphicsLayer()
     {
     }
@@ -462,6 +463,7 @@ internal class GraphicsToSerializationConverter : JsonConverter<IReadOnlyCollect
 [ProtoContract]
 internal record ProtoGraphicCollection
 {
+    [ActivatorUtilitiesConstructor]
     public ProtoGraphicCollection()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/ImageryLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/ImageryLayer.cs
@@ -3,6 +3,7 @@ using dymaptic.GeoBlazor.Core.Components.Renderers;
 using dymaptic.GeoBlazor.Core.Objects;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -25,6 +26,7 @@ public class ImageryLayer : Layer
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public ImageryLayer()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/ImageryTileLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/ImageryTileLayer.cs
@@ -4,6 +4,7 @@ using dymaptic.GeoBlazor.Core.Components.Renderers;
 using dymaptic.GeoBlazor.Core.Objects;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using System.Text.Json.Serialization;
 
@@ -26,6 +27,7 @@ public class ImageryTileLayer : Layer, IPopupTemplateLayer
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public ImageryTileLayer()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/KMLLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/KMLLayer.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Exceptions;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -19,6 +20,7 @@ public class KMLLayer : Layer
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public KMLLayer()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/Label.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/Label.cs
@@ -1,7 +1,7 @@
-﻿using dymaptic.GeoBlazor.Core.Extensions;
-using dymaptic.GeoBlazor.Core.Objects;
+﻿using dymaptic.GeoBlazor.Core.Objects;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -17,6 +17,7 @@ public class Label : LayerObject
     /// <summary>
     ///     Parameterless constructor for use as a Blazor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public Label()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/MapImageLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/MapImageLayer.cs
@@ -2,6 +2,7 @@ using dymaptic.GeoBlazor.Core.Components.Geometries;
 using dymaptic.GeoBlazor.Core.Objects;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using System.Text.Json.Serialization;
 
@@ -19,6 +20,7 @@ public class MapImageLayer : Layer
     /// <summary>
     ///     Parameterless constructor for use as a Razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public MapImageLayer()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/OpacityVariable.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/OpacityVariable.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -13,6 +14,7 @@ public class OpacityVariable: VisualVariable
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public OpacityVariable()
     {
     }
@@ -128,6 +130,7 @@ public class OpacityStop : MapComponent
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public OpacityStop()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/OpenStreetMapLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/OpenStreetMapLayer.cs
@@ -1,4 +1,7 @@
-﻿namespace dymaptic.GeoBlazor.Core.Components.Layers;
+﻿using Microsoft.Extensions.DependencyInjection;
+
+
+namespace dymaptic.GeoBlazor.Core.Components.Layers;
 
 /// <summary>
 ///     Allows you to use basemaps from OpenStreetMap. Set the tileservers property to change which OpenStreetMap tiles you
@@ -10,6 +13,7 @@ public class OpenStreetMapLayer : WebTileLayer
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public OpenStreetMapLayer()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/RotationVariable.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/RotationVariable.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -16,6 +17,7 @@ public class RotationVariable : VisualVariable
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public RotationVariable()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/SizeVariable.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/SizeVariable.cs
@@ -1,7 +1,7 @@
-﻿using dymaptic.GeoBlazor.Core.Extensions;
-using dymaptic.GeoBlazor.Core.Objects;
+﻿using dymaptic.GeoBlazor.Core.Objects;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -17,6 +17,7 @@ public class SizeVariable : VisualVariable
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public SizeVariable()
     {
     }
@@ -247,6 +248,7 @@ public class SizeStop : MapComponent
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public SizeStop()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/Sublayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/Sublayer.cs
@@ -4,6 +4,7 @@ using dymaptic.GeoBlazor.Core.Components.Renderers;
 using dymaptic.GeoBlazor.Core.Extensions;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -20,6 +21,7 @@ public class Sublayer: MapComponent, IPopupTemplateLayer
     /// <summary>
     ///     Parameterless constructor for use as a Razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public Sublayer()
     {
     }
@@ -614,6 +616,7 @@ public class LayerFloorInfo: MapComponent
     /// <summary>
     ///     Parameterless constructor for use as a Razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public LayerFloorInfo()
     {
     }
@@ -660,6 +663,7 @@ public class DynamicMapLayer : DynamicLayer
     /// <summary>
     ///     Parameterless constructor for use as a Razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public DynamicMapLayer()
     {
     }
@@ -709,6 +713,7 @@ public class DynamicDataLayer : DynamicLayer
     /// <summary>
     ///     Parameterless constructor for use as a Razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public DynamicDataLayer()
     {
     }
@@ -828,6 +833,7 @@ public class TableDataSource : DynamicDataSource
     /// <summary>
     ///     Parameterless constructor for use as a Razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public TableDataSource()
     {
     }
@@ -888,6 +894,7 @@ public class QueryTableDataSource : DynamicDataSource
     /// <summary>
     ///     Parameterless constructor for use as a Razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public QueryTableDataSource()
     {
     }
@@ -1008,6 +1015,7 @@ public class RasterDataSource : DynamicDataSource
     /// <summary>
     ///     Parameterless constructor for use as a Razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public RasterDataSource()
     {
     }
@@ -1056,6 +1064,7 @@ public class JoinTableDataSource : DynamicDataSource
     /// <summary>
     ///     Parameterless constructor for use as a Razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public JoinTableDataSource()
     {
     }
@@ -1201,6 +1210,7 @@ public class DynamicLayerField : MapComponent
     /// <summary>
     ///     Parameterless constructor for use as a Razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public DynamicLayerField()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/TileInfo.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/TileInfo.cs
@@ -1,8 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Geometries;
-using dymaptic.GeoBlazor.Core.Extensions;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 
 

--- a/src/dymaptic.GeoBlazor.Core/Components/Layers/WCSLayer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Layers/WCSLayer.cs
@@ -1,7 +1,7 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Renderers;
 using dymaptic.GeoBlazor.Core.Exceptions;
 using Microsoft.AspNetCore.Components;
-using System.Security.Cryptography.X509Certificates;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -22,6 +22,7 @@ public class WCSLayer : Layer
     /// <summary>
     ///     Constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public WCSLayer()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/AttachmentsPopupContent.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/AttachmentsPopupContent.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -14,6 +15,7 @@ public class AttachmentsPopupContent : PopupContent
     /// <summary>
     ///     Parameterless constructor for use as a razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public AttachmentsPopupContent()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/ExpressionInfo.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/ExpressionInfo.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using ProtoBuf;
 using System.Text.Json.Serialization;
 
@@ -20,6 +21,7 @@ public class ExpressionInfo : MapComponent
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public ExpressionInfo()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/ExpressionPopupContent.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/ExpressionPopupContent.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using ProtoBuf;
 using System.Text.Json.Serialization;
 
@@ -23,6 +24,7 @@ public class ExpressionPopupContent : PopupContent
     /// <summary>
     ///     Parameterless constructor for use as a razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public ExpressionPopupContent()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldInfo.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldInfo.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using ProtoBuf;
 using System.Text.Json.Serialization;
 
@@ -14,6 +15,7 @@ public class FieldInfo : MapComponent
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public FieldInfo()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldInfoFormat.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldInfoFormat.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using ProtoBuf;
 using System.Text.Json.Serialization;
 
@@ -16,6 +17,7 @@ public class FieldInfoFormat : MapComponent
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public FieldInfoFormat()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldsPopupContent.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/FieldsPopupContent.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -14,6 +15,7 @@ public class FieldsPopupContent : PopupContent
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public FieldsPopupContent()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/MediaInfo.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/MediaInfo.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using ProtoBuf;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -79,6 +80,7 @@ public class BarChartMediaInfo : MediaInfo
     /// <summary>
     ///     Parameterless constructor for use as a razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public BarChartMediaInfo()
     {
     }
@@ -196,6 +198,7 @@ public class ChartMediaInfoValue : MapComponent
     /// <summary>
     ///     Parameterless constructor for use as a razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public ChartMediaInfoValue()
     {
     }
@@ -383,6 +386,7 @@ public class ChartMediaInfoValueSeries : MapComponent
     /// <summary>
     ///     Parameterless constructor for use as a razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public ChartMediaInfoValueSeries()
     {
     }
@@ -477,6 +481,7 @@ public class ColumnChartMediaInfo : MediaInfo
     /// <summary>
     ///     Parameterless constructor for use as a razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public ColumnChartMediaInfo()
     {
     }
@@ -594,6 +599,7 @@ public class ImageMediaInfo : MediaInfo
     /// <summary>
     ///     Parameterless constructor for use as a razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public ImageMediaInfo()
     {
     }
@@ -728,6 +734,7 @@ public class ImageMediaInfoValue : MapComponent
     /// <summary>
     ///     Parameterless constructor for use as a razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public ImageMediaInfoValue()
     {
     }
@@ -778,6 +785,7 @@ public class LineChartMediaInfo : MediaInfo
     /// <summary>
     ///     Parameterless constructor for use as a razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public LineChartMediaInfo()
     {
     }
@@ -895,6 +903,7 @@ public class PieChartMediaInfo : MediaInfo
     /// <summary>
     ///     Parameterless constructor for use as a razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public PieChartMediaInfo()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/MediaPopupContent.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/MediaPopupContent.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -14,6 +15,7 @@ public class MediaPopupContent : PopupContent
     /// <summary>
     ///     Parameterless constructor for use as a Razor Component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public MediaPopupContent()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/PopupTemplate.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/PopupTemplate.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Layers;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using ProtoBuf;
 using System.Text.Json.Serialization;
@@ -18,6 +19,7 @@ public class PopupTemplate : MapComponent
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public PopupTemplate()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/RelationshipPopupContent.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/RelationshipPopupContent.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Objects;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using ProtoBuf;
 using System.Text.Json.Serialization;
 
@@ -23,6 +24,7 @@ public class RelationshipPopupContent : PopupContent
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public RelationshipPopupContent()
     {
     }
@@ -138,6 +140,7 @@ public class RelatedRecordsInfoFieldOrder : MapComponent
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public RelatedRecordsInfoFieldOrder()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Popups/TextPopupContent.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Popups/TextPopupContent.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -15,6 +16,7 @@ public class TextPopupContent : PopupContent
     /// <summary>
     ///     Parameterless constructor for use as a razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public TextPopupContent()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Renderers/ColorRamps/AlgorithmicColorRamp.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Renderers/ColorRamps/AlgorithmicColorRamp.cs
@@ -1,6 +1,7 @@
 ﻿using dymaptic.GeoBlazor.Core.Objects;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -16,6 +17,7 @@ public class AlgorithmicColorRamp : ColorRamp
     /// <summary>
     ///     Constructor for use in code
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public AlgorithmicColorRamp() { }
 
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/Renderers/ColorRamps/MultipartColorRamp.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Renderers/ColorRamps/MultipartColorRamp.cs
@@ -1,4 +1,7 @@
-﻿namespace dymaptic.GeoBlazor.Core.Components.Renderers.ColorRamps;
+﻿using Microsoft.Extensions.DependencyInjection;
+
+
+namespace dymaptic.GeoBlazor.Core.Components.Renderers.ColorRamps;
 
 /// <summary>
 ///     Creates a color ramp for use in a raster renderer. The algorithmic color ramp is defined by specifying two colors and the
@@ -10,6 +13,7 @@ public class MultipartColorRamp : ColorRamp
     /// <summary>
     ///     Constructor for use in code
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public MultipartColorRamp() { }
 
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/Renderers/DimensionalDefinition.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Renderers/DimensionalDefinition.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Layers;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -15,6 +16,7 @@ public class DimensionalDefinition : LayerObject
     /// <summary>
     ///     Constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public DimensionalDefinition() { }
 
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/Renderers/ImageryRenderer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Renderers/ImageryRenderer.cs
@@ -1,6 +1,4 @@
-﻿using dymaptic.GeoBlazor.Core.Components.Layers;
-using dymaptic.GeoBlazor.Core.Extensions;
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 
 

--- a/src/dymaptic.GeoBlazor.Core/Components/Renderers/RasterStretchRenderer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Renderers/RasterStretchRenderer.cs
@@ -1,7 +1,7 @@
-﻿using dymaptic.GeoBlazor.Core.Components.Layers;
-using dymaptic.GeoBlazor.Core.Components.Renderers.ColorRamps;
+﻿using dymaptic.GeoBlazor.Core.Components.Renderers.ColorRamps;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using System.Text.Json.Serialization;
 
@@ -21,6 +21,7 @@ public class RasterStretchRenderer : MapComponent, IImageryRenderer
     /// <summary>
     ///     Constructor for use in code
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public RasterStretchRenderer() { }
 
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Components/Renderers/SimpleRenderer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Renderers/SimpleRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Layers;
 using dymaptic.GeoBlazor.Core.Components.Symbols;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -16,6 +17,7 @@ public class SimpleRenderer : Renderer
     /// <summary>
     ///     Parameterless constructor for use as a Razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public SimpleRenderer()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Renderers/UniqueValueRenderer.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Renderers/UniqueValueRenderer.cs
@@ -1,5 +1,4 @@
-﻿using dymaptic.GeoBlazor.Core.Components.Renderers;
-using dymaptic.GeoBlazor.Core.Components.Symbols;
+﻿using dymaptic.GeoBlazor.Core.Components.Symbols;
 using Microsoft.AspNetCore.Components;
 using System.Text.Json.Serialization;
 

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/MapFont.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/MapFont.cs
@@ -1,6 +1,6 @@
-﻿using dymaptic.GeoBlazor.Core.Extensions;
-using dymaptic.GeoBlazor.Core.Objects;
+﻿using dymaptic.GeoBlazor.Core.Objects;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using ProtoBuf;
 using System.Text.Json.Serialization;
 
@@ -18,6 +18,7 @@ public class MapFont : MapComponent
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public MapFont()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/Outline.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/Outline.cs
@@ -1,4 +1,5 @@
 ﻿using dymaptic.GeoBlazor.Core.Objects;
+using Microsoft.Extensions.DependencyInjection;
 
 
 namespace dymaptic.GeoBlazor.Core.Components.Symbols;
@@ -11,6 +12,7 @@ public class Outline : SimpleLineSymbol
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public Outline()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/PictureFillSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/PictureFillSymbol.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Objects;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -14,6 +15,7 @@ public class PictureFillSymbol : FillSymbol
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public PictureFillSymbol()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/PictureMarkerSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/PictureMarkerSymbol.cs
@@ -1,6 +1,6 @@
-﻿using dymaptic.GeoBlazor.Core.Extensions;
-using dymaptic.GeoBlazor.Core.Objects;
+﻿using dymaptic.GeoBlazor.Core.Objects;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -16,6 +16,7 @@ public class PictureMarkerSymbol : MarkerSymbol
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public PictureMarkerSymbol()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleFillSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleFillSymbol.cs
@@ -2,6 +2,7 @@
 using dymaptic.GeoBlazor.Core.Objects;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -18,6 +19,7 @@ public class SimpleFillSymbol : FillSymbol
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public SimpleFillSymbol()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleLineSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleLineSymbol.cs
@@ -2,7 +2,7 @@
 using dymaptic.GeoBlazor.Core.Objects;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
-using ProtoBuf;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -18,6 +18,7 @@ public class SimpleLineSymbol : LineSymbol
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public SimpleLineSymbol()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleMarkerSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/SimpleMarkerSymbol.cs
@@ -2,6 +2,7 @@
 using dymaptic.GeoBlazor.Core.Objects;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -18,6 +19,7 @@ public class SimpleMarkerSymbol : MarkerSymbol
     /// <summary>
     ///     Parameterless constructor for using as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public SimpleMarkerSymbol()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/Symbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/Symbol.cs
@@ -1,5 +1,4 @@
-﻿using dymaptic.GeoBlazor.Core.Extensions;
-using dymaptic.GeoBlazor.Core.Objects;
+﻿using dymaptic.GeoBlazor.Core.Objects;
 using Microsoft.AspNetCore.Components;
 using ProtoBuf;
 using System.Text.Json;

--- a/src/dymaptic.GeoBlazor.Core/Components/Symbols/TextSymbol.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Symbols/TextSymbol.cs
@@ -2,6 +2,7 @@
 using dymaptic.GeoBlazor.Core.Objects;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -19,6 +20,7 @@ public class TextSymbol : Symbol
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public TextSymbol()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Views/Viewpoint.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Views/Viewpoint.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Geometries;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 namespace dymaptic.GeoBlazor.Core.Components.Views;
@@ -14,6 +15,7 @@ public class Viewpoint : MapComponent
     /// <summary>
     ///     Parameterless constructor for use as a Blazor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public Viewpoint()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/WebMap.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/WebMap.cs
@@ -1,7 +1,5 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Widgets;
-using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
-using System.Text.Json.Serialization;
 
 
 namespace dymaptic.GeoBlazor.Core.Components;

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/Bookmark.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/Bookmark.cs
@@ -1,6 +1,7 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Views;
 using dymaptic.GeoBlazor.Core.Objects;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 namespace dymaptic.GeoBlazor.Core.Components.Widgets;
@@ -15,6 +16,7 @@ public class Bookmark : MapComponent
     /// <summary>
     ///     Parameterless constructor for use as a Blazor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public Bookmark()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/FormElement.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/FormElement.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -50,6 +51,7 @@ public class FieldElement : FormElement
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public FieldElement()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/FormTemplate.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/FormTemplate.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Popups;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 
 
 namespace dymaptic.GeoBlazor.Core.Components.Widgets;
@@ -14,6 +15,7 @@ public class FormTemplate : MapComponent
     /// <summary>
     ///     Parameterless constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public FormTemplate()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/PopupWidget.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/PopupWidget.cs
@@ -1,10 +1,10 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Geometries;
 using dymaptic.GeoBlazor.Core.Components.Layers;
 using dymaptic.GeoBlazor.Core.Components.Popups;
-using dymaptic.GeoBlazor.Core.Components.Symbols;
 using dymaptic.GeoBlazor.Core.Components.Views;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -428,6 +428,7 @@ public class PopupDockOptions : MapComponent
     /// <summary>
     ///     Parameterless constructor for use as a razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public PopupDockOptions()
     {
     }
@@ -538,6 +539,7 @@ public class PopupVisibleElements : MapComponent
     /// <summary>
     ///     Parameterless constructor for use as a razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public PopupVisibleElements()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/SearchWidget.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/SearchWidget.cs
@@ -1,13 +1,10 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Geometries;
 using dymaptic.GeoBlazor.Core.Components.Layers;
 using dymaptic.GeoBlazor.Core.Components.Popups;
-using dymaptic.GeoBlazor.Core.Components.Symbols;
-using dymaptic.GeoBlazor.Core.Exceptions;
 using dymaptic.GeoBlazor.Core.Objects;
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
-using System.Reflection.Metadata;
 using System.Text.Json.Serialization;
 
 

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/SliderWidget.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/SliderWidget.cs
@@ -1,5 +1,6 @@
 using dymaptic.GeoBlazor.Core.Serialization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using System.Text.Json.Serialization;
 
@@ -18,6 +19,7 @@ public class SliderWidget: Widget
     /// <summary>
     ///     Parameterless constructor for use as a Razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public SliderWidget()
     {
     }
@@ -840,6 +842,7 @@ public class SliderTickConfig: MapComponent
     /// <summary>
     ///     Parameterless constructor for use as a Razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public SliderTickConfig()
     {
     }
@@ -981,6 +984,7 @@ public class SliderVisibleElements : MapComponent
     /// <summary>
     ///     Parameterless constructor for use as a Razor component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public SliderVisibleElements()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Model/AuthenticationManager.cs
+++ b/src/dymaptic.GeoBlazor.Core/Model/AuthenticationManager.cs
@@ -1,5 +1,4 @@
 ﻿using dymaptic.GeoBlazor.Core.Components.Views;
-using dymaptic.GeoBlazor.Core.Objects;
 using Microsoft.Extensions.Configuration;
 using Microsoft.JSInterop;
 

--- a/src/dymaptic.GeoBlazor.Core/Objects/HighlightOptions.cs
+++ b/src/dymaptic.GeoBlazor.Core/Objects/HighlightOptions.cs
@@ -1,5 +1,6 @@
 ﻿using dymaptic.GeoBlazor.Core.Components;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json.Serialization;
 
 
@@ -17,6 +18,7 @@ public class HighlightOptions : MapComponent
     /// <summary>
     ///     Default Constructor for use as a Blazor Component.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public HighlightOptions()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/ReadMe.md
+++ b/src/dymaptic.GeoBlazor.Core/ReadMe.md
@@ -1,5 +1,12 @@
 ﻿# GeoBlazor
 
+# *.NET 9 NOTICE*
+*Version 3.1.2-beta-1 fixes a [breaking change](https://github.com/dotnet/aspnetcore/issues/58004) that Microsoft introduced in how constructors are used in .NET 9 Razor Components.*
+
+*Even with that fix, you will still experience __very slow__ build times when targeting .NET 9 or even just using the .NET 9 SDK to build previous versions. We have an open request for a fix [here](https://github.com/dotnet/aspnetcore/issues/59014)*
+
+*To avoid disruptions, we recommend staying on .NET 8 for now, and using a global.json file to pin your SDK build version to .NET 8.*
+
 ## PUT MAPS IN YOUR BLAZOR APPS
 
 With GeoBlazor, you have access to the world’s most powerful and versatile web mapping API, the
@@ -21,7 +28,7 @@ ArcGIS JavaScript API, but without having to write a single line of JavaScript.
 
 1. Create a new Blazor Web App (.NET 8), Blazor Server, Blazor Wasm, or Blazor Hybrid (MAUI) project,
    using the templates provided in your IDE or the `dotnet` CLI.
-2. add a `PackageReference` to the latest version of the `dymaptic.GeoBlazor.Core` package via your IDE's Nuget Package
+2. Add a `PackageReference` to the latest version of the `dymaptic.GeoBlazor.Core` package via your IDE's Nuget Package
    Manager or `dotnet add package dymaptic.GeoBlazor.Core`. For Blazor Web Apps supporting WebAssembly, add this
    reference to the `.Client` WebAssembly project.
 3. The ArcGIS API requires some form of authentication. The simplest is to use an API Key. Generate a key from
@@ -107,8 +114,6 @@ ArcGIS JavaScript API, but without having to write a single line of JavaScript.
    ```
 
 7. Create a new Razor Component in the `Pages` folder, or just use `Index.razor`. Add a `MapView`. Give it basic
-
-8. Create a new Razor Component in the `Pages` folder, or just use `Index.razor`. Add a `MapView`. Give it basic
    parameters to ensure that it can render.
 
    ```html
@@ -122,7 +127,7 @@ ArcGIS JavaScript API, but without having to write a single line of JavaScript.
       private readonly double _longitude = -118.805;
    } 
    ```
-9. Within the `MapView`, define a map using the `WebMap` component. To load a pre-generated map from ArcGIS Online or
+8. Within the `MapView`, define a map using the `WebMap` component. To load a pre-generated map from ArcGIS Online or
    Portal, get the Map Id (PortalItem Id)
    of the map.
 
@@ -133,7 +138,7 @@ ArcGIS JavaScript API, but without having to write a single line of JavaScript.
        </WebMap>
    </MapView>
    ```
-10. Add a Widget to the `MapView`, after the `WebMap`.
+9. Add a Widget to the `MapView`, after the `WebMap`.
 
    ```html
    <MapView Longitude="_longitude" Latitude="_latitude" Zoom="11" Style="height: 400px; width: 100%;"> 
@@ -144,11 +149,11 @@ ArcGIS JavaScript API, but without having to write a single line of JavaScript.
    </MapView>
    ```
 
-11. Run your application and make sure you can see your map!
-12. Now that you have a great starting point, you can now start to customize the features available in your new app
+10. Run your application and make sure you can see your map!
+11. Now that you have a great starting point, you can now start to customize the features available in your new app
     using Geoblazor's capabilites:<br/>
     -Take a look at the [Documentation](https://docs.geoblazor.com/index.html) pages to learn more.
-13. _Optional_: To remove the `Thank You` message from your console messages, please consider registering your application
+12. _Optional_: To remove the `Thank You` message from your console messages, please consider registering your application
     on the [dymaptic licensing server](https://licensing.dymaptic.com). After registering and filling out a small questionnaire,
     you will receive a registration key, which you can add to any configuration (e.g., `appsettings.json`) to remove the
     message.

--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -2061,7 +2061,7 @@ async function createWidget(widget: any, viewId: string): Promise<Widget | null>
                 };
             }
             if (hasValue(widget.hasCustomReferenceListHandler) && widget.hasCustomReferenceListHandler) {
-                basemapLayerListWidget.baseListItemCreatedFunction = async (evt) => {
+                basemapLayerListWidget.referenceListItemCreatedFunction = async (evt) => {
                     let dotNetReferenceListItem = buildDotNetListItem(evt.item);
                     let returnItem = await widget.baseLayerListWidgetObjectReference.invokeMethodAsync('OnReferenceListItemCreated', dotNetReferenceListItem) as DotNetListItem;
                     if (hasValue(returnItem) && hasValue(evt.item)) {

--- a/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
+++ b/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
@@ -20,11 +20,12 @@
         <RepositoryType>git</RepositoryType>
         <PackageIcon>Blazor-API-500px.png</PackageIcon>
         <GeneratePackageOnBuild Condition="$(Configuration) == 'RELEASE' AND $(GeneratePackage) != 'false'">true</GeneratePackageOnBuild>
-        <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
+        <CompressionEnabled>false</CompressionEnabled>
     </PropertyGroup>
 
     <ItemGroup>
@@ -41,23 +42,17 @@
         <PackageReference Include="DefaultDocumentation" Version="0.8.2" PrivateAssets="all" />
         <PackageReference Include="protobuf-net" Version="3.2.30" />
     </ItemGroup>
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.32" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    </ItemGroup>
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.20" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.11" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
     </ItemGroup>
     <PropertyGroup Condition="$(Configuration) == 'RELEASE' AND $(TargetFrameworks.StartsWith($(TargetFramework)))">
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
+++ b/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
@@ -20,7 +20,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageIcon>Blazor-API-500px.png</PackageIcon>
         <GeneratePackageOnBuild Condition="$(Configuration) == 'RELEASE' AND $(GeneratePackage) != 'false'">true</GeneratePackageOnBuild>
-        <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <Nullable>enable</Nullable>
@@ -47,12 +47,6 @@
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    </ItemGroup>
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
     </ItemGroup>
     <PropertyGroup Condition="$(Configuration) == 'RELEASE' AND $(TargetFrameworks.StartsWith($(TargetFramework)))">
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "9.0.101",
     "rollForward": "latestMinor"
   }
 }

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.101",
+    "version": "8.0.0",
     "rollForward": "latestMinor"
   }
 }

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/AttributesTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/AttributesTests.razor
@@ -11,7 +11,11 @@ base.BuildRenderTree(__builder);
         MapView? mapView = null;
         AddMapRenderFragment( 
             @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
             </MapView>);
 
         await WaitForMapToRender();
@@ -67,7 +71,10 @@ base.BuildRenderTree(__builder);
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler"
                       OnLayerViewCreate="onLayerCreated">
-                <Map ArcGISDefaultBasemap="topo-vector">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <FeatureLayer @ref="layer" Source="features"
                                   GeometryType="GeometryType.Point"
                                   ObjectIdField="OBJECTID">
@@ -127,7 +134,10 @@ base.BuildRenderTree(__builder);
             @<MapView @ref="view"
                       class="map-view" 
                       OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <GraphicsLayer @ref="layer" />
                 </Map>
             </MapView>);

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/BaseMapTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/BaseMapTests.razor
@@ -11,7 +11,11 @@
     {
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
             </MapView>);
         await WaitForMapToRender();
     }

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/ExpandWidgetTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/ExpandWidgetTests.razor
@@ -12,7 +12,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <ExpandWidget Position="OverlayPosition.TopLeft" Expanded="true" Mode="Mode.Floating">
                     <LayerListWidget @ref="layerList" />
                 </ExpandWidget>
@@ -31,7 +35,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
     
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <ExpandWidget Position="OverlayPosition.TopLeft" Expanded="true" Mode="Mode.Floating">
                     <button id="test-button" type="button">Click Me</button>
                 </ExpandWidget>
@@ -50,7 +58,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <ExpandWidget Position="OverlayPosition.TopLeft" Expanded="true" Mode="Mode.Floating">
                     <button id="test-button-1" type="button">Click Me</button>
                     <LegendWidget @ref="legend" />
@@ -74,7 +86,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <ExpandWidget Position="OverlayPosition.TopLeft" Expanded="true" Mode="Mode.Floating">
                     <LegendWidget @ref="legend" />
                     <button id="test-button-2" type="button">Click Me</button>

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerTests.razor
@@ -18,7 +18,10 @@
         }
         AddMapRenderFragment(
             @<MapView OnViewInitialized="@OnViewInitialized" @ref="@mapView" class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="topo-vector">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                 </Map>
             </MapView>);
         await WaitForMapToRender();
@@ -64,7 +67,10 @@
         }
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="topo-vector">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <FeatureLayer @ref="layer" Source="graphics" 
                                   GeometryType="GeometryType.Point"
                                   ObjectIdField="OBJECT_ID">
@@ -133,7 +139,10 @@
         FeatureLayer? layer = null;
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="topo-vector">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <FeatureLayer @ref="layer" Source="@([])" 
                                   GeometryType="GeometryType.Point"
                                   ObjectIdField="OBJECT_ID">
@@ -158,7 +167,10 @@
         FeatureLayer? layer = null;
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="topo-vector">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <FeatureLayer @ref="layer" Source="@([])" 
                                   GeometryType="GeometryType.Point"
                                   ObjectIdField="OBJECT_ID">
@@ -179,7 +191,10 @@
         FeatureLayer? layer = null;
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="topo-vector">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <FeatureLayer @ref="layer" Source="@([])" 
                                   GeometryType="GeometryType.Point"
                                   ObjectIdField="OBJECT_ID">
@@ -213,7 +228,10 @@
         FeatureLayer? layer = null;
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="topo-vector">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <FeatureLayer @ref="layer" Source="@([])" 
                                   GeometryType="GeometryType.Point"
                                   ObjectIdField="OBJECT_ID">
@@ -261,7 +279,10 @@
         FeatureLayer? layer = null;
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="topo-vector">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <FeatureLayer @ref="layer" Source="@([])" 
                                   GeometryType="GeometryType.Point"
                                   ObjectIdField="OBJECT_ID">
@@ -305,7 +326,10 @@
         FeatureLayer? layer = null;
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="topo-vector">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <FeatureLayer @ref="layer" OutFields="@(new[] { "*" })">
                         <PortalItem Id="234d2e3f6f554e0e84757662469c26d3" />
                     </FeatureLayer>
@@ -340,7 +364,10 @@
         FeatureLayer? layer = null;
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler" Longitude="-98.5795" Latitude="39.8282">
-                <Map ArcGISDefaultBasemap="topo-vector">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <FeatureLayer @ref="layer" OutFields="@(new[] { "*" })">
                         <PortalItem Id="7a301e848a7c4bfcaefdac4fe98a7f99" />
                     </FeatureLayer>
@@ -374,7 +401,10 @@
         FeatureLayer? layer = null;
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler" Longitude="-97.75188" Latitude="37.23308">
-                <Map ArcGISDefaultBasemap="topo-vector">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <FeatureLayer @ref="layer" OutFields="@(new[] { "*" })"
                                   Url="https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/US_National_Parks_Annual_Visitation/FeatureServer/0">
                     </FeatureLayer>

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerViewTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerViewTests.razor
@@ -20,7 +20,10 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler"
                       OnLayerViewCreate="OnLayerViewCreate">
-                <Map ArcGISDefaultBasemap="topo-vector">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <FeatureLayer OutFields="@(new[] { "*" })">
                         <PortalItem Id="234d2e3f6f554e0e84757662469c26d3" />
                     </FeatureLayer>

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/GeometryTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/GeometryTests.razor
@@ -12,7 +12,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <Graphic Attributes="_attributes">
                     <Point Latitude="100" Longitude="12" />
                     <SimpleMarkerSymbol Color="@(new MapColor("green"))">
@@ -32,7 +36,11 @@
     {
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <Graphic Attributes="_attributes">
                     <PolyLine Paths="_paths" />
                     <SimpleLineSymbol Color="@(new MapColor("ffffff"))"></SimpleLineSymbol>
@@ -49,7 +57,11 @@
     {
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <Graphic Attributes="_attributes">
                     <Polygon Rings="_rings" />
                     <SimpleFillSymbol Color="@(new MapColor("ffffff"))">
@@ -69,7 +81,11 @@
     {
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <Graphic>
                     <Point Latitude="100" Longitude="12" />
                 </Graphic>
@@ -94,7 +110,11 @@
         MapView? mapView = null;        
         AddMapRenderFragment( 
             @<MapView @ref=" mapView" class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
             </MapView>);
         await WaitForMapToRender();
 
@@ -111,7 +131,11 @@
         MapView? mapView = null;
         AddMapRenderFragment(
             @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
             </MapView>);
         await WaitForMapToRender();
 
@@ -128,7 +152,11 @@
         MapView? mapView = null;
         AddMapRenderFragment(
             @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
             </MapView>);
         await WaitForMapToRender();
 

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/GraphicsTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/GraphicsTests.razor
@@ -40,7 +40,10 @@
 
         AddMapRenderFragment(
             @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <GraphicsLayer @ref="graphicsLayer">
                         <Graphic @ref="graphic">
                             <Point X="0" Y="0" />
@@ -79,7 +82,11 @@
         MapView? mapView = null;
         AddMapRenderFragment(
     @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
-        <Map ArcGISDefaultBasemap="arcgis-imagery" />
+        <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
     </MapView>);
 
         await WaitForMapToRender();
@@ -100,7 +107,10 @@
 
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <GraphicsLayer @ref="graphicsLayer">
                         <Graphic @ref="graphic">
                             <Point X="0" Y="0" />
@@ -121,7 +131,11 @@
         MapView? mapView = null;
         AddMapRenderFragment( 
             @<MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
             </MapView>);
 
         await WaitForMapToRender();
@@ -138,7 +152,10 @@
         GraphicsLayer? layer = null;
         AddMapRenderFragment( 
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <GraphicsLayer @ref="layer" />
                 </Map>
             </MapView>);
@@ -174,7 +191,10 @@
         GraphicsLayer? layer = null;
         AddMapRenderFragment( 
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <GraphicsLayer @ref="layer" />
                 </Map>
             </MapView>);
@@ -198,7 +218,10 @@
         GraphicsLayer? layer = null;
         AddMapRenderFragment( 
             @<MapView class="map-view" OnViewRendered="renderHandler">
-                <Map ArcGISDefaultBasemap="arcgis-imagery">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <GraphicsLayer @ref="layer" />
                 </Map>
             </MapView>);

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/LegendWidgetTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/LegendWidgetTests.razor
@@ -12,7 +12,10 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <GeoJSONLayer Title="Earthquakes from the last month"
                                   Url="https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_month.geojson" />
                 </Map>

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/MapViewTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/MapViewTests.razor
@@ -12,7 +12,11 @@
         MapView? view = null;
         AddMapRenderFragment(
         @<MapView @ref="view" class="map-view" OnViewRendered="renderHandler">
-            <Map ArcGISDefaultBasemap="arcgis-imagery" />
+            <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
         </MapView>);
         await WaitForMapToRender();
 

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/SymbolTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/SymbolTests.razor
@@ -17,7 +17,10 @@
                       Latitude="34.02700"
                       Longitude="-118.80543"
                       Zoom="13">
-                <Map ArcGISDefaultBasemap="arcgis-topographic">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <FeatureLayer @ref="layer"
                                   Url="https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trailheads/FeatureServer/0">
                         <SimpleRenderer>
@@ -42,7 +45,10 @@
                       Latitude="34.02700"
                       Longitude="-118.80543"
                       Zoom="13">
-                <Map ArcGISDefaultBasemap="arcgis-topographic">
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
                     <FeatureLayer @ref="layer"
                                   Url="https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Trailheads/FeatureServer/0">
                         <SimpleRenderer>

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/WidgetTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/WidgetTests.razor
@@ -12,7 +12,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <BasemapGalleryWidget />
 
             </MapView>);
@@ -85,7 +89,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <BasemapToggleWidget />
 
             </MapView>);
@@ -100,7 +108,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <BasemapToggleWidget NextBasemapName="arcgis-topographic" />
 
             </MapView>);
@@ -115,7 +127,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <CompassWidget />
 
             </MapView>);
@@ -130,7 +146,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <HomeWidget />
 
             </MapView>);
@@ -172,7 +192,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <LegendWidget />
 
             </MapView>);
@@ -187,7 +211,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <LocateWidget />
 
             </MapView>);
@@ -202,7 +230,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <PopupWidget />
 
             </MapView>);
@@ -217,7 +249,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <ScaleBarWidget />
 
             </MapView>);
@@ -232,7 +268,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <SearchWidget />
 
             </MapView>);
@@ -257,7 +297,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <SearchWidget @ref="widget">
                     <SearchSource GetResultsHandler="GetResultsHandler" />
                 </SearchWidget>
@@ -286,7 +330,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <SearchWidget>
                     <SearchSource GetSuggestionsHandler="GetSuggestionsHandler" />
                 </SearchWidget>
@@ -314,7 +362,11 @@
         AddMapRenderFragment(
             @<MapView class="map-view" OnViewRendered="renderHandler">
 
-                <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 <SearchWidget @ref="widget" />
 
             </MapView>);
@@ -361,7 +413,11 @@
         AddMapRenderFragment(
             @<div>
                 <MapView @ref="mapView" class="map-view" OnViewRendered="renderHandler">
-                    <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 </MapView>
                 <HomeWidget @ref="homeWidget" MapView="@mapView"
                             OnWidgetCreated="OnWidgetCreated"/>
@@ -381,7 +437,11 @@
         AddMapRenderFragment(
             @<div>
                 <MapView class="map-view" OnViewRendered="renderHandler">
-                    <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                 </MapView>
                 <HomeWidget />
             </div>);
@@ -402,7 +462,11 @@
             @<div>
                 <div id="external-container" />
                 <MapView class="map-view" OnViewRendered="renderHandler">
-                    <Map ArcGISDefaultBasemap="arcgis-imagery" />
+                    <Map>
+        <Basemap>
+            <BasemapStyle Name="BasemapStyleName.ArcgisTopographic" />
+        </Basemap>
+    </Map>
                     <HomeWidget @ref="homeWidget" ContainerId="external-container"
                                 OnWidgetCreated="OnWidgetCreated" />
                 </MapView>


### PR DESCRIPTION
Closes #370 

- Found related MS gissue [here](https://github.com/dotnet/aspnetcore/issues/58004)
- Added `[ActivatorUtilitiesConstructor]` to all parameterless constructors for MapComponents (Razor Components) in GeoBlazor
- Cleaned up usings
- Also updated samples to remove deprecated `ArcGISDefaultBasemap`
- Updated nuget documentation with .NET 9 warning/message
- Fix for `BasemapLayerListWidget` error in `arcGisJsInterop`
- Built and tested a nuget beta build, will release as 3.1.2-beta-1