### PR TITLE
update project files and readme

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <CoreVersion>4.0.0.0-beta-8</CoreVersion>
+    <CoreVersion>4.0.0.0-beta-9</CoreVersion>
   </PropertyGroup>
 </Project>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -81,6 +81,14 @@ Or for the Pro version with additional features:
 ```
 
 > **Note:** *.NET 9 can cause __very slow__ build times due to its new static asset compression. If you need faster builds, we recommend staying on .NET 8 for now, and using a global.json file to pin your SDK build version to .NET 8. See our [open request for a fix here](https://github.com/dotnet/aspnetcore/issues/59014).*
+>
+> *If you decide to stay with .NET 9, we suggest adding the following line to your `csproj` file to disable the new compression feature:*
+>
+> ```xml
+>    <PropertyGroup>
+>        <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>
+>    </PropertyGroup>
+> ```
 
 ## 🏁 Getting Started
 

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Server/dymaptic.GeoBlazor.Core.Sample.Server.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Server/dymaptic.GeoBlazor.Core.Sample.Server.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <UserSecretsId>ef66ef9c-9152-4e73-83b0-b8e00cc0f646</UserSecretsId>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <CompressionEnabled Condition="$(Configuration) == 'DEBUG'">false</CompressionEnabled>
+        <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.ServerOAuth/dymaptic.GeoBlazor.Core.Sample.ServerOAuth.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.ServerOAuth/dymaptic.GeoBlazor.Core.Sample.ServerOAuth.csproj
@@ -5,6 +5,7 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>8cc29e4d-db60-4432-bdd1-81b5fd050e1b</UserSecretsId>
+        <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/dymaptic.GeoBlazor.Core.Sample.Shared.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/dymaptic.GeoBlazor.Core.Sample.Shared.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>
     </PropertyGroup>
 
 

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Wasm/dymaptic.GeoBlazor.Core.Sample.Wasm.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Wasm/dymaptic.GeoBlazor.Core.Sample.Wasm.csproj
@@ -2,7 +2,9 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.WasmOAuth/dymaptic.GeoBlazor.Core.Sample.WasmOAuth.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.WasmOAuth/dymaptic.GeoBlazor.Core.Sample.WasmOAuth.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
+        <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.WebApp.Client/dymaptic.GeoBlazor.Core.Sample.WebApp.Client.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.WebApp.Client/dymaptic.GeoBlazor.Core.Sample.WebApp.Client.csproj
@@ -6,6 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
         <StaticWebAssetProjectMode>Default</StaticWebAssetProjectMode>
+        <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.WebApp/dymaptic.GeoBlazor.Core.Sample.WebApp.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.WebApp/dymaptic.GeoBlazor.Core.Sample.WebApp.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>8fd6e776-4434-4649-b202-09b0c3b479f5</UserSecretsId>
-        <CompressionEnabled Condition="$(Configuration) == 'DEBUG'">false</CompressionEnabled>
+        <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/dymaptic.GeoBlazor.Core/ReadMe.md
+++ b/src/dymaptic.GeoBlazor.Core/ReadMe.md
@@ -1,35 +1,10 @@
-﻿<style>
-   #geoblazor-logo { 
-      background-color: #5D2E8E; 
-      padding: 1rem; 
-      border-radius: 1rem; 
-   }
+﻿# GeoBlazor
 
-   #pro-link {
-      background-color: #d6d6d6;
-      padding: 1rem;
-      border-radius: 1rem;
-      width: 300px;
-   }
-</style>
-
-<p style="text-align: center;">
-  <img id="geoblazor-logo" src="./gb_white_text_300px.png" alt="GeoBlazor" width="300">
-</p>
-
-<p style="text-align: center;">
-  <b>The premier mapping solution for Asp.NET Core Blazor applications.</b>
-</p>
+## The premier mapping solution for Asp.NET Core Blazor applications.
 
 GeoBlazor brings the power of the ArcGIS Maps SDK for JavaScript into your Blazor applications with 100% C# code - no JavaScript required. Create beautiful, interactive maps with industry-leading geospatial capabilities while maintaining a pure .NET development experience.
 
-<p style="text-align: center;">
-   <em>
-      <a href="https://www.nuget.org/packages/dymaptic.GeoBlazor.Pro">
-         <img id="pro-link" alt="GeoBlazor Pro" src="./Go-GeoBlazor-Pro.png" />
-      </a>
-   </em>
-</p>
+[Go GeoBlazor Pro](https://www.nuget.org/packages/dymaptic.GeoBlazor.Pro)
 
 [![Build](https://img.shields.io/github/actions/workflow/status/dymaptic/GeoBlazor/main-release-build.yml?logo=github)](https://github.com/dymaptic/GeoBlazor/actions/workflows/main-release-build.yml)
 [![Issues](https://img.shields.io/github/issues/dymaptic/GeoBlazor?logo=github)](https://github.com/dymaptic/GeoBlazor/issues)
@@ -80,6 +55,14 @@ Or for the Pro version with additional features:
 ```
 
 > **Note:** *.NET 9 can cause __very slow__ build times due to its new static asset compression. If you need faster builds, we recommend staying on .NET 8 for now, and using a global.json file to pin your SDK build version to .NET 8. See our [open request for a fix here](https://github.com/dotnet/aspnetcore/issues/59014).*
+> 
+> *If you decide to stay with .NET 9, we suggest adding the following line to your `csproj` file to disable the new compression feature:*
+> 
+> ```xml
+>    <PropertyGroup>
+>        <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>
+>    </PropertyGroup>
+> ```
 
 ## 🏁 Getting Started
 

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Server/dymaptic.GeoBlazor.Core.Test.Blazor.Server.csproj
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Server/dymaptic.GeoBlazor.Core.Test.Blazor.Server.csproj
@@ -6,7 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>f4d3c64c-5267-42db-94c9-e0ebec987571</UserSecretsId>
         <RootNamespace>dymaptic.GeoBlazor.Core.Test.Blazor.Server</RootNamespace>
-        <CompressionEnabled Condition="$(Configuration) == 'DEBUG'">false</CompressionEnabled>
+        <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/dymaptic.GeoBlazor.Core.Test.Blazor.Shared.csproj
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/dymaptic.GeoBlazor.Core.Test.Blazor.Shared.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
+        <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>
     </PropertyGroup>
 
 

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Wasm/dymaptic.GeoBlazor.Core.Test.Blazor.Wasm.csproj
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Wasm/dymaptic.GeoBlazor.Core.Test.Blazor.Wasm.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <CompressionEnabled Condition="$(Configuration) == 'DEBUG'">false</CompressionEnabled>
+    <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/dymaptic.GeoBlazor.Core.Test/dymaptic.GeoBlazor.Core.Test.csproj
+++ b/test/dymaptic.GeoBlazor.Core.Test/dymaptic.GeoBlazor.Core.Test.csproj
@@ -2,10 +2,10 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-
+        <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-
         <UserSecretsId>ab458f16-6a20-47f6-bce7-62a029ccefa3</UserSecretsId>
+        <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Closes #402 

- Adds `CompressionEnabled = false` to `Debug` mode for all test and sample projects and libraries. This speeds up build times, which improves the development cycle. Some of them had the inverse setting (`Debug == true` instead of `Release != true`), so I updated these to be consistent.
- Added the `CompressionEnabled` setting as a tip to the two `ReadMe.md` files.
- In the internal `src/dymaptic.GeoBlazor.Core/ReadMe.md` file, I removed the html header material, because it was not being rendered correctly on NuGet.org when packaged. I left this material in the root `ReadMe.md` for GitHub.