### PR TITLE
Fix for mismatched components on deserialization copying properties

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <CoreVersion>4.0.1.1</CoreVersion>
+    <CoreVersion>4.0.1.2</CoreVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Closes #428 

- I noticed a potential inefficiency with repeated calls to `GetType()` in `MapComponent`, which could be expensive, so I added the `MapComponentType` property to ensure that is only loaded once per component. This is most of the lines changed in the file.
- The actual logic change is on line 716, where we now validate that old and new components are the same exact type before trying to copy properties from one to the other. This lets it fall through to the `else` of just copying in what ArcGIS returns if they don't match.

I will open a PR in the Pro repository with a Unit test using the TimeSliderWidget. We don't have a lot of examples of this type of inheritance in properties, so I don't think this bug is widespread and don't have any examples I can think of in Core.