### PR TITLE
release cleanup

### DIFF
--- a/.github/workflows/main-release-build.yml
+++ b/.github/workflows/main-release-build.yml
@@ -91,17 +91,6 @@ jobs:
             Exit 1
         }
         
-    - name: Add & Commit
-      # Only run this step if the branch is main
-      if: github.ref == 'refs/heads/main'
-      continue-on-error: true
-      run: |
-        git config --global user.name "dymaptic"
-        git config --global user.email "geoblazor@dymaptic.com"
-        git add .
-        git commit -m "Pipeline Build Commit of Nuget Version Bump"
-        git push
-        
       # This step will copy the PR description to an environment variable
     - name: Copy PR Release Notes
       run: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <CoreVersion>4.0.0.5</CoreVersion>
+    <CoreVersion>4.0.0.6</CoreVersion>
   </PropertyGroup>
 </Project>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Server/dymaptic.GeoBlazor.Core.Sample.Server.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Server/dymaptic.GeoBlazor.Core.Sample.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <UserSecretsId>ef66ef9c-9152-4e73-83b0-b8e00cc0f646</UserSecretsId>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.ServerOAuth/dymaptic.GeoBlazor.Core.Sample.ServerOAuth.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.ServerOAuth/dymaptic.GeoBlazor.Core.Sample.ServerOAuth.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>8cc29e4d-db60-4432-bdd1-81b5fd050e1b</UserSecretsId>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/dymaptic.GeoBlazor.Core.Sample.Shared.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/dymaptic.GeoBlazor.Core.Sample.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>
     </PropertyGroup>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Wasm/dymaptic.GeoBlazor.Core.Sample.Wasm.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Wasm/dymaptic.GeoBlazor.Core.Sample.Wasm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.WasmOAuth/dymaptic.GeoBlazor.Core.Sample.WasmOAuth.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.WasmOAuth/dymaptic.GeoBlazor.Core.Sample.WasmOAuth.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.WebApp.Client/dymaptic.GeoBlazor.Core.Sample.WebApp.Client.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.WebApp.Client/dymaptic.GeoBlazor.Core.Sample.WebApp.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.WebApp/dymaptic.GeoBlazor.Core.Sample.WebApp.csproj
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.WebApp/dymaptic.GeoBlazor.Core.Sample.WebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>8fd6e776-4434-4649-b202-09b0c3b479f5</UserSecretsId>

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Server/dymaptic.GeoBlazor.Core.Test.Blazor.Server.csproj
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Server/dymaptic.GeoBlazor.Core.Test.Blazor.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>f4d3c64c-5267-42db-94c9-e0ebec987571</UserSecretsId>

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/dymaptic.GeoBlazor.Core.Test.Blazor.Shared.csproj
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/dymaptic.GeoBlazor.Core.Test.Blazor.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Wasm/dymaptic.GeoBlazor.Core.Test.Blazor.Wasm.csproj
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Wasm/dymaptic.GeoBlazor.Core.Test.Blazor.Wasm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <CompressionEnabled Condition="$(Configuration) != 'RELEASE'">false</CompressionEnabled>

--- a/test/dymaptic.GeoBlazor.Core.Test/dymaptic.GeoBlazor.Core.Test.csproj
+++ b/test/dymaptic.GeoBlazor.Core.Test/dymaptic.GeoBlazor.Core.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <UserSecretsId>ab458f16-6a20-47f6-bce7-62a029ccefa3</UserSecretsId>


### PR DESCRIPTION
- Releasing the samples and templates was a challenge due to the combination of .net8 and .net9 in our repository, so this PR is moving all the samples and tests to .net9, leaving only the library itself targeting .net8 for backwards compatibility.
- Also removed the attempt to commit the published build version back to `main`. Since it's a protected branch, that fails. However, the way `bumpVersion.ps1` is written, this doesn't matter. The next time we release, it is going to query NuGet and bump to 4.0.1, unless we manually set it higher than that in the meantime.