### PR TITLE
Fix OpenStreetMapLayer urlTemplate Error with WebTileLayer

### DIFF
--- a/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/arcGisJsInterop.ts
@@ -2674,11 +2674,14 @@ export async function createLayer(layerObject: any, wrap?: boolean | null, viewI
 
             break;
         case 'open-street-map':
-            let openStreetMapLayer: OpenStreetMapLayer;
+            let openStreetMapLayer: WebTileLayer;
             if (hasValue(layerObject.urlTemplate)) {
-                openStreetMapLayer = new OpenStreetMapLayer({
+                openStreetMapLayer = new WebTileLayer({
                     urlTemplate: layerObject.urlTemplate
                 });
+                copyValuesIfExists(new OpenStreetMapLayer(), openStreetMapLayer,
+                    'subDomains', 'blendMode', 'copyright', 'maxScale', 'minScale', 'fullExtent'
+                )
             } else if (hasValue(layerObject.portalItem)) {
                 let portalItem = buildJsPortalItem(layerObject.portalItem);
                 openStreetMapLayer = new OpenStreetMapLayer({ portalItem: portalItem });


### PR DESCRIPTION
### Resolve OpenStreetMapLayer urlTemplate Error with WebTileLayer

#### Issue
The ArcGIS JS API core throws a `"Cannot assign to read-only property 'urlTemplate'"` error when setting a custom `urlTemplate` on `OpenStreetMapLayer`, even in the constructor. This appears to be an API limitation.

#### Fix
This PR switches to `WebTileLayer` for the `open-street-map` case when a custom `urlTemplate` is provided, then copies relevant properties (`subDomains`, `blendMode`, `copyright`, `maxScale`, `minScale`, `fullExtent`) from an `OpenStreetMapLayer` instance to maintain consistent behavior. While the root issue lies in the ArcGIS JS API, this approach effectively resolves it for the wrapper.

#### Notes
Tested and works with custom tile sources (e.g., offline proxies). No functionality is lost.