### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/dev-pr-build.yml
+++ b/.github/workflows/dev-pr-build.yml
@@ -33,14 +33,25 @@ jobs:
       run: |
         ./bumpVersion.ps1
         
+    - name: Restore dependencies
+      run: dotnet restore ./src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
+        
     - name: Update NPM
       uses: actions/setup-node@v4
       with:
         node-version: '>=22.11.0'
         check-latest: 'true'
-    
-    - name: Restore dependencies
-      run: dotnet restore ./src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
+          
+    # This step will install the NPM dependencies and build the JS files with ESBuild
+    # The assetCopy.ps1 script will copy the ArcGIS Asset files to the correct location
+    - name: Copy Assets and Generate JS
+      shell: pwsh
+      run: |
+        cd ./src/dymaptic.GeoBlazor.Core
+        npm install
+        npm run releaseBuild
+        ./assetCopy.ps1
+        cd ../..
     
     - name: Build Core
       run: dotnet build ./src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj --no-restore /p:OptOutFromCoreEsBuild=false /p:GenerateDocs=true /p:UpdateTemplates=true -c Release

--- a/.github/workflows/main-release-build.yml
+++ b/.github/workflows/main-release-build.yml
@@ -27,11 +27,13 @@ jobs:
       with:
         nuget-version: 'latest'
 
+      # This script queries nuget for the current version, and increments the build number by one
     - name: Bump Version
       shell: pwsh
       run: |
         ./bumpVersion.ps1 -publish
         
+      # Loads all NuGet dependencies
     - name: Restore dependencies
       run: dotnet restore ./src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
 
@@ -41,6 +43,8 @@ jobs:
         node-version: '>=22.11.0'
         check-latest: 'true'
     
+      # This step will install the NPM dependencies and build the JS files with ESBuild
+      # The assetCopy.ps1 script will copy the ArcGIS Asset files to the correct location
     - name: Copy Assets and Generate JS
       shell: pwsh
       run: |
@@ -50,24 +54,29 @@ jobs:
         ./assetCopy.ps1
         cd ../..
     
+      # OptOutFromCoreEsBuild - we've already built the JS files in the previous step
+      # GenerateDocs - this will generate the XML for intellisense in the Nuget package
+      # This step also creates the NuGet package
     - name: Build Core
-      run: dotnet build ./src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj --no-restore /p:OptOutFromCoreEsBuild=true /p:GenerateDocs=false -c Release
+      run: dotnet build ./src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj --no-restore /p:OptOutFromCoreEsBuild=true /p:GenerateDocs=true -c Release
     
+      # xmllint is a dependency of the copy steps below
     - name: Install xmllint
       shell: bash
       run: |
         sudo apt update
         sudo apt install -y libxml2-utils
     
+      # This step will copy the version number from the Directory.Build.props file to an environment variable
     - name: Copy Build Versions
       run: |
         CORE_VERSION=$(xmllint --xpath "//PropertyGroup/CoreVersion/text()" ./Directory.Build.props)
         echo "CORE_VERSION=$CORE_VERSION" >> $GITHUB_ENV
-    
+
+      # Verify that the JS files are present in the output directory
     - name: Verify JS Files and Assets
       shell: pwsh
       continue-on-error: false
-      # Verify that the JS files are present in the output directory
       run: |
         $nugetPath = "./src/dymaptic.GeoBlazor.Core/bin/Release/dymaptic.GeoBlazor.Core.${{env.CORE_VERSION}}.nupkg"
         $extractPath = "./src/dymaptic.GeoBlazor.Core/bin/Release/extract"
@@ -83,6 +92,8 @@ jobs:
         }
         
     - name: Add & Commit
+      # Only run this step if the branch is main
+      if: github.ref == 'refs/heads/main'
       continue-on-error: true
       run: |
         git config --global user.name "dymaptic"
@@ -91,6 +102,7 @@ jobs:
         git commit -m "Pipeline Build Commit of Nuget Version Bump"
         git push
         
+      # This step will copy the PR description to an environment variable
     - name: Copy PR Release Notes
       run: |
         PR_DESCRIPTION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
@@ -101,7 +113,16 @@ jobs:
         echo "$DESC_PLUS_EOF" >> $GITHUB_ENV
         echo "EOF" >> $GITHUB_ENV
     
+      # Copies the nuget package to the artifacts directory
+    - name: Upload nuget artifact
+      uses: actions/upload-artifact@v4.6.0
+      with:
+        name: .core-nuget
+        path: ./src/dymaptic.GeoBlazor.Core/bin/Release/dymaptic.GeoBlazor.Core.*.nupkg
+    
+      # Creates a GitHub Release based on the Version and the PR description
     - name: Create Release
+      # Only run this step if the branch is main
       if: github.ref == 'refs/heads/main'
       uses: softprops/action-gh-release@v1
       with:
@@ -111,14 +132,10 @@ jobs:
         prerelease: false
         files: |
           ./src/dymaptic.GeoBlazor.Core/bin/Release/dymaptic.GeoBlazor.Core.*.nupkg
-    
-    - name: Upload nuget artifact
-      uses: actions/upload-artifact@v4.6.0
-      with:
-        name: .core-nuget
-        path: ./src/dymaptic.GeoBlazor.Core/bin/Release/dymaptic.GeoBlazor.Core.*.nupkg
   
+  # This step will publish the Pro NuGet package to NuGet.org
   nuget-push:
+    # Only run this step if the branch is main
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <CoreVersion>4.0.0.0</CoreVersion>
+    <CoreVersion>4.0.0.0-beta-9.2</CoreVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <CoreVersion>4.0.0.0-beta-12</CoreVersion>
+    <CoreVersion>4.0.0.0</CoreVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <CoreVersion>4.0.0.0-beta-9.2</CoreVersion>
+    <CoreVersion>4.0.0.0-beta-10</CoreVersion>
   </PropertyGroup>
 </Project>

--- a/bumpVersion.ps1
+++ b/bumpVersion.ps1
@@ -1,4 +1,6 @@
 param([switch]$publish, [string]$test)
+# example: .\bumpVersion.ps1 -test 1.2.3 ---- would test the version bump from 1.2.3 to 1.2.4
+# example: .\bumpVersion.ps1 -publish ---- compares against nuget, increments the 3rd number by one
 
 ## Read Directory.Build.Props to get the version number and increment it
 $DirectoryBuildPropsPath = Join-Path -Path $PSScriptRoot "./Directory.Build.props"


### PR DESCRIPTION
- `bumpVersion.ps1`: The `nuget search` command here apparently uses an old .NET Framework version of NuGet, which isn't supported on the GH runners. I replaced it with a web API query to find the latest published version of the package.
- `dev-pr-build.yml`: I'm not sure why I took the `npm build` step out of the dev build pipeline, but I think that was a bad idea, we want to know at PR time if we break something in the TypeScript layer. I've added it back in here. It's copied straight from the main release build, so it should be good to go.
- `main-release-build.yml`
   - Added comments for clarity
   - Flipped `GenerateDocs` to `true`. I'm pretty sure when we had set this to `false` in the past it would cause missing Intellisense in the NuGet packages.
   - I tested this on the `gh-action-test` branch`, and got it to pass, except for the parts that actually push to NuGet and create the Release. This helped me find the issues with the `bumpVersion` script.