### PR TITLE
Fix light mode sample css for older samples

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <CoreVersion>4.0.1.1</CoreVersion>
+    <CoreVersion>4.0.1.2</CoreVersion>
   </PropertyGroup>
 </Project>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Drawing.razor.css
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Drawing.razor.css
@@ -3,10 +3,6 @@
     flex-wrap: wrap;
 }
 
-.form-group .table {
-    color: white;
-}
-
 .draw-label {
     display: block;
     font-size: 1.5rem;

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Events.razor.css
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/Events.razor.css
@@ -10,20 +10,6 @@
     overflow-x: hidden;
 }
 
-.form-group {
-    border: 1px solid black;
-    padding: 0.5rem 2rem;
-    background-image: linear-gradient(180deg, var(--geoblazor-tertiary) 0%, var(--geoblazor-primary) 100%);
-    margin: 1rem;
-    color: white;
-    min-width: 30rem;
-    height: 10rem;
-}
-
-.form-group .table {
-    color: white;
-}
-
 .react-label {
     display: block;
     font-size: 1.3rem;

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/HitTests.razor.css
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/HitTests.razor.css
@@ -1,7 +1,6 @@
 ﻿#info {
-    background-color: black;
+    background-color: var(--background-grey-1);
     opacity: 0.75;
-    color: orange;
     font-size: 18pt;
     padding: 8px;
 }

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ReactiveUtils.razor.css
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/ReactiveUtils.razor.css
@@ -8,19 +8,6 @@
     padding: 0.5rem;
     margin: 0.5rem;
 }
-
-.form-group {
-    border: 1px solid black;
-    padding: 0.5rem 2rem;
-    background-image: linear-gradient(180deg, var(--geoblazor-tertiary) 0%, var(--geoblazor-primary) 100%);
-    margin: 1rem;
-    color: white;
-}
-
-.form-group .table {
-    color: white;
-}
-
 .react-label {
     display: block;
     font-size: 1.3rem;


### PR DESCRIPTION
Closes #422

Removed older hard-coded `color` css settings that pre-dated our new light/dark theme for 4 samples:

- Events
- Reactive Utils
- Hit Tests
- Drawing (although I'm not sure this setting was actually being used)