### PR TITLE
fixing LocationService bug, adding support for single address string

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <CoreVersion>4.2.0.0-beta-6</CoreVersion>
+    <CoreVersion>4.2.0.0-beta-7</CoreVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CompressionEnabled Condition="$(Configuration) != 'RELEASE' OR $(EnableCompression) != 'true'">false</CompressionEnabled>
     <DefineConstants Condition="$(EnableCompression) == 'true'">$(DefineConstants);ENABLE_COMPRESSION</DefineConstants>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <CoreVersion>4.2.0.0-beta-7</CoreVersion>
+    <CoreVersion>4.2.0.0-beta-8</CoreVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CompressionEnabled Condition="$(Configuration) != 'RELEASE' OR $(EnableCompression) != 'true'">false</CompressionEnabled>
     <DefineConstants Condition="$(EnableCompression) == 'true'">$(DefineConstants);ENABLE_COMPRESSION</DefineConstants>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/LocationMethods.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.Shared/Pages/LocationMethods.razor
@@ -7,14 +7,14 @@
 <div class="form-group">
 
     <h2>Addresses To Locations method</h2>
-    <code>var locations =  _locations2 = await Location.AddressesToLocations([new Address("380 New York Street", "Redlands", "CA", "92373"), new Address("400 New York Street", "Redlands", "CA", "92373")]);</code>
+    <code>var locations = await Location.AddressesToLocations([new Address("380 New York Street", "Redlands", "CA", "92373"), new Address("400 New York Street", "Redlands", "CA", "92373")]);</code>
     <label>
 
         <button type="button" class="btn btn-primary" @onclick="AddressesToLocations">Addresses To Locations</button>
         <b>Address Candidates:</b>
         @foreach (var location in _locations2)
         {
-            <div>@location?.Address  @location?.Score</div>
+            <div>@location?.Address  @location?.Score - @location?.Location?.Latitude,@location?.Location?.Longitude</div>
         }
     </label>
 </div>
@@ -28,7 +28,7 @@
         <b>Address Candidates:</b>
         @foreach (var location in _locations1)
         {
-            <div>@location.Address  @location.Score</div>
+            <div>@location?.Address  @location?.Score - @location?.Location?.Latitude,@location?.Location?.Longitude</div>
         }
     </label>
 </div>

--- a/src/dymaptic.GeoBlazor.Core/Components/BookmarksViewModel.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/BookmarksViewModel.cs
@@ -1,44 +1,38 @@
 namespace dymaptic.GeoBlazor.Core.Components;
 
-public partial class BookmarksViewModel: MapComponent, IViewModel
+public partial class BookmarksViewModel : MapComponent, IViewModel
 {
-   // Add custom code to this file to override generated code
-   
-   /// <summary>
-   ///     This function provides the ability to override either the <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-MapView.html#goTo">MapView goTo()</a> or <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-SceneView.html#goTo">SceneView goTo()</a> methods.
-   ///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-support-GoTo.html#goToOverride">ArcGIS Maps SDK for JavaScript</a>
-   /// </summary>
-   [ArcGISProperty]
-   [Parameter]
-   [JsonIgnore]
-   [CodeGenerationIgnore]
-   public GoToOverride? GoToOverride { get; set; }
+    // Add custom code to this file to override generated code
 
-   /// <summary>
-   ///    JS-invokable method that triggers the <see cref = "GoToOverride"/> function.
-   ///     Should not be called by consuming code.
-   /// </summary>
-   [JSInvokable]
-   [CodeGenerationIgnore]
-   public async Task OnJsGoToOverride(IJSStreamReference jsStreamRef)
-   {
-      await using Stream stream = await jsStreamRef.OpenReadStreamAsync(1_000_000_000L);
-      await using MemoryStream ms = new();
-      await stream.CopyToAsync(ms);
-      ms.Seek(0, SeekOrigin.Begin);
-      byte[] encodedJson = ms.ToArray();
-      string json = Encoding.UTF8.GetString(encodedJson);
-      GoToOverrideParameters goToParameters = JsonSerializer.Deserialize<GoToOverrideParameters>(
-         json, GeoBlazorSerialization.JsonSerializerOptions)!;
-      if (GoToOverride is not null)
-      {
-         await GoToOverride.Invoke(goToParameters);
-      }
-   }
-    
-   /// <summary>
-   ///     A convenience property that signifies whether a custom <see cref="GoToOverride" /> function was registered.
-   /// </summary>
-   [CodeGenerationIgnore]
-   public bool HasGoToOverride => GoToOverride is not null;
+    /// <summary>
+    ///     This function provides the ability to override either the <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-MapView.html#goTo">MapView goTo()</a> or <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-SceneView.html#goTo">SceneView goTo()</a> methods.
+    ///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-support-GoTo.html#goToOverride">ArcGIS Maps SDK for JavaScript</a>
+    /// </summary>
+    [ArcGISProperty]
+    [Parameter]
+    [JsonIgnore]
+    [CodeGenerationIgnore]
+    public GoToOverride? GoToOverride { get; set; }
+
+    /// <summary>
+    ///    JS-invokable method that triggers the <see cref = "GoToOverride"/> function.
+    ///     Should not be called by consuming code.
+    /// </summary>
+    [JSInvokable]
+    [CodeGenerationIgnore]
+    public async Task OnJsGoToOverride(IJSStreamReference jsStreamRef)
+    {
+        GoToOverrideParameters? goToParameters = await jsStreamRef.ReadJsStreamReference<GoToOverrideParameters>();
+
+        if (GoToOverride is not null && goToParameters != null)
+        {
+            await GoToOverride.Invoke(goToParameters);
+        }
+    }
+
+    /// <summary>
+    ///     A convenience property that signifies whether a custom <see cref="GoToOverride" /> function was registered.
+    /// </summary>
+    [CodeGenerationIgnore]
+    public bool HasGoToOverride => GoToOverride is not null;
 }

--- a/src/dymaptic.GeoBlazor.Core/Components/CompassViewModel.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/CompassViewModel.cs
@@ -22,15 +22,8 @@ public partial class CompassViewModel: IViewModel
    [CodeGenerationIgnore]
    public async Task OnJsGoToOverride(IJSStreamReference jsStreamRef)
    {
-      await using Stream stream = await jsStreamRef.OpenReadStreamAsync(1_000_000_000L);
-      await using MemoryStream ms = new();
-      await stream.CopyToAsync(ms);
-      ms.Seek(0, SeekOrigin.Begin);
-      byte[] encodedJson = ms.ToArray();
-      string json = Encoding.UTF8.GetString(encodedJson);
-      GoToOverrideParameters goToParameters = JsonSerializer.Deserialize<GoToOverrideParameters>(
-         json, GeoBlazorSerialization.JsonSerializerOptions)!;
-      if (GoToOverride is not null)
+      GoToOverrideParameters? goToParameters = await jsStreamRef.ReadJsStreamReference<GoToOverrideParameters>();
+      if (GoToOverride is not null && goToParameters is not null)
       {
          await GoToOverride.Invoke(goToParameters);
       }

--- a/src/dymaptic.GeoBlazor.Core/Components/FeatureLayerView.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/FeatureLayerView.cs
@@ -10,7 +10,7 @@ public partial class FeatureLayerView : LayerView
     public FeatureLayerView()
     {
     }
-    
+
     /// <summary>
     ///     Constructor for use in C# code.
     /// </summary>
@@ -39,8 +39,7 @@ public partial class FeatureLayerView : LayerView
     ///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-layers-FeatureLayerViewMixin.html#maximumNumberOfFeaturesExceeded">ArcGIS Maps SDK for JavaScript</a>
     /// </param>
     [CodeGenerationIgnore]
-    internal FeatureLayerView(
-        LayerView layerView,
+    internal FeatureLayerView(LayerView layerView,
         AbortManager abortManager,
         FeatureEffect? featureEffect = null,
         FeatureFilter? filter = null,
@@ -59,13 +58,12 @@ public partial class FeatureLayerView : LayerView
         HighlightOptions = highlightOptions;
         MaximumNumberOfFeatures = maximumNumberOfFeatures;
         MaximumNumberOfFeaturesExceeded = maximumNumberOfFeaturesExceeded;
-#pragma warning restore BL0005    
+#pragma warning restore BL0005
     }
-    
+
     /// <inheritdoc />
     public override LayerType? Type => LayerType.Feature;
 
-    
     /// <summary>
     ///     Options for configuring the highlight.
     ///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-layers-HighlightLayerViewMixin.html#highlightOptions">ArcGIS Maps SDK for JavaScript</a>
@@ -74,7 +72,7 @@ public partial class FeatureLayerView : LayerView
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public HighlightOptions? HighlightOptions { get; set; }
-    
+
     /// <summary>
     ///     The maximum number of features that can be displayed at a time.
     ///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-layers-FeatureLayerViewMixin.html#maximumNumberOfFeatures">ArcGIS Maps SDK for JavaScript</a>
@@ -83,7 +81,7 @@ public partial class FeatureLayerView : LayerView
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public double? MaximumNumberOfFeatures { get; set; }
-    
+
     /// <summary>
     ///     Signifies whether the maximum number of features has been exceeded.
     ///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-layers-FeatureLayerViewMixin.html#maximumNumberOfFeaturesExceeded">ArcGIS Maps SDK for JavaScript</a>
@@ -104,12 +102,11 @@ public partial class FeatureLayerView : LayerView
         JsComponentReference ??= await CoreJsModule!.InvokeAsync<IJSObjectReference>("getJsComponent");
 
         if (JsComponentReference is null) return;
-        await JsComponentReference.InvokeVoidAsync(
-            "setFilter", CancellationTokenSource.Token, filter);
+
+        await JsComponentReference.InvokeVoidAsync("setFilter", CancellationTokenSource.Token, filter);
 
         Filter = filter;
     }
-
 
     /// <summary>
     ///  Sets the <see cref="FeatureEffect" /> for this view.
@@ -117,12 +114,10 @@ public partial class FeatureLayerView : LayerView
     /// <param name="featureEffect">
     /// The new effect (or null to clear) to apply to this view.
     /// </param>
-
     public async Task SetFeatureEffect(FeatureEffect? featureEffect)
     {
         JsComponentReference ??= await CoreJsModule!.InvokeAsync<IJSObjectReference>("getJsComponent");
-        await JsComponentReference.InvokeVoidAsync(
-            "setFeatureEffect", CancellationTokenSource.Token, featureEffect);
+        await JsComponentReference.InvokeVoidAsync("setFeatureEffect", CancellationTokenSource.Token, featureEffect);
 
         FeatureEffect = featureEffect;
     }
@@ -140,9 +135,11 @@ public partial class FeatureLayerView : LayerView
     public async Task<Handle> Highlight(ObjectId objectId)
     {
         JsComponentReference ??= await CoreJsModule!.InvokeAsync<IJSObjectReference>("getJsComponent");
+
         IJSObjectReference objectRef =
             await JsComponentReference.InvokeAsync<IJSObjectReference>("highlight",
                 CancellationTokenSource.Token, objectId);
+
         return new Handle(objectRef);
     }
 
@@ -162,17 +159,19 @@ public partial class FeatureLayerView : LayerView
     public async Task<Handle> Highlight(IReadOnlyCollection<ObjectId> objectIds)
     {
         JsComponentReference ??= await CoreJsModule!.InvokeAsync<IJSObjectReference>("getJsComponent");
+
         if (objectIds.Count == 0)
         {
             throw new ArgumentException("At least one ObjectID must be provided.", nameof(objectIds));
         }
+
         IJSObjectReference objectRef =
             await JsComponentReference.InvokeAsync<IJSObjectReference>("highlight",
                 CancellationTokenSource.Token, objectIds);
 
         return new Handle(objectRef);
     }
-    
+
     /// <summary>
     ///     Highlights the given feature(s).
     /// </summary>
@@ -190,22 +189,24 @@ public partial class FeatureLayerView : LayerView
     {
         JsComponentReference ??= await CoreJsModule!.InvokeAsync<IJSObjectReference>("getJsComponent");
         IJSObjectReference? objectRef;
+
         if (graphic.Attributes.TryGetValue("OBJECTID", out object? objectId))
         {
             objectRef = await JsComponentReference.InvokeAsync<IJSObjectReference>("highlight",
-                    CancellationTokenSource.Token, objectId);
+                CancellationTokenSource.Token, objectId);
         }
         else
         {
             objectRef = await JsComponentReference.InvokeAsync<IJSObjectReference?>("highlightByGeoBlazorId",
                 CancellationTokenSource.Token, graphic.Id);
-            
+
             if (objectRef is null)
             {
-                throw new InvalidOperationException("The graphic does not have an OBJECTID attribute and was not registered with GeoBlazor.");
+                throw new InvalidOperationException(
+                    "The graphic does not have an OBJECTID attribute and was not registered with GeoBlazor.");
             }
         }
-        
+
         return new Handle(objectRef);
     }
 
@@ -231,6 +232,7 @@ public partial class FeatureLayerView : LayerView
         {
             throw new ArgumentException("At least one graphic must be provided.", nameof(graphics));
         }
+
         if (graphics.First().Attributes.TryGetValue("OBJECTID", out _))
         {
             objectRef = await JsComponentReference.InvokeAsync<IJSObjectReference>("highlight",
@@ -240,10 +242,11 @@ public partial class FeatureLayerView : LayerView
         {
             objectRef = await JsComponentReference.InvokeAsync<IJSObjectReference?>("highlightByGeoBlazorIds",
                 CancellationTokenSource.Token, graphics.Select(g => g.Id).ToArray());
-            
+
             if (objectRef is null)
             {
-                throw new InvalidOperationException("The graphics do not have the OBJECTID attribute and were not registered with GeoBlazor.");
+                throw new InvalidOperationException(
+                    "The graphics do not have the OBJECTID attribute and were not registered with GeoBlazor.");
             }
         }
 
@@ -258,6 +261,7 @@ public partial class FeatureLayerView : LayerView
     public async Task<Query> CreateQuery()
     {
         JsComponentReference ??= await CoreJsModule!.InvokeAsync<IJSObjectReference>("getJsComponent");
+
         return await JsComponentReference.InvokeAsync<Query>("createQuery", CancellationTokenSource.Token);
     }
 
@@ -280,10 +284,14 @@ public partial class FeatureLayerView : LayerView
     [CodeGenerationIgnore]
     public async Task<ExtentQueryResult?> QueryExtent(Query query, CancellationToken cancellationToken = default)
     {
-        JsComponentReference ??= await CoreJsModule!.InvokeAsync<IJSObjectReference>("getJsComponent", cancellationToken);
+        JsComponentReference ??=
+            await CoreJsModule!.InvokeAsync<IJSObjectReference>("getJsComponent", cancellationToken);
         IJSObjectReference abortSignal = await AbortManager!.CreateAbortSignal(cancellationToken);
-        ExtentQueryResult? result = await JsComponentReference.InvokeAsync<ExtentQueryResult?>("queryExtent", cancellationToken, query, new { signal = abortSignal });
+
+        ExtentQueryResult? result = await JsComponentReference.InvokeAsync<ExtentQueryResult?>("queryExtent",
+            cancellationToken, query, new { signal = abortSignal });
         await AbortManager.DisposeAbortController(cancellationToken);
+
         return result;
     }
 
@@ -309,10 +317,14 @@ public partial class FeatureLayerView : LayerView
     [CodeGenerationIgnore]
     public async Task<int?> QueryFeatureCount(Query? query = null, CancellationToken cancellationToken = default)
     {
-        JsComponentReference ??= await CoreJsModule!.InvokeAsync<IJSObjectReference>("getJsComponent", cancellationToken);
+        JsComponentReference ??=
+            await CoreJsModule!.InvokeAsync<IJSObjectReference>("getJsComponent", cancellationToken);
         IJSObjectReference abortSignal = await AbortManager!.CreateAbortSignal(cancellationToken);
-        int? result = await JsComponentReference.InvokeAsync<int?>("queryFeatureCount", cancellationToken, query, new { signal = abortSignal });
+
+        int? result = await JsComponentReference.InvokeAsync<int?>("queryFeatureCount", cancellationToken, query,
+            new { signal = abortSignal });
         await AbortManager.DisposeAbortController(cancellationToken);
+
         return result;
     }
 
@@ -338,17 +350,20 @@ public partial class FeatureLayerView : LayerView
     [CodeGenerationIgnore]
     public async Task<FeatureSet?> QueryFeatures(Query? query = null, CancellationToken cancellationToken = default)
     {
-        JsComponentReference ??= await CoreJsModule!.InvokeAsync<IJSObjectReference>("getJsComponent", cancellationToken);
+        JsComponentReference ??=
+            await CoreJsModule!.InvokeAsync<IJSObjectReference>("getJsComponent", cancellationToken);
         IJSObjectReference abortSignal = await AbortManager!.CreateAbortSignal(cancellationToken);
         Guid queryId = Guid.NewGuid();
-        FeatureSet result = await JsComponentReference.InvokeAsync<FeatureSet>("queryFeatures", 
+
+        FeatureSet result = await JsComponentReference.InvokeAsync<FeatureSet>("queryFeatures",
             cancellationToken, query, new { signal = abortSignal }, DotNetComponentReference, queryId);
+
         if (_activeQueries.ContainsKey(queryId))
         {
-            result = result with { Features = _activeQueries[queryId]};
+            result = result with { Features = _activeQueries[queryId] };
             _activeQueries.Remove(queryId);
         }
-        
+
         foreach (Graphic graphic in result.Features!)
         {
             graphic.View = View;
@@ -357,6 +372,7 @@ public partial class FeatureLayerView : LayerView
         }
 
         await AbortManager.DisposeAbortController(cancellationToken);
+
         return result;
     }
 
@@ -364,23 +380,20 @@ public partial class FeatureLayerView : LayerView
     ///     Internal use callback from JavaScript
     /// </summary>
     [JSInvokable]
-    public async Task OnQueryFeaturesStreamCallback(IJSStreamReference streamReference, Guid queryId)
+    public async Task OnQueryFeaturesStreamCallback(IJSStreamReference jsStreamRef, Guid queryId)
     {
         try
         {
-            await using Stream stream = await streamReference.OpenReadStreamAsync(
-                Layer?.View?.QueryResultsMaxSizeLimit ?? 1_000_000_000L);
-            using var ms = new MemoryStream();
-            await stream.CopyToAsync(ms);
-            ms.Seek(0, SeekOrigin.Begin);
-            ProtoGraphicCollection collection = Serializer.Deserialize<ProtoGraphicCollection>(ms);
+            ProtoGraphicCollection? collection =
+                await jsStreamRef.ReadJsStreamReference<ProtoGraphicCollection>(Layer?.View?.QueryResultsMaxSizeLimit ??
+                    1_000_000_000L);
             Graphic[] graphics = collection?.Graphics.Select(g => g.FromSerializationRecord()).ToArray()!;
 
             _activeQueries[queryId] = graphics;
         }
         catch (Exception ex)
         {
-            throw new SerializationException("Error deserializing graphics from stream.", ex);   
+            throw new SerializationException("Error deserializing graphics from stream.", ex);
         }
     }
 
@@ -396,10 +409,14 @@ public partial class FeatureLayerView : LayerView
     [CodeGenerationIgnore]
     public async Task<ObjectId[]?> QueryObjectIds(Query query, CancellationToken cancellationToken = default)
     {
-        JsComponentReference ??= await CoreJsModule!.InvokeAsync<IJSObjectReference>("getJsComponent", cancellationToken);
+        JsComponentReference ??=
+            await CoreJsModule!.InvokeAsync<IJSObjectReference>("getJsComponent", cancellationToken);
         IJSObjectReference abortSignal = await AbortManager!.CreateAbortSignal(cancellationToken);
-        ObjectId[]? queryResult = await JsComponentReference.InvokeAsync<ObjectId[]?>("queryObjectIds", cancellationToken, query, new { signal = abortSignal });
+
+        ObjectId[]? queryResult = await JsComponentReference.InvokeAsync<ObjectId[]?>("queryObjectIds",
+            cancellationToken, query, new { signal = abortSignal });
         await AbortManager.DisposeAbortController(cancellationToken);
+
         return queryResult;
     }
 

--- a/src/dymaptic.GeoBlazor.Core/Components/FeaturesViewModel.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/FeaturesViewModel.cs
@@ -1,100 +1,94 @@
 namespace dymaptic.GeoBlazor.Core.Components;
 
-public partial class FeaturesViewModel: IViewModel
+public partial class FeaturesViewModel : IViewModel
 {
-   // Add custom code to this file to override generated code
-   /// <summary>
-   ///     This function provides the ability to override either the <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-MapView.html#goTo">MapView goTo()</a> or <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-SceneView.html#goTo">SceneView goTo()</a> methods.
-   ///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-support-GoTo.html#goToOverride">ArcGIS Maps SDK for JavaScript</a>
-   /// </summary>
-   [ArcGISProperty]
-   [Parameter]
-   [JsonIgnore]
-   [CodeGenerationIgnore]
-   public GoToOverride? GoToOverride { get; set; }
+    // Add custom code to this file to override generated code
+    /// <summary>
+    ///     This function provides the ability to override either the <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-MapView.html#goTo">MapView goTo()</a> or <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-SceneView.html#goTo">SceneView goTo()</a> methods.
+    ///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-support-GoTo.html#goToOverride">ArcGIS Maps SDK for JavaScript</a>
+    /// </summary>
+    [ArcGISProperty]
+    [Parameter]
+    [JsonIgnore]
+    [CodeGenerationIgnore]
+    public GoToOverride? GoToOverride { get; set; }
 
-   /// <summary>
-   ///    JS-invokable method that triggers the <see cref = "GoToOverride"/> function.
-   ///     Should not be called by consuming code.
-   /// </summary>
-   [JSInvokable]
-   [CodeGenerationIgnore]
-   public async Task OnJsGoToOverride(IJSStreamReference jsStreamRef)
-   {
-      await using Stream stream = await jsStreamRef.OpenReadStreamAsync(1_000_000_000L);
-      await using MemoryStream ms = new();
-      await stream.CopyToAsync(ms);
-      ms.Seek(0, SeekOrigin.Begin);
-      byte[] encodedJson = ms.ToArray();
-      string json = Encoding.UTF8.GetString(encodedJson);
-      GoToOverrideParameters goToParameters = JsonSerializer.Deserialize<GoToOverrideParameters>(
-         json, GeoBlazorSerialization.JsonSerializerOptions)!;
-      if (GoToOverride is not null)
-      {
-         await GoToOverride.Invoke(goToParameters);
-      }
-   }
-    
-   /// <summary>
-   ///     A convenience property that signifies whether a custom <see cref="GoToOverride" /> function was registered.
-   /// </summary>
-   [CodeGenerationIgnore]
-   public bool HasGoToOverride => GoToOverride is not null;
-   
-   /// <summary>
-   ///     Use this method to return feature(s) at a given screen location.
-   ///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Features-FeaturesViewModel.html#fetchFeatures">ArcGIS Maps SDK for JavaScript</a>
-   /// </summary>
-   /// <param name="screenPoint">
-   ///     An object representing a point on the screen. This point can be in either the
-   ///     <a href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-MapView.html#ScreenPoint">MapView</a> or
-   ///     <a href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-SceneView.html#ScreenPoint">SceneView</a>.
-   /// </param>
-   /// <param name="options">
-   ///     The <a href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Features.html#FetchFeaturesOptions">options</a> to pass into the <code>fetchFeatures</code> method.
-   /// </param>
-   /// <param name="cancellationToken">
-   ///     The CancellationToken to cancel an asynchronous operation.
-   /// </param>
-   [ArcGISMethod]
-   [CodeGenerationIgnore]
-   public async Task<FetchPopupFeaturesResult?> FetchFeatures(ScreenPoint screenPoint,
-      PopupFetchFeaturesOptions options,
-      CancellationToken cancellationToken = default)
-   {
-      if (JsComponentReference is null) return null;
-        
-      IJSObjectReference abortSignal = await AbortManager!.CreateAbortSignal(cancellationToken);
-      FetchPopupFeaturesResult? result = await JsComponentReference!.InvokeAsync<FetchPopupFeaturesResult?>(
-         "fetchFeatures", 
-         CancellationTokenSource.Token,
-         screenPoint,
-         new { options.Event, signal = abortSignal });
-                
-      await AbortManager.DisposeAbortController(cancellationToken);
-        
-      return result;
-   }
-   
-   /// <summary>
-   ///     <a target="_blank" href="https://docs.geoblazor.com/pages/classes/dymaptic.GeoBlazor.Core.Components.FeaturesViewModel.html#featuresviewmodelzoomto-method">GeoBlazor Docs</a>
-   ///     Sets the view to a given target.
-   ///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Features-FeaturesViewModel.html#zoomTo">ArcGIS Maps SDK for JavaScript</a>
-   /// </summary>
-   /// <param name="target">
-   /// </param>
-   /// <param name="options">
-   /// </param>
-   [ArcGISMethod]
-   [CodeGenerationIgnore]
-   public async Task<string?> ZoomTo(GoToTarget target,
-      GoToOptions options)
-   {
-      if (JsComponentReference is null) return null;
-        
-      return await JsComponentReference!.InvokeAsync<string?>(
-         "zoomTo", 
-         CancellationTokenSource.Token,
-         new { target, options });
-   }
+    /// <summary>
+    ///    JS-invokable method that triggers the <see cref = "GoToOverride"/> function.
+    ///     Should not be called by consuming code.
+    /// </summary>
+    [JSInvokable]
+    [CodeGenerationIgnore]
+    public async Task OnJsGoToOverride(IJSStreamReference jsStreamRef)
+    {
+        GoToOverrideParameters? goToParameters = await jsStreamRef.ReadJsStreamReference<GoToOverrideParameters>();
+
+        if (GoToOverride is not null && goToParameters is not null)
+        {
+            await GoToOverride.Invoke(goToParameters);
+        }
+    }
+
+    /// <summary>
+    ///     A convenience property that signifies whether a custom <see cref="GoToOverride" /> function was registered.
+    /// </summary>
+    [CodeGenerationIgnore]
+    public bool HasGoToOverride => GoToOverride is not null;
+
+    /// <summary>
+    ///     Use this method to return feature(s) at a given screen location.
+    ///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Features-FeaturesViewModel.html#fetchFeatures">ArcGIS Maps SDK for JavaScript</a>
+    /// </summary>
+    /// <param name="screenPoint">
+    ///     An object representing a point on the screen. This point can be in either the
+    ///     <a href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-MapView.html#ScreenPoint">MapView</a> or
+    ///     <a href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-SceneView.html#ScreenPoint">SceneView</a>.
+    /// </param>
+    /// <param name="options">
+    ///     The <a href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Features.html#FetchFeaturesOptions">options</a> to pass into the <code>fetchFeatures</code> method.
+    /// </param>
+    /// <param name="cancellationToken">
+    ///     The CancellationToken to cancel an asynchronous operation.
+    /// </param>
+    [ArcGISMethod]
+    [CodeGenerationIgnore]
+    public async Task<FetchPopupFeaturesResult?> FetchFeatures(ScreenPoint screenPoint,
+        PopupFetchFeaturesOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        if (JsComponentReference is null) return null;
+
+        IJSObjectReference abortSignal = await AbortManager!.CreateAbortSignal(cancellationToken);
+
+        FetchPopupFeaturesResult? result = await JsComponentReference!.InvokeAsync<FetchPopupFeaturesResult?>(
+            "fetchFeatures",
+            CancellationTokenSource.Token,
+            screenPoint,
+            new { options.Event, signal = abortSignal });
+
+        await AbortManager.DisposeAbortController(cancellationToken);
+
+        return result;
+    }
+
+    /// <summary>
+    ///     <a target="_blank" href="https://docs.geoblazor.com/pages/classes/dymaptic.GeoBlazor.Core.Components.FeaturesViewModel.html#featuresviewmodelzoomto-method">GeoBlazor Docs</a>
+    ///     Sets the view to a given target.
+    ///     <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Features-FeaturesViewModel.html#zoomTo">ArcGIS Maps SDK for JavaScript</a>
+    /// </summary>
+    /// <param name="target">
+    /// </param>
+    /// <param name="options">
+    /// </param>
+    [ArcGISMethod]
+    [CodeGenerationIgnore]
+    public async Task<string?> ZoomTo(GoToTarget target,
+        GoToOptions options)
+    {
+        if (JsComponentReference is null) return null;
+
+        return await JsComponentReference!.InvokeAsync<string?>("zoomTo",
+            CancellationTokenSource.Token,
+            new { target, options });
+    }
 }

--- a/src/dymaptic.GeoBlazor.Core/Components/HomeViewModel.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/HomeViewModel.cs
@@ -21,15 +21,8 @@ public partial class HomeViewModel : MapComponent, IViewModel
     [CodeGenerationIgnore]
     public async Task OnJsGoToOverride(IJSStreamReference jsStreamRef)
     {
-        await using Stream stream = await jsStreamRef.OpenReadStreamAsync(1_000_000_000L);
-        await using MemoryStream ms = new();
-        await stream.CopyToAsync(ms);
-        ms.Seek(0, SeekOrigin.Begin);
-        byte[] encodedJson = ms.ToArray();
-        string json = Encoding.UTF8.GetString(encodedJson);
-        GoToOverrideParameters goToParameters = JsonSerializer.Deserialize<GoToOverrideParameters>(
-            json, GeoBlazorSerialization.JsonSerializerOptions)!;
-        if (GoToOverride is not null)
+        GoToOverrideParameters? goToParameters = await jsStreamRef.ReadJsStreamReference<GoToOverrideParameters>();
+        if (GoToOverride is not null && goToParameters is not null)
         {
             await GoToOverride.Invoke(goToParameters);
         }

--- a/src/dymaptic.GeoBlazor.Core/Components/LocateViewModel.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/LocateViewModel.cs
@@ -21,15 +21,8 @@ public partial class LocateViewModel : MapComponent
     [CodeGenerationIgnore]
     public async Task OnJsGoToOverride(IJSStreamReference jsStreamRef)
     {
-        await using Stream stream = await jsStreamRef.OpenReadStreamAsync(1_000_000_000L);
-        await using MemoryStream ms = new();
-        await stream.CopyToAsync(ms);
-        ms.Seek(0, SeekOrigin.Begin);
-        byte[] encodedJson = ms.ToArray();
-        string json = Encoding.UTF8.GetString(encodedJson);
-        GoToOverrideParameters goToParameters = JsonSerializer.Deserialize<GoToOverrideParameters>(
-            json, GeoBlazorSerialization.JsonSerializerOptions)!;
-        if (GoToOverride is not null)
+        GoToOverrideParameters? goToParameters =  await jsStreamRef.ReadJsStreamReference<GoToOverrideParameters>();
+        if (GoToOverride is not null && goToParameters is not null)
         {
             await GoToOverride.Invoke(goToParameters);
         }
@@ -48,15 +41,7 @@ public partial class LocateViewModel : MapComponent
     [CodeGenerationIgnore]
     public async Task OnJsLocate(IJSStreamReference jsStreamRef)
     {
-        await using Stream stream = await jsStreamRef.OpenReadStreamAsync(1_000_000_000L);
-        await using MemoryStream ms = new();
-        await stream.CopyToAsync(ms);
-        ms.Seek(0, SeekOrigin.Begin);
-        byte[] encodedJson = ms.ToArray();
-        string json = Encoding.UTF8.GetString(encodedJson);
-        LocateViewModelLocateEvent locateEvent = 
-            JsonSerializer.Deserialize<LocateViewModelLocateEvent>(json, 
-                GeoBlazorSerialization.JsonSerializerOptions)!;
+        LocateViewModelLocateEvent? locateEvent =  await jsStreamRef.ReadJsStreamReference<LocateViewModelLocateEvent>();
         View!.ExtentChangedInJs = true;
         await OnLocate.InvokeAsync(locateEvent);
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/LocationService.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/LocationService.cs
@@ -2188,6 +2188,33 @@ public class LocationService : LogicComponent
         return await streamRef.ReadJsStreamReference<List<AddressCandidate>>() ?? [];
     }
 
+    /// <summary>
+    ///     Converts a list of addresses to locations.
+    /// </summary>
+    /// <param name="url">
+    ///     URL to the ArcGIS Server REST resource that represents a locator service.
+    /// </param>
+    /// <param name="addresses">
+    ///     A list of addresses to be converted to locations. The addresses can be specified as a JSON object or an array of JSON objects.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    /// </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    /// </param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="outSpatialReference">
+    ///     The spatial reference of the output geometries. If not specified, the output geometries are in the spatial reference of the input geometries when performing a reverse geocode and in the default spatial reference returned by the service if finding locations by address.
+    /// </param>
+    /// <param name="requestOptions">
+    ///     Additional options to be used for the data request
+    /// </param>
+    /// <param name="addressSearchStringParameterName">
+    ///     The name of the single line address field, defaults to SearchString.
+    /// </param>
     public async Task<List<AddressCandidate>> AddressesToLocations(string url, object addresses,
         string? countryCode = null, List<string>? categories = null, LocationType? locationType = null,
         SpatialReference? outSpatialReference = null, RequestOptions? requestOptions = null,

--- a/src/dymaptic.GeoBlazor.Core/Components/LocationService.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/LocationService.cs
@@ -1,5 +1,6 @@
 // ReSharper disable MethodOverloadWithOptionalParameter
 namespace dymaptic.GeoBlazor.Core.Components;
+
 /// <summary>
 ///     Represents a geocode service resource exposed by the ArcGIS Server REST API. It is used to generate candidates for an address. It is also used to generate batch results for a set of addresses.
 ///     Set the URL to the ArcGIS Server REST resource that represents a Locator service, for example:
@@ -20,6 +21,9 @@ public class LocationService : LogicComponent
 
     /// <inheritdoc/>
     protected override string ComponentName => nameof(LocationService);
+
+
+#region AddressesToLocationsWithAddress
 
     /// <summary>
     ///     Find address candidates for multiple input addresses.
@@ -141,7 +145,8 @@ public class LocationService : LogicComponent
         List<string>? categories, LocationType? locationType,
         SpatialReference? outSpatialReference, RequestOptions? requestOptions)
     {
-        return await AddressesToLocations(ESRIGeoLocationUrl, addresses, countryCode, categories, locationType, outSpatialReference, requestOptions);
+        return await AddressesToLocations(ESRIGeoLocationUrl, addresses, countryCode, categories, locationType,
+            outSpatialReference, requestOptions);
     }
 
     /// <summary>
@@ -263,14 +268,349 @@ public class LocationService : LogicComponent
         string? countryCode = null, List<string>? categories = null, LocationType? locationType = null,
         SpatialReference? outSpatialReference = null, RequestOptions? requestOptions = null)
     {
-        IJSStreamReference streamRef = await InvokeAsync<IJSStreamReference>("addressesToLocations", url, addresses, countryCode, categories, locationType, outSpatialReference, requestOptions);
+        IJSStreamReference streamRef = await InvokeAsync<IJSStreamReference>("addressesToLocations", url, addresses,
+            countryCode, categories, locationType, outSpatialReference, requestOptions);
         await using Stream stream = await streamRef.OpenReadStreamAsync(1_000_000_000L);
         using var ms = new MemoryStream();
         await stream.CopyToAsync(ms);
         ms.Seek(0, SeekOrigin.Begin);
         string json = Encoding.UTF8.GetString(ms.ToArray());
+
         return JsonSerializer.Deserialize<List<AddressCandidate>>(json, _jsonOptions) ?? new List<AddressCandidate>();
     }
+
+#endregion
+
+
+#region AddressesToLocationsWithString
+
+    /// <summary>
+    ///     Find address candidates for multiple input addresses.
+    ///     Uses the default ESRI geolocation service.
+    ///     Note: If using as API token: the token must have "Geocode (Stored)" enabled to get results
+    /// </summary>
+    /// <param name="addresses">The input addresses in the format supported by the geocode service. </param>
+    [CodeGenerationIgnore]
+    public async Task<List<AddressCandidate>> AddressesToLocations(List<string> addresses)
+    {
+        return await AddressesToLocations(ESRIGeoLocationUrl, addresses);
+    }
+
+    /// <summary>
+    ///     Find address candidates for multiple input addresses.
+    ///     Uses the default ESRI geolocation service.
+    ///     Note: If using as API token: the token must have "Geocode (Stored)" enabled to get results
+    /// </summary>
+    /// <param name="addresses">The input addresses in the format supported by the geocode service. </param>
+    /// <param name="countryCode">
+    ///     Limits the results to only search in the country provided. For example US for United States or SE for Sweden. Only applies to the World Geocode Service. See the World Geocoding Service documentation for more information.
+    /// </param>
+    public async Task<List<AddressCandidate>> AddressesToLocations(List<string> addresses, string? countryCode)
+    {
+        return await AddressesToLocations(ESRIGeoLocationUrl, addresses, countryCode);
+    }
+
+    /// <summary>
+    ///     Find address candidates for multiple input addresses.
+    ///     Uses the default ESRI geolocation service.
+    ///     Note: If using as API token: the token must have "Geocode (Stored)" enabled to get results
+    /// </summary>
+    /// <param name="addresses">The input addresses in the format supported by the geocode service. </param>
+    /// <param name="countryCode">
+    ///     Limits the results to only search in the country provided. For example US for United States or SE for Sweden. Only applies to the World Geocode Service. See the World Geocoding Service documentation for more information.
+    /// </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    public async Task<List<AddressCandidate>> AddressesToLocations(List<string> addresses, string? countryCode,
+        List<string>? categories)
+    {
+        return await AddressesToLocations(ESRIGeoLocationUrl, addresses, countryCode, categories);
+    }
+
+    /// <summary>
+    ///     Find address candidates for multiple input addresses.
+    ///     Uses the default ESRI geolocation service.
+    ///     Note: If using as API token: the token must have "Geocode (Stored)" enabled to get results
+    /// </summary>
+    /// <param name="addresses">The input addresses in the format supported by the geocode service. </param>
+    /// <param name="countryCode">
+    ///     Limits the results to only search in the country provided. For example US for United States or SE for Sweden. Only applies to the World Geocode Service. See the World Geocoding Service documentation for more information.
+    /// </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    public async Task<List<AddressCandidate>> AddressesToLocations(List<string> addresses, string? countryCode,
+        List<string>? categories, LocationType? locationType)
+    {
+        return await AddressesToLocations(ESRIGeoLocationUrl, addresses, countryCode, categories, locationType);
+    }
+
+    /// <summary>
+    ///     Find address candidates for multiple input addresses.
+    ///     Uses the default ESRI geolocation service.
+    ///     Note: If using as API token: the token must have "Geocode (Stored)" enabled to get results
+    /// </summary>
+    /// <param name="addresses">The input addresses in the format supported by the geocode service. </param>
+    /// <param name="countryCode">
+    ///     Limits the results to only search in the country provided. For example US for United States or SE for Sweden. Only applies to the World Geocode Service. See the World Geocoding Service documentation for more information.
+    /// </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="outSpatialReference">
+    ///     The spatial reference of the output geometries. If not specified, the output geometries are in the spatial reference of the input geometries when performing a reverse geocode and in the default spatial reference returned by the service if finding locations by address.
+    /// </param>
+    public async Task<List<AddressCandidate>> AddressesToLocations(List<string> addresses, string? countryCode,
+        List<string>? categories, LocationType? locationType,
+        SpatialReference? outSpatialReference)
+    {
+        return await AddressesToLocations(ESRIGeoLocationUrl, addresses, countryCode, categories, locationType,
+            outSpatialReference);
+    }
+
+    /// <summary>
+    ///     Find address candidates for multiple input addresses.
+    ///     Uses the default ESRI geolocation service.
+    ///     Note: If using as API token: the token must have "Geocode (Stored)" enabled to get results
+    /// </summary>
+    /// <param name="addresses">The input addresses in the format supported by the geocode service. </param>
+    /// <param name="countryCode">
+    ///     Limits the results to only search in the country provided. For example US for United States or SE for Sweden. Only applies to the World Geocode Service. See the World Geocoding Service documentation for more information.
+    /// </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="outSpatialReference">
+    ///     The spatial reference of the output geometries. If not specified, the output geometries are in the spatial reference of the input geometries when performing a reverse geocode and in the default spatial reference returned by the service if finding locations by address.
+    /// </param>
+    /// <param name="requestOptions">
+    ///     Additional options to be used for the data request
+    /// </param>
+    public async Task<List<AddressCandidate>> AddressesToLocations(List<string> addresses, string? countryCode,
+        List<string>? categories, LocationType? locationType,
+        SpatialReference? outSpatialReference, RequestOptions? requestOptions)
+    {
+        return await AddressesToLocations(ESRIGeoLocationUrl, addresses, countryCode, categories, locationType,
+            outSpatialReference, requestOptions);
+    }
+
+    /// <summary>
+    ///     Find address candidates for multiple input addresses.
+    ///     Uses the default ESRI geolocation service.
+    ///     Note: If using as API token: the token must have "Geocode (Stored)" enabled to get results
+    /// </summary>
+    /// <param name="addresses">The input addresses in the format supported by the geocode service. </param>
+    /// <param name="countryCode">
+    ///     Limits the results to only search in the country provided. For example US for United States or SE for Sweden. Only applies to the World Geocode Service. See the World Geocoding Service documentation for more information.
+    /// </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="outSpatialReference">
+    ///     The spatial reference of the output geometries. If not specified, the output geometries are in the spatial reference of the input geometries when performing a reverse geocode and in the default spatial reference returned by the service if finding locations by address.
+    /// </param>
+    /// <param name="requestOptions">
+    ///     Additional options to be used for the data request
+    /// </param>
+    /// <param name="addressSearchStringParameterName">
+    ///     the name of the single line address field, defaults to SearchString
+    /// </param>
+    public async Task<List<AddressCandidate>> AddressesToLocations(List<string> addresses, string? countryCode,
+        List<string>? categories, LocationType? locationType,
+        SpatialReference? outSpatialReference, RequestOptions? requestOptions, string? addressSearchStringParameterName)
+    {
+        return await AddressesToLocations(ESRIGeoLocationUrl, addresses, countryCode, categories, locationType,
+            outSpatialReference, requestOptions, addressSearchStringParameterName);
+    }
+
+    /// <summary>
+    ///     Find address candidates for multiple input addresses.
+    ///     Note: If using as API token: the token must have "Geocode (Stored)" enabled to get results
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="addresses">The input addresses in the format supported by the geocode service. </param>
+    public Task<List<AddressCandidate>> AddressesToLocations(string url, List<string> addresses)
+    {
+        return AddressesToLocations(url, addresses, null, null, null, null, null, null);
+    }
+
+    /// <summary>
+    ///     Find address candidates for multiple input addresses.
+    ///     Note: If using as API token: the token must have "Geocode (Stored)" enabled to get results
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="addresses">The input addresses in the format supported by the geocode service. </param>
+    /// <param name="countryCode">
+    ///     Limits the results to only search in the country provided. For example US for United States or SE for Sweden. Only applies to the World Geocode Service. See the World Geocoding Service documentation for more information.
+    /// </param>
+    public Task<List<AddressCandidate>> AddressesToLocations(string url, List<string> addresses,
+        string? countryCode)
+    {
+        return AddressesToLocations(url, addresses, countryCode, null, null, null, null, null);
+    }
+
+    /// <summary>
+    ///     Find address candidates for multiple input addresses.
+    ///     Note: If using as API token: the token must have "Geocode (Stored)" enabled to get results
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="addresses">The input addresses in the format supported by the geocode service. </param>
+    /// <param name="countryCode">
+    ///     Limits the results to only search in the country provided. For example US for United States or SE for Sweden. Only applies to the World Geocode Service. See the World Geocoding Service documentation for more information.
+    /// </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    public Task<List<AddressCandidate>> AddressesToLocations(string url, List<string> addresses,
+        string? countryCode, List<string>? categories)
+    {
+        return AddressesToLocations(url, addresses, countryCode, categories, null, null, null, null);
+    }
+
+    /// <summary>
+    ///     Find address candidates for multiple input addresses.
+    ///     Note: If using as API token: the token must have "Geocode (Stored)" enabled to get results
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="addresses">The input addresses in the format supported by the geocode service. </param>
+    /// <param name="countryCode">
+    ///     Limits the results to only search in the country provided. For example US for United States or SE for Sweden. Only applies to the World Geocode Service. See the World Geocoding Service documentation for more information.
+    /// </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    public Task<List<AddressCandidate>> AddressesToLocations(string url, List<string> addresses,
+        string? countryCode, List<string>? categories, LocationType? locationType)
+    {
+        return AddressesToLocations(url, addresses, countryCode, categories, locationType, null, null, null);
+    }
+
+    /// <summary>
+    ///     Find address candidates for multiple input addresses.
+    ///     Note: If using as API token: the token must have "Geocode (Stored)" enabled to get results
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="addresses">The input addresses in the format supported by the geocode service. </param>
+    /// <param name="countryCode">
+    ///     Limits the results to only search in the country provided. For example US for United States or SE for Sweden. Only applies to the World Geocode Service. See the World Geocoding Service documentation for more information.
+    /// </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="outSpatialReference">
+    ///     The spatial reference of the output geometries. If not specified, the output geometries are in the spatial reference of the input geometries when performing a reverse geocode and in the default spatial reference returned by the service if finding locations by address.
+    /// </param>
+    public Task<List<AddressCandidate>> AddressesToLocations(string url, List<string> addresses,
+        string? countryCode, List<string>? categories, LocationType? locationType,
+        SpatialReference? outSpatialReference)
+    {
+        return AddressesToLocations(url, addresses, countryCode, categories, locationType, outSpatialReference, null,
+            null);
+    }
+
+    /// <summary>
+    ///     Find address candidates for multiple input addresses.
+    ///     Note: If using as API token: the token must have "Geocode (Stored)" enabled to get results
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="addresses">The input addresses in the format supported by the geocode service. </param>
+    /// <param name="countryCode">
+    ///     Limits the results to only search in the country provided. For example US for United States or SE for Sweden. Only applies to the World Geocode Service. See the World Geocoding Service documentation for more information.
+    /// </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="outSpatialReference">
+    ///     The spatial reference of the output geometries. If not specified, the output geometries are in the spatial reference of the input geometries when performing a reverse geocode and in the default spatial reference returned by the service if finding locations by address.
+    /// </param>
+    /// <param name="requestOptions">
+    ///     Additional options to be used for the data request
+    /// </param>
+    public Task<List<AddressCandidate>> AddressesToLocations(string url, List<string> addresses,
+        string? countryCode, List<string>? categories, LocationType? locationType,
+        SpatialReference? outSpatialReference, RequestOptions? requestOptions)
+    {
+        return AddressesToLocations(url, addresses, countryCode, categories, locationType, outSpatialReference,
+            requestOptions, null);
+    }
+
+    /// <summary>
+    ///     Find address candidates for multiple input addresses.
+    ///     Note: If using as API token: the token must have "Geocode (Stored)" enabled to get results
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="addresses">The input addresses in the format supported by the geocode service. </param>
+    /// <param name="countryCode">
+    ///     Limits the results to only search in the country provided. For example US for United States or SE for Sweden. Only applies to the World Geocode Service. See the World Geocoding Service documentation for more information.
+    /// </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="outSpatialReference">
+    ///     The spatial reference of the output geometries. If not specified, the output geometries are in the spatial reference of the input geometries when performing a reverse geocode and in the default spatial reference returned by the service if finding locations by address.
+    /// </param>
+    /// <param name="requestOptions">
+    ///     Additional options to be used for the data request
+    /// </param>
+    /// <param name="addressSearchStringParameterName">
+    ///     the name of the single line address field, defaults to SearchString
+    /// </param>
+    public async Task<List<AddressCandidate>> AddressesToLocations(string url, List<string> addresses,
+        string? countryCode = null, List<string>? categories = null, LocationType? locationType = null,
+        SpatialReference? outSpatialReference = null, RequestOptions? requestOptions = null,
+        string? addressSearchStringParameterName = null)
+    {
+        IJSStreamReference streamRef = await InvokeAsync<IJSStreamReference>("addressesToLocations", url,
+            addresses, addressSearchStringParameterName, countryCode, categories, locationType,
+            outSpatialReference, requestOptions);
+        await using Stream stream = await streamRef.OpenReadStreamAsync(1_000_000_000L);
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms);
+        ms.Seek(0, SeekOrigin.Begin);
+        string json = Encoding.UTF8.GetString(ms.ToArray());
+
+        return JsonSerializer.Deserialize<List<AddressCandidate>>(json, _jsonOptions) ?? new List<AddressCandidate>();
+    }
+
+#endregion
+
+
+#region AddressToLocationsWithAddress
 
     /// <summary>
     ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
@@ -576,9 +916,11 @@ public class LocationService : LogicComponent
     public async Task<List<AddressCandidate>> AddressToLocations(Address address, List<string>? categories = null,
         string? countryCode = null, bool? forStorage = null, Point? location = null, LocationType? locationType = null,
         string? magicKey = null, int? maxLocations = null, List<string>? outFields = null,
-        SpatialReference? outSpatialReference = null, Extent? searchExtent = null, RequestOptions? requestOptions = null)
+        SpatialReference? outSpatialReference = null, Extent? searchExtent = null,
+        RequestOptions? requestOptions = null)
     {
-        return await AddressToLocations(ESRIGeoLocationUrl, address, categories, countryCode, forStorage, location, locationType, magicKey, maxLocations, outFields, outSpatialReference, searchExtent, requestOptions);
+        return await AddressToLocations(ESRIGeoLocationUrl, address, categories, countryCode, forStorage, location,
+            locationType, magicKey, maxLocations, outFields, outSpatialReference, searchExtent, requestOptions);
     }
 
     /// <summary>
@@ -588,7 +930,7 @@ public class LocationService : LogicComponent
     /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
     public Task<List<AddressCandidate>> AddressToLocations(string url, Address address)
     {
-        return AddressToLocations(url, address, null, null, null, 
+        return AddressToLocations(url, address, null, null, null,
             null, null, null, null, null, null, null, null);
     }
 
@@ -604,7 +946,7 @@ public class LocationService : LogicComponent
     public Task<List<AddressCandidate>> AddressToLocations(string url, Address address,
         List<string>? categories)
     {
-        return AddressToLocations(url, address, categories, null, null, 
+        return AddressToLocations(url, address, categories, null, null,
             null, null, null, null, null, null, null, null);
     }
 
@@ -624,7 +966,7 @@ public class LocationService : LogicComponent
     public Task<List<AddressCandidate>> AddressToLocations(string url, Address address,
         List<string>? categories, string? countryCode)
     {
-        return AddressToLocations(url, address, categories, countryCode, null, 
+        return AddressToLocations(url, address, categories, countryCode, null,
             null, null, null, null, null, null, null, null);
     }
 
@@ -645,7 +987,7 @@ public class LocationService : LogicComponent
     public Task<List<AddressCandidate>> AddressToLocations(string url, Address address,
         List<string>? categories, string? countryCode, bool? forStorage)
     {
-        return AddressToLocations(url, address, categories, countryCode, forStorage, 
+        return AddressToLocations(url, address, categories, countryCode, forStorage,
             null, null, null, null, null, null, null, null);
     }
 
@@ -667,7 +1009,7 @@ public class LocationService : LogicComponent
     public Task<List<AddressCandidate>> AddressToLocations(string url, Address address,
         List<string>? categories, string? countryCode, bool? forStorage, Point? location)
     {
-        return AddressToLocations(url, address, categories, countryCode, forStorage, 
+        return AddressToLocations(url, address, categories, countryCode, forStorage,
             location, null, null, null, null, null, null, null);
     }
 
@@ -693,7 +1035,7 @@ public class LocationService : LogicComponent
         List<string>? categories, string? countryCode, bool? forStorage, Point? location,
         LocationType? locationType)
     {
-        return AddressToLocations(url, address, categories, countryCode, forStorage, 
+        return AddressToLocations(url, address, categories, countryCode, forStorage,
             location, locationType, null, null, null, null, null, null);
     }
 
@@ -720,7 +1062,7 @@ public class LocationService : LogicComponent
         List<string>? categories, string? countryCode, bool? forStorage, Point? location,
         LocationType? locationType, string? magicKey)
     {
-        return AddressToLocations(url, address, categories, countryCode, forStorage, 
+        return AddressToLocations(url, address, categories, countryCode, forStorage,
             location, locationType, magicKey, null, null, null, null, null);
     }
 
@@ -748,7 +1090,7 @@ public class LocationService : LogicComponent
         List<string>? categories, string? countryCode, bool? forStorage, Point? location,
         LocationType? locationType, string? magicKey, int? maxLocations)
     {
-        return AddressToLocations(url, address, categories, countryCode, forStorage, 
+        return AddressToLocations(url, address, categories, countryCode, forStorage,
             location, locationType, magicKey, maxLocations, null, null, null, null);
     }
 
@@ -780,7 +1122,7 @@ public class LocationService : LogicComponent
         LocationType? locationType, string? magicKey, int? maxLocations,
         List<string>? outFields)
     {
-        return AddressToLocations(url, address, categories, countryCode, forStorage, 
+        return AddressToLocations(url, address, categories, countryCode, forStorage,
             location, locationType, magicKey, maxLocations, outFields, null, null, null);
     }
 
@@ -815,7 +1157,7 @@ public class LocationService : LogicComponent
         LocationType? locationType, string? magicKey, int? maxLocations,
         List<string>? outFields, SpatialReference? outSpatialReference)
     {
-        return AddressToLocations(url, address, categories, countryCode, forStorage, 
+        return AddressToLocations(url, address, categories, countryCode, forStorage,
             location, locationType, magicKey, maxLocations, outFields, outSpatialReference, null, null);
     }
 
@@ -853,8 +1195,8 @@ public class LocationService : LogicComponent
         LocationType? locationType, string? magicKey, int? maxLocations,
         List<string>? outFields, SpatialReference? outSpatialReference, Extent? searchExtent)
     {
-        return AddressToLocations(url, address, categories, countryCode, forStorage, 
-            location, locationType, magicKey, maxLocations, outFields, outSpatialReference, 
+        return AddressToLocations(url, address, categories, countryCode, forStorage,
+            location, locationType, magicKey, maxLocations, outFields, outSpatialReference,
             searchExtent, null);
     }
 
@@ -890,22 +1232,724 @@ public class LocationService : LogicComponent
     /// <param name="requestOptions">
     ///     Additional options to be used for the data request 
     /// </param>
+    /// 
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
     public async Task<List<AddressCandidate>> AddressToLocations(string url, Address address,
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         List<string>? categories = null, string? countryCode = null, bool? forStorage = null, Point? location = null,
         LocationType? locationType = null, string? magicKey = null, int? maxLocations = null,
-        List<string>? outFields = null,  SpatialReference? outSpatialReference = null, Extent? searchExtent = null,
+        List<string>? outFields = null, SpatialReference? outSpatialReference = null, Extent? searchExtent = null,
         RequestOptions? requestOptions = null)
     {
-        IJSStreamReference streamRef = await InvokeAsync<IJSStreamReference>("addressToLocations", url, address, categories, countryCode, forStorage, location, locationType, magicKey, maxLocations, outFields, outSpatialReference, searchExtent, requestOptions);
+        IJSStreamReference streamRef = await InvokeAsync<IJSStreamReference>("addressToLocations", url, address,
+            categories, countryCode, forStorage, location, locationType, magicKey, maxLocations, outFields,
+            outSpatialReference, searchExtent, requestOptions);
         await using Stream stream = await streamRef.OpenReadStreamAsync(1_000_000_000L);
         using var ms = new MemoryStream();
         await stream.CopyToAsync(ms);
         ms.Seek(0, SeekOrigin.Begin);
         string json = Encoding.UTF8.GetString(ms.ToArray());
+
         return JsonSerializer.Deserialize<List<AddressCandidate>>(json, _jsonOptions) ?? new List<AddressCandidate>();
     }
+
+#endregion
+
+
+#region AddressToLocationsWithString
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    ///     Uses the default ESRI geolocation service.
+    /// </summary>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    [CodeGenerationIgnore]
+    public Task<List<AddressCandidate>> AddressToLocations(string address)
+    {
+        return AddressToLocations(ESRIGeoLocationUrl, address);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    ///     Uses the default ESRI geolocation service.
+    /// </summary>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    public async Task<List<AddressCandidate>> AddressToLocations(string address, List<string>? categories)
+    {
+        return await AddressToLocations(ESRIGeoLocationUrl, address, categories);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    ///     Uses the default ESRI geolocation service.
+    /// </summary>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    public async Task<List<AddressCandidate>> AddressToLocations(string address, List<string>? categories,
+        string? countryCode)
+    {
+        return await AddressToLocations(ESRIGeoLocationUrl, address, categories, countryCode);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    ///     Uses the default ESRI geolocation service.
+    /// </summary>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    public async Task<List<AddressCandidate>> AddressToLocations(string address, List<string>? categories,
+        string? countryCode, bool? forStorage)
+    {
+        return await AddressToLocations(ESRIGeoLocationUrl, address, categories, countryCode, forStorage);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    ///     Uses the default ESRI geolocation service.
+    /// </summary>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    public async Task<List<AddressCandidate>> AddressToLocations(string address, List<string>? categories,
+        string? countryCode, bool? forStorage, Point? location)
+    {
+        return await AddressToLocations(ESRIGeoLocationUrl, address, categories, countryCode, forStorage, location);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    ///     Uses the default ESRI geolocation service.
+    /// </summary>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    public async Task<List<AddressCandidate>> AddressToLocations(string address, List<string>? categories,
+        string? countryCode, bool? forStorage, Point? location, LocationType? locationType)
+    {
+        return await AddressToLocations(ESRIGeoLocationUrl, address, categories, countryCode, forStorage, location,
+            locationType);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    ///     Uses the default ESRI geolocation service.
+    /// </summary>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="magicKey">A suggestLocations result ID (magicKey). Used to query for a specific results information.</param>
+    public async Task<List<AddressCandidate>> AddressToLocations(string address, List<string>? categories,
+        string? countryCode, bool? forStorage, Point? location, LocationType? locationType,
+        string? magicKey)
+    {
+        return await AddressToLocations(ESRIGeoLocationUrl, address, categories, countryCode, forStorage, location,
+            locationType, magicKey);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    ///     Uses the default ESRI geolocation service.
+    /// </summary>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="magicKey">A suggestLocations result ID (magicKey). Used to query for a specific results information.</param>
+    /// <param name="maxLocations">Maximum results to return from the query.</param>
+    public async Task<List<AddressCandidate>> AddressToLocations(string address, List<string>? categories,
+        string? countryCode, bool? forStorage, Point? location, LocationType? locationType,
+        string? magicKey, int? maxLocations)
+    {
+        return await AddressToLocations(ESRIGeoLocationUrl, address, categories, countryCode, forStorage, location,
+            locationType, magicKey, maxLocations);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    ///     Uses the default ESRI geolocation service.
+    /// </summary>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="magicKey">A suggestLocations result ID (magicKey). Used to query for a specific results information.</param>
+    /// <param name="maxLocations">Maximum results to return from the query.</param>
+    /// <param name="outFields">
+    ///     The list of fields included in the returned result set. This list is a comma delimited list of field names. If you specify the shape field in the list of return fields, it is ignored. For non-intersection addresses you can specify the candidate fields as defined in the geocode service. For intersection addresses you can specify the intersection candidate fields.
+    /// </param>
+    public async Task<List<AddressCandidate>> AddressToLocations(string address, List<string>? categories,
+        string? countryCode, bool? forStorage, Point? location, LocationType? locationType,
+        string? magicKey, int? maxLocations, List<string>? outFields)
+    {
+        return await AddressToLocations(ESRIGeoLocationUrl, address, categories, countryCode, forStorage, location,
+            locationType, magicKey, maxLocations, outFields);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    ///     Uses the default ESRI geolocation service.
+    /// </summary>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="magicKey">A suggestLocations result ID (magicKey). Used to query for a specific results information.</param>
+    /// <param name="maxLocations">Maximum results to return from the query.</param>
+    /// <param name="outFields">
+    ///     The list of fields included in the returned result set. This list is a comma delimited list of field names. If you specify the shape field in the list of return fields, it is ignored. For non-intersection addresses you can specify the candidate fields as defined in the geocode service. For intersection addresses you can specify the intersection candidate fields.
+    /// </param>
+    /// <param name="outSpatialReference">
+    ///     The spatial reference of the output geometries. If not specified, the output geometries are in the spatial reference of the input geometries when performing a reverse geocode and in the default spatial reference returned by the service if finding locations by address.
+    /// </param>
+    public async Task<List<AddressCandidate>> AddressToLocations(string address, List<string>? categories,
+        string? countryCode, bool? forStorage, Point? location, LocationType? locationType,
+        string? magicKey, int? maxLocations, List<string>? outFields,
+        SpatialReference? outSpatialReference)
+    {
+        return await AddressToLocations(ESRIGeoLocationUrl, address, categories, countryCode, forStorage, location,
+            locationType, magicKey, maxLocations, outFields, outSpatialReference);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    ///     Uses the default ESRI geolocation service.
+    /// </summary>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="magicKey">A suggestLocations result ID (magicKey). Used to query for a specific results information.</param>
+    /// <param name="maxLocations">Maximum results to return from the query.</param>
+    /// <param name="outFields">
+    ///     The list of fields included in the returned result set. This list is a comma delimited list of field names. If you specify the shape field in the list of return fields, it is ignored. For non-intersection addresses you can specify the candidate fields as defined in the geocode service. For intersection addresses you can specify the intersection candidate fields.
+    /// </param>
+    /// <param name="outSpatialReference">
+    ///     The spatial reference of the output geometries. If not specified, the output geometries are in the spatial reference of the input geometries when performing a reverse geocode and in the default spatial reference returned by the service if finding locations by address.
+    /// </param>
+    /// <param name="searchExtent">
+    ///     Defines the extent within which the geocode server will search. Requires ArcGIS Server version 10.1 or greater.
+    /// </param>
+    public async Task<List<AddressCandidate>> AddressToLocations(string address, List<string>? categories,
+        string? countryCode, bool? forStorage, Point? location, LocationType? locationType,
+        string? magicKey, int? maxLocations, List<string>? outFields,
+        SpatialReference? outSpatialReference, Extent? searchExtent)
+    {
+        return await AddressToLocations(ESRIGeoLocationUrl, address, categories, countryCode, forStorage, location,
+            locationType, magicKey, maxLocations, outFields, outSpatialReference, searchExtent);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    ///     Uses the default ESRI geolocation service.
+    /// </summary>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="magicKey">A suggestLocations result ID (magicKey). Used to query for a specific results information.</param>
+    /// <param name="maxLocations">Maximum results to return from the query.</param>
+    /// <param name="outFields">
+    ///     The list of fields included in the returned result set. This list is a comma delimited list of field names. If you specify the shape field in the list of return fields, it is ignored. For non-intersection addresses you can specify the candidate fields as defined in the geocode service. For intersection addresses you can specify the intersection candidate fields.
+    /// </param>
+    /// <param name="outSpatialReference">
+    ///     The spatial reference of the output geometries. If not specified, the output geometries are in the spatial reference of the input geometries when performing a reverse geocode and in the default spatial reference returned by the service if finding locations by address.
+    /// </param>
+    /// <param name="searchExtent">
+    ///     Defines the extent within which the geocode server will search. Requires ArcGIS Server version 10.1 or greater.
+    /// </param>
+    /// <param name="requestOptions">
+    ///     Additional options to be used for the data request 
+    /// </param>
+    public async Task<List<AddressCandidate>> AddressToLocations(string address, List<string>? categories = null,
+        string? countryCode = null, bool? forStorage = null, Point? location = null, LocationType? locationType = null,
+        string? magicKey = null, int? maxLocations = null, List<string>? outFields = null,
+        SpatialReference? outSpatialReference = null, Extent? searchExtent = null,
+        RequestOptions? requestOptions = null)
+    {
+        return await AddressToLocations(ESRIGeoLocationUrl, address, categories, countryCode, forStorage, location,
+            locationType, magicKey, maxLocations, outFields, outSpatialReference, searchExtent, requestOptions, null);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    ///     Uses the default ESRI geolocation service.
+    /// </summary>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="magicKey">A suggestLocations result ID (magicKey). Used to query for a specific results information.</param>
+    /// <param name="maxLocations">Maximum results to return from the query.</param>
+    /// <param name="outFields">
+    ///     The list of fields included in the returned result set. This list is a comma delimited list of field names. If you specify the shape field in the list of return fields, it is ignored. For non-intersection addresses you can specify the candidate fields as defined in the geocode service. For intersection addresses you can specify the intersection candidate fields.
+    /// </param>
+    /// <param name="outSpatialReference">
+    ///     The spatial reference of the output geometries. If not specified, the output geometries are in the spatial reference of the input geometries when performing a reverse geocode and in the default spatial reference returned by the service if finding locations by address.
+    /// </param>
+    /// <param name="searchExtent">
+    ///     Defines the extent within which the geocode server will search. Requires ArcGIS Server version 10.1 or greater.
+    /// </param>
+    /// <param name="requestOptions">
+    ///     Additional options to be used for the data request 
+    /// </param>
+    /// <param name="addressSearchStringParameterName">
+    ///     the name of the single line address field, defaults to SearchString
+    /// </param>
+    public async Task<List<AddressCandidate>> AddressToLocations(string address, List<string>? categories = null,
+        string? countryCode = null, bool? forStorage = null, Point? location = null, LocationType? locationType = null,
+        string? magicKey = null, int? maxLocations = null, List<string>? outFields = null,
+        SpatialReference? outSpatialReference = null, Extent? searchExtent = null,
+        RequestOptions? requestOptions = null, string? addressSearchStringParameterName = null)
+    {
+        return await AddressToLocations(ESRIGeoLocationUrl, address, categories, countryCode, forStorage, location,
+            locationType, magicKey, maxLocations, outFields, outSpatialReference, searchExtent, requestOptions,
+            addressSearchStringParameterName);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    public Task<List<AddressCandidate>> AddressToLocations(string url, string address)
+    {
+        return AddressToLocations(url, address, null, null, null,
+            null, null, null, null, null, null, null, null, null);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    public Task<List<AddressCandidate>> AddressToLocations(string url, string address,
+        List<string>? categories)
+    {
+        return AddressToLocations(url, address, categories, null, null,
+            null, null, null, null, null, null, null, null, null);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    public Task<List<AddressCandidate>> AddressToLocations(string url, string address,
+        List<string>? categories, string? countryCode)
+    {
+        return AddressToLocations(url, address, categories, countryCode, null,
+            null, null, null, null, null, null, null, null, null);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    public Task<List<AddressCandidate>> AddressToLocations(string url, string address,
+        List<string>? categories, string? countryCode, bool? forStorage)
+    {
+        return AddressToLocations(url, address, categories, countryCode, forStorage,
+            null, null, null, null, null, null, null, null, null);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    public Task<List<AddressCandidate>> AddressToLocations(string url, string address,
+        List<string>? categories, string? countryCode, bool? forStorage, Point? location)
+    {
+        return AddressToLocations(url, address, categories, countryCode, forStorage,
+            location, null, null, null, null, null, null, null, null);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    public Task<List<AddressCandidate>> AddressToLocations(string url, string address,
+        List<string>? categories, string? countryCode, bool? forStorage, Point? location,
+        LocationType? locationType)
+    {
+        return AddressToLocations(url, address, categories, countryCode, forStorage,
+            location, locationType, null, null, null, null, null, null, null);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="magicKey">A suggestLocations result ID (magicKey). Used to query for a specific results information.</param>
+    public Task<List<AddressCandidate>> AddressToLocations(string url, string address,
+        List<string>? categories, string? countryCode, bool? forStorage, Point? location,
+        LocationType? locationType, string? magicKey)
+    {
+        return AddressToLocations(url, address, categories, countryCode, forStorage,
+            location, locationType, magicKey, null, null, null, null, null, null);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="magicKey">A suggestLocations result ID (magicKey). Used to query for a specific results information.</param>
+    /// <param name="maxLocations">Maximum results to return from the query.</param>
+    public Task<List<AddressCandidate>> AddressToLocations(string url, string address,
+        List<string>? categories, string? countryCode, bool? forStorage, Point? location,
+        LocationType? locationType, string? magicKey, int? maxLocations)
+    {
+        return AddressToLocations(url, address, categories, countryCode, forStorage,
+            location, locationType, magicKey, maxLocations, null, null, null, null, null);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="magicKey">A suggestLocations result ID (magicKey). Used to query for a specific results information.</param>
+    /// <param name="maxLocations">Maximum results to return from the query.</param>
+    /// <param name="outFields">
+    ///     The list of fields included in the returned result set. This list is a comma delimited list of field names. If you specify the shape field in the list of return fields, it is ignored. For non-intersection addresses you can specify the candidate fields as defined in the geocode service. For intersection addresses you can specify the intersection candidate fields.
+    /// </param>
+    public Task<List<AddressCandidate>> AddressToLocations(string url, string address,
+        List<string>? categories, string? countryCode, bool? forStorage, Point? location,
+        LocationType? locationType, string? magicKey, int? maxLocations,
+        List<string>? outFields)
+    {
+        return AddressToLocations(url, address, categories, countryCode, forStorage,
+            location, locationType, magicKey, maxLocations, outFields, null, null, null, null);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="magicKey">A suggestLocations result ID (magicKey). Used to query for a specific results information.</param>
+    /// <param name="maxLocations">Maximum results to return from the query.</param>
+    /// <param name="outFields">
+    ///     The list of fields included in the returned result set. This list is a comma delimited list of field names. If you specify the shape field in the list of return fields, it is ignored. For non-intersection addresses you can specify the candidate fields as defined in the geocode service. For intersection addresses you can specify the intersection candidate fields.
+    /// </param>
+    /// <param name="outSpatialReference">
+    ///     The spatial reference of the output geometries. If not specified, the output geometries are in the spatial reference of the input geometries when performing a reverse geocode and in the default spatial reference returned by the service if finding locations by address.
+    /// </param>
+    public Task<List<AddressCandidate>> AddressToLocations(string url, string address,
+        List<string>? categories, string? countryCode, bool? forStorage, Point? location,
+        LocationType? locationType, string? magicKey, int? maxLocations,
+        List<string>? outFields, SpatialReference? outSpatialReference)
+    {
+        return AddressToLocations(url, address, categories, countryCode, forStorage,
+            location, locationType, magicKey, maxLocations, outFields, outSpatialReference, null, null, null);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="magicKey">A suggestLocations result ID (magicKey). Used to query for a specific results information.</param>
+    /// <param name="maxLocations">Maximum results to return from the query.</param>
+    /// <param name="outFields">
+    ///     The list of fields included in the returned result set. This list is a comma delimited list of field names. If you specify the shape field in the list of return fields, it is ignored. For non-intersection addresses you can specify the candidate fields as defined in the geocode service. For intersection addresses you can specify the intersection candidate fields.
+    /// </param>
+    /// <param name="outSpatialReference">
+    ///     The spatial reference of the output geometries. If not specified, the output geometries are in the spatial reference of the input geometries when performing a reverse geocode and in the default spatial reference returned by the service if finding locations by address.
+    /// </param>
+    /// <param name="searchExtent">
+    ///     Defines the extent within which the geocode server will search. Requires ArcGIS Server version 10.1 or greater.
+    /// </param>
+    public Task<List<AddressCandidate>> AddressToLocations(string url, string address,
+        List<string>? categories, string? countryCode, bool? forStorage, Point? location,
+        LocationType? locationType, string? magicKey, int? maxLocations,
+        List<string>? outFields, SpatialReference? outSpatialReference, Extent? searchExtent)
+    {
+        return AddressToLocations(url, address, categories, countryCode, forStorage,
+            location, locationType, magicKey, maxLocations, outFields, outSpatialReference,
+            searchExtent, null, null);
+    }
+
+    /// <summary>
+    ///     Sends a request to the ArcGIS REST geocode resource to find candidates for a single address specified in the address parameter.
+    /// </summary>
+    /// <param name="url">URL to the ArcGIS Server REST resource that represents a locator service.</param>
+    /// <param name="address">the various address fields accepted by the corresponding geocode service. </param>
+    /// <param name="categories">
+    ///     Limit result to one or more categories. For example, "Populated Place" or "Scandinavian Food".
+    ///     Only applies to the World Geocode Service. See Category filtering (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="countryCode">
+    ///     Limit result to a specific country. For example, "US" for United States or "SE" for Sweden.
+    ///     Only applies to the World Geocode Service. See Geocode coverage (World Geocoding Service) for more information.
+    /// </param>
+    /// <param name="forStorage">Allows the results of single geocode transactions to be persisted.</param>
+    /// <param name="location">Used to weight returned results for a specified area.</param>
+    /// <param name="locationType">
+    ///     Define the type of location, either "street" or "rooftop", of the point returned from the World Geocoding Service.
+    /// </param>
+    /// <param name="magicKey">A suggestLocations result ID (magicKey). Used to query for a specific results information.</param>
+    /// <param name="maxLocations">Maximum results to return from the query.</param>
+    /// <param name="outFields">
+    ///     The list of fields included in the returned result set. This list is a comma delimited list of field names. If you specify the shape field in the list of return fields, it is ignored. For non-intersection addresses you can specify the candidate fields as defined in the geocode service. For intersection addresses you can specify the intersection candidate fields.
+    /// </param>
+    /// <param name="outSpatialReference">
+    ///     The spatial reference of the output geometries. If not specified, the output geometries are in the spatial reference of the input geometries when performing a reverse geocode and in the default spatial reference returned by the service if finding locations by address.
+    /// </param>
+    /// <param name="searchExtent">
+    ///     Defines the extent within which the geocode server will search. Requires ArcGIS Server version 10.1 or greater.
+    /// </param>
+    /// <param name="requestOptions">
+    ///     Additional options to be used for the data request 
+    /// </param>
+    /// <param name="addressSearchStringParameterName">
+    ///     the name of the single line address field, defaults to SearchString
+    /// </param>
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+    public async Task<List<AddressCandidate>> AddressToLocations(string url, string address,
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+        List<string>? categories = null, string? countryCode = null, bool? forStorage = null, Point? location = null,
+        LocationType? locationType = null, string? magicKey = null, int? maxLocations = null,
+        List<string>? outFields = null, SpatialReference? outSpatialReference = null, Extent? searchExtent = null,
+        RequestOptions? requestOptions = null, string? addressSearchStringParameterName = null)
+    {
+        IJSStreamReference streamRef = await InvokeAsync<IJSStreamReference>("addressToLocations", url, address,
+            addressSearchStringParameterName, categories, countryCode, forStorage, location, locationType, magicKey,
+            maxLocations,
+            outFields, outSpatialReference, searchExtent, requestOptions);
+        await using Stream stream = await streamRef.OpenReadStreamAsync(1_000_000_000L);
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms);
+        ms.Seek(0, SeekOrigin.Begin);
+        string json = Encoding.UTF8.GetString(ms.ToArray());
+
+        return JsonSerializer.Deserialize<List<AddressCandidate>>(json, _jsonOptions) ?? new List<AddressCandidate>();
+    }
+
+#endregion
+
 
     /// <summary>
     ///     Locates an address based on a given point.
@@ -915,7 +1959,7 @@ public class LocationService : LogicComponent
     ///     The point at which to search for the closest address. The location should be in the same spatial reference as that of the geocode service.
     /// </param>
     [CodeGenerationIgnore]
-public Task<AddressCandidate> LocationToAddress(Point location)
+    public Task<AddressCandidate> LocationToAddress(Point location)
     {
         return LocationToAddress(ESRIGeoLocationUrl, location);
     }
@@ -1041,7 +2085,8 @@ public Task<AddressCandidate> LocationToAddress(Point location)
     public async Task<AddressCandidate> LocationToAddress(string url, Point location, LocationType? locationType,
         SpatialReference? outSpatialReference, RequestOptions? requestOptions)
     {
-        return await InvokeAsync<AddressCandidate>("locationToAddress", url, location, locationType, outSpatialReference, requestOptions);
+        return await InvokeAsync<AddressCandidate>("locationToAddress", url, location, locationType,
+            outSpatialReference, requestOptions);
     }
 
     /// <summary>
@@ -1055,7 +2100,7 @@ public Task<AddressCandidate> LocationToAddress(Point location)
     ///     The input text entered by a user which is used by the suggest operation to generate a list of possible matches.
     /// </param>
     [CodeGenerationIgnore]
-public async Task<List<SuggestionResult>> SuggestLocations(Point location, string text)
+    public async Task<List<SuggestionResult>> SuggestLocations(Point location, string text)
     {
         return await SuggestLocations(ESRIGeoLocationUrl, location, text);
     }
@@ -1155,12 +2200,10 @@ public async Task<List<SuggestionResult>> SuggestLocations(Point location, strin
     public async Task<List<SuggestionResult>> SuggestLocations(string url, Point location, string text,
         List<string>? categories, RequestOptions? requestOptions)
     {
-        return await InvokeAsync<List<SuggestionResult>>("suggestLocations", url, location, text, categories, requestOptions);
+        return await InvokeAsync<List<SuggestionResult>>("suggestLocations", url, location, text, categories,
+            requestOptions);
     }
 
-    private readonly JsonSerializerOptions _jsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-    };
+    private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, };
     private const string ESRIGeoLocationUrl = "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer";
 }

--- a/src/dymaptic.GeoBlazor.Core/Components/LocationService.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/LocationService.cs
@@ -2182,8 +2182,8 @@ public class LocationService : LogicComponent
         RequestOptions? requestOptions = null, string? addressSearchStringParameterName = null)
     {
         IJSStreamReference streamRef = await InvokeAsync<IJSStreamReference>("addressToLocations", url, address,
-            addressSearchStringParameterName, categories, countryCode, forStorage, location, locationType, magicKey,
-            maxLocations, outFields, outSpatialReference, searchExtent, requestOptions);
+            categories, countryCode, forStorage, location, locationType, magicKey,
+            maxLocations, outFields, outSpatialReference, searchExtent, requestOptions, addressSearchStringParameterName);
 
         return await streamRef.ReadJsStreamReference<List<AddressCandidate>>() ?? [];
     }
@@ -2194,8 +2194,8 @@ public class LocationService : LogicComponent
         string? addressSearchStringParameterName = null)
     {
         IJSStreamReference streamRef = await InvokeAsync<IJSStreamReference>("addressesToLocations", url,
-            addresses, addressSearchStringParameterName, countryCode, categories, locationType,
-            outSpatialReference, requestOptions);
+            addresses, countryCode, categories, locationType,
+            outSpatialReference, requestOptions, addressSearchStringParameterName);
 
         return await streamRef.ReadJsStreamReference<List<AddressCandidate>>() ?? [];
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/MapComponent.razor.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/MapComponent.razor.cs
@@ -1,6 +1,5 @@
 ﻿namespace dymaptic.GeoBlazor.Core.Components;
 
-
 /// <summary>
 ///     The abstract base Razor Component class that all GeoBlazor components derive from.
 /// </summary>
@@ -13,7 +12,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     [Inject]
     [JsonIgnore]
     public IJSRuntime? JsRuntime { get; set; }
-    
+
     /// <summary>
     ///     Manages references to JavaScript modules.
     /// </summary>
@@ -59,6 +58,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
         get
         {
             _coreJsModule ??= Parent?.CoreJsModule;
+
             return _coreJsModule;
         }
         set => _coreJsModule = value;
@@ -73,11 +73,12 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
         get
         {
             _proJsModule ??= Parent?.ProJsModule;
+
             return _proJsModule;
         }
         internal set => _proJsModule = value;
     }
-    
+
     /// <summary>
     ///     Handles conversion from .NET CancellationToken to JavaScript AbortController
     /// </summary>
@@ -105,7 +106,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     [JsonIgnore]
     [Parameter]
     public virtual Layer? Layer { get; set; }
-    
+
     /// <summary>
     ///     The Id of the relevant Layer for the MapComponent. Not always applicable to every component type.
     /// </summary>
@@ -124,7 +125,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     /// </summary>
     [JsonConverter(typeof(DefaultGuidConverter))]
     public Guid Id { get; set; } = Guid.NewGuid();
-    
+
     /// <summary>
     ///     Whether the component has been disposed.
     /// </summary>
@@ -227,9 +228,11 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
 
             return;
         }
+
         try
         {
-            Props ??= MapComponentType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            Props ??= MapComponentType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic |
+                BindingFlags.Instance);
             PropertyInfo? prop = Props.FirstOrDefault(p => p.Name == propertyName);
 
             if (prop is null)
@@ -260,7 +263,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
             Console.WriteLine(ex);
         }
     }
-    
+
     /// <summary>
     ///     Asynchronously retrieve the current value of any property, based on the property name. You must also define the type of the property in the Generic type.
     /// </summary>
@@ -280,27 +283,29 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
             Task methodTask = (Task)typedMethod.Invoke(this, [])!;
 
             await methodTask.ConfigureAwait(false);
+
             return methodTask.GetType().GetProperty("Result")!.GetValue(methodTask) is T result ? result : default;
         }
-        
+
         Props ??= MapComponentType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
         PropertyInfo prop = Props.First(p => p.Name == propertyName);
         T? currentValue = (T?)prop.GetValue(this);
-        
+
         if (CoreJsModule is null)
         {
             // we aren't hooked to JS, so return the current value in memory
             return currentValue;
         }
-                 
+
         JsComponentReference ??= await CoreJsModule.InvokeAsync<IJSObjectReference>(
             "getJsComponent", CancellationTokenSource.Token, Id);
+
         if (JsComponentReference is null)
         {
             // we aren't hooked to JS, so return the current value in memory
             return currentValue;
         }
-        
+
         bool isMapComponent = prop.PropertyType.IsAssignableTo(typeof(MapComponent));
         Type instanceType = typeof(T);
         T? instance = default;
@@ -314,7 +319,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
                     // this component has already been registered
                     return currentValue;
                 }
-                
+
                 IJSObjectReference? refResult;
 
                 try
@@ -349,7 +354,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
                     {
                         // continue, we'll try to instantiate the object below
                     }
-                    
+
                     if (instanceType.IsAbstract)
                     {
                         if (refResult is null)
@@ -405,7 +410,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
                 if (refResult is not null)
                 {
                     JsComponentReference = refResult;
-                    
+
                     // register this type in JS
                     await CoreJsModule!.InvokeVoidAsync("registerGeoBlazorObject",
                         CancellationTokenSource.Token, component.JsComponentReference, component.Id);
@@ -459,6 +464,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
                 instance = await CoreJsModule!.InvokeAsync<T?>("getProperty",
                     CancellationTokenSource.Token, JsComponentReference, propertyName.ToLowerFirstChar());
             }
+
             prop.SetValue(this, instance);
             ModifiedParameters[propertyName] = instance;
 
@@ -469,9 +475,11 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
             // do nothing, task was cancelled
             return currentValue;
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
-            Console.WriteLine($"Error calling GetProperty for property {propertyName} on component {MapComponentType.Name}: {ex}");
+            Console.WriteLine($"Error calling GetProperty for property {propertyName} on component {
+                MapComponentType.Name}: {ex}");
+
             return currentValue;
         }
     }
@@ -573,6 +581,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     public virtual ValueTask Refresh()
     {
         UpdateState();
+
         return ValueTask.CompletedTask;
     }
 
@@ -599,21 +608,22 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     {
         return SetVisibility(visible);
     }
-    
+
     /// <summary>
     ///     Retrieves the current value of the <see cref="Visible" /> property.
     /// </summary>
     public async Task<bool?> GetVisible()
     {
         if (CoreJsModule is null) return Visible;
-        
+
         JsComponentReference ??= await CoreJsModule.InvokeAsync<IJSObjectReference>("getJsComponent",
             CancellationTokenSource.Token, Id);
+
         if (JsComponentReference is null) return Visible;
-        
+
         bool? result = await CoreJsModule.InvokeAsync<bool?>("getProperty",
             CancellationTokenSource.Token, JsComponentReference, "visible");
-        
+
         if (result is not null)
         {
 #pragma warning disable BL0005
@@ -621,10 +631,10 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
 #pragma warning restore BL0005
             ModifiedParameters[nameof(Visible)] = Visible;
         }
-        
+
         return Visible;
     }
-    
+
     /// <summary>
     ///     The reference to the .NET object that represents the component.
     /// </summary>
@@ -635,12 +645,12 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     ///     The reference to the JavaScript object that represents the component.
     /// </summary>
     internal IJSObjectReference? JsComponentReference { get; set; }
-    
+
     /// <summary>
     ///     For internal use, registration from JavaScript.
     /// </summary>
     [JSInvokable]
-    public virtual async ValueTask<MapComponent?> OnJsComponentCreated(IJSObjectReference jsComponentReference, 
+    public virtual async ValueTask<MapComponent?> OnJsComponentCreated(IJSObjectReference jsComponentReference,
         IJSStreamReference jsonStreamReference)
     {
         JsComponentReference = jsComponentReference;
@@ -648,7 +658,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
 
         try
         {
-            if (await ReadJsStreamReference(jsonStreamReference, MapComponentType) is MapComponent deserialized)
+            if (await jsonStreamReference.ReadJsStreamReference(MapComponentType) is MapComponent deserialized)
             {
                 instantiatedComponent = deserialized;
                 CopyProperties(instantiatedComponent);
@@ -660,11 +670,11 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
                 getSourceJSONMethod.Invoke(this, []);
             }
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             Console.WriteLine($"Error deserializing instantiated component: {ex}");
         }
-        
+
         return instantiatedComponent;
     }
 
@@ -679,7 +689,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
             {
                 continue;
             }
-            
+
             CopyProperty(prop, deserializedComponent);
         }
     }
@@ -687,21 +697,22 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     private void CopyProperty(PropertyInfo prop, MapComponent deserializedComponent)
     {
         object? newValue = prop.GetValue(deserializedComponent);
+
         if (newValue is null)
         {
             return;
         }
-            
+
         object? currentValue = prop.GetValue(this);
 
-        if (currentValue is not null 
+        if (currentValue is not null
             && (currentValue is not IEnumerable collection || collection.Cast<object>().Any())
             && currentValue is not MapComponent)
         {
             // don't overwrite existing values and non-empty collections
             return;
         }
-            
+
         if (currentValue is MapComponent currentPropComponent && currentValue.GetType() == newValue.GetType())
         {
             currentPropComponent.CoreJsModule = CoreJsModule;
@@ -728,11 +739,11 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     public virtual void ValidateRequiredChildren()
     {
         if (IsValidated) return;
-        
+
         Props ??= MapComponentType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-        
+
         IEnumerable<PropertyInfo> requiredParameters = Props.Where(p =>
-                Attribute.IsDefined(p, typeof(RequiredPropertyAttribute)));
+            Attribute.IsDefined(p, typeof(RequiredPropertyAttribute)));
 
         List<ComponentOption> options = [];
 
@@ -744,7 +755,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
 
             object[] attributes = requiredParameter.GetCustomAttributes(typeof(RequiredPropertyAttribute), true);
 
-            if (attributes.Length > 0 && attributes[0] is RequiredPropertyAttribute { OtherOptions: not null } attr 
+            if (attributes.Length > 0 && attributes[0] is RequiredPropertyAttribute { OtherOptions: not null } attr
                 && attr.OtherOptions.Any())
             {
                 ComponentOption? optionSet = options.FirstOrDefault(o =>
@@ -767,9 +778,10 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
                 {
                     optionSet.Found = true;
                 }
+
                 continue;
             }
-            
+
             if (value is null)
             {
                 throw new MissingRequiredChildElementException(MapComponentType.Name, propName);
@@ -789,16 +801,15 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
                 throw new MissingRequiredOptionsChildElementException(MapComponentType.Name, option.Options);
             }
         }
-        
+
         IsValidated = true;
     }
-    
+
     /// <summary>
     ///     Validates source-generated child components.
     /// </summary>
     public virtual void ValidateRequiredGeneratedChildren()
     {
-        
     }
 
     /// <summary>
@@ -820,14 +831,14 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
-        
+
         if (Parent is not null && !_registered)
         {
             if (!await Parent.RegisterGeneratedChildComponent(this))
             {
                 await Parent.RegisterChildComponent(this);
             }
-            
+
             if (Parent is Layer layer)
             {
                 Layer = layer;
@@ -836,7 +847,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
             {
                 Layer ??= Parent.Layer;
             }
-            
+
             View ??= Parent.View;
             _registered = true;
         }
@@ -846,9 +857,9 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     public override async Task SetParametersAsync(ParameterView parameters)
     {
         await base.SetParametersAsync(parameters);
-        
+
         _layerId ??= Layer?.Id;
-        
+
         foreach (KeyValuePair<string, object?> kvp in ModifiedParameters)
         {
             try
@@ -872,12 +883,12 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
         {
             return;
         }
-        
+
         Props ??= MapComponentType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
         foreach (PropertyInfo propInfo in Props)
         {
-            if (propInfo.PropertyType.IsAssignableTo(typeof(IInteractiveRecord)) 
+            if (propInfo.PropertyType.IsAssignableTo(typeof(IInteractiveRecord))
                 && propInfo.GetValue(this) is IInteractiveRecord record)
             {
                 record.CoreJsModule = CoreJsModule;
@@ -890,12 +901,14 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await base.OnAfterRenderAsync(firstRender);
+
         if (firstRender)
         {
             ProJsModule ??= await JsModuleManager!.GetArcGisJsPro(JsRuntime!, CancellationToken.None);
             CoreJsModule ??= await JsModuleManager!.GetArcGisJsCore(JsRuntime!, ProJsModule, CancellationToken.None);
             AbortManager ??= new AbortManager(CoreJsModule);
         }
+
         IsRenderedBlazorComponent = true;
     }
 
@@ -912,36 +925,12 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
             await Parent.RenderView(forceRender);
         }
     }
-    
-    /// <summary>
-    ///     Convenience method to deserialize an <see cref="IJSStreamReference" /> to a specific .NET type.
-    /// </summary>
-    protected async Task<T?> ReadJsStreamReference<T>(IJSStreamReference jsStreamReference)
-    {
-        return (T?)await ReadJsStreamReference(jsStreamReference, typeof(T));
-    }
 
-    /// <summary>
-    ///     Convenience method to deserialize an <see cref="IJSStreamReference" /> to a specific .NET type.
-    ///     This overload returns an <see cref="object" />, so the type does not need to be known at compile time.
-    /// </summary>
-    protected async Task<object?> ReadJsStreamReference(IJSStreamReference jsStreamReference, Type returnType)
-    {
-        await using Stream stream = await jsStreamReference
-            .OpenReadStreamAsync(View?.QueryResultsMaxSizeLimit ?? 1_000_000_000L);
-        await using MemoryStream ms = new();
-        await stream.CopyToAsync(ms);
-        ms.Seek(0, SeekOrigin.Begin);
-        byte[] encodedJson = ms.ToArray();
-        string json = Encoding.UTF8.GetString(encodedJson);
-        return JsonSerializer.Deserialize(json, returnType, GeoBlazorSerialization.JsonSerializerOptions);
-    }
-    
     private readonly Dictionary<string, (Delegate Handler, IJSObjectReference JsObjRef)> _watchers = new();
     private readonly Dictionary<string, (Delegate Handler, IJSObjectReference JsObjRef)> _listeners = new();
     private readonly Dictionary<string, (Delegate Handler, IJSObjectReference JsObjRef)> _waiters = new();
     private static Type? _proExtensions;
-    
+
     /// <summary>
     ///     The previous parameters that were set in the component.
     /// </summary>
@@ -956,7 +945,8 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     ///     Creates a cancellation token to control external calls
     /// </summary>
     protected internal readonly CancellationTokenSource CancellationTokenSource = new();
-    
+
+
 #region Events
 
     /// <summary>
@@ -978,6 +968,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     ///     For adding watchers to types other than <see cref="MapView" /> and <see cref="SceneView" />, the default <code>targetName</code> should not be relied upon. Make sure it matches the variable in your
     ///     <code>watchExpression</code>
     /// </remarks>
+
     // ReSharper disable once UnusedMethodReturnValue.Global
     public Task AddReactiveWatcher<T>(string watchExpression, Func<T, Task> handler)
     {
@@ -1069,7 +1060,8 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     ///     For adding watchers to types other than <see cref="MapView" /> and <see cref="SceneView" />, the default <code>targetName</code> should not be relied upon. Make sure it matches the variable in your
     ///     <code>watchExpression</code>
     /// </remarks>
-    public Task AddReactiveWatcher<T>(string watchExpression, Func<T, Task> handler, string? targetName, bool once, bool initial)
+    public Task AddReactiveWatcher<T>(string watchExpression, Func<T, Task> handler, string? targetName, bool once,
+        bool initial)
     {
         return AddReactiveWatcherImplementation(watchExpression, handler, targetName, once, initial);
     }
@@ -1183,18 +1175,18 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     ///     For adding watchers to types other than <see cref="MapView" /> and <see cref="SceneView" />, the default <code>targetName</code> should not be relied upon. Make sure it matches the variable in your
     ///     <code>watchExpression</code>
     /// </remarks>
-    public Task AddReactiveWatcher<T>(string watchExpression, Action<T> handler, string? targetName, bool once, bool initial)
+    public Task AddReactiveWatcher<T>(string watchExpression, Action<T> handler, string? targetName, bool once,
+        bool initial)
     {
         return AddReactiveWatcherImplementation(watchExpression, handler, targetName, once, initial);
     }
-
 
     /// <inheritdoc />
     protected override bool ShouldRender()
     {
         return AllowRender;
     }
-    
+
     /// <summary>
     ///     Updates the state of the component, but only if it was added in normal Blazor Markup.
     /// </summary>
@@ -1210,7 +1202,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     ///     Whether to allow the component to render on the next cycle.
     /// </summary>
     public bool AllowRender = true;
-    
+
     /// <summary>
     ///     Determines whether the component was added as a markup Blazor component or programmatically.
     /// </summary>
@@ -1226,7 +1218,6 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     ///     The application is running with just GeoBlazor Core, not Pro
     /// </summary>
     protected static bool ProNotFound;
-
 
     private async Task AddReactiveWatcherImplementation(string watchExpression, Delegate handler, string? targetName,
         bool once, bool initial)
@@ -1285,7 +1276,7 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
 
         if (jsStreamReference is not null)
         {
-            typedValue = await ReadJsStreamReference(jsStreamReference, returnType);
+            typedValue = await jsStreamReference.ReadJsStreamReference(returnType);
         }
 
         handler.DynamicInvoke(typedValue);
@@ -1377,7 +1368,6 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
         }
     }
 
-
     /// <summary>
     ///     Removes the tracker on a particular expression.
     /// </summary>
@@ -1411,10 +1401,10 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
         Delegate handler = _listeners[eventName].Handler;
         Type returnType = handler.Method.GetParameters()[0].ParameterType;
         object? typedValue = null;
-        
+
         if (jsStreamReference is not null)
         {
-            typedValue = await ReadJsStreamReference(jsStreamReference, returnType);
+            typedValue = await jsStreamReference.ReadJsStreamReference(returnType);
         }
 
         handler.DynamicInvoke(typedValue);
@@ -1519,7 +1509,8 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
     ///     For adding waiters to types other than <see cref="MapView" /> and <see cref="SceneView" />, the default <code>targetName</code> should not be relied upon. Make sure it matches the variable in your
     ///     <code>waitExpression</code>
     /// </remarks>
-    public Task AddReactiveWaiter(string waitExpression, Func<Task> handler, string? targetName, bool once, bool initial)
+    public Task AddReactiveWaiter(string waitExpression, Func<Task> handler, string? targetName, bool once,
+        bool initial)
     {
         return AddReactiveWaiterImplementation(waitExpression, handler, targetName, once, initial);
     }
@@ -1626,7 +1617,6 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable, IM
         return AddReactiveWaiterImplementation(waitExpression, handler, targetName, once, initial);
     }
 
-
     private async Task AddReactiveWaiterImplementation(string waitExpression, Delegate handler, string? targetName,
         bool once, bool initial)
     {
@@ -1727,7 +1717,8 @@ internal class MapComponentConverter : JsonConverter<MapComponent>
 
     public override void Write(Utf8JsonWriter writer, MapComponent value, JsonSerializerOptions options)
     {
-        writer.WriteRawValue(JsonSerializer.Serialize(value, typeof(object), GeoBlazorSerialization.JsonSerializerOptions));
+        writer.WriteRawValue(JsonSerializer.Serialize(value, typeof(object),
+            GeoBlazorSerialization.JsonSerializerOptions));
     }
 }
 

--- a/src/dymaptic.GeoBlazor.Core/Components/SearchViewModel.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/SearchViewModel.cs
@@ -21,15 +21,8 @@ public partial class SearchViewModel : MapComponent
     [CodeGenerationIgnore]
     public async Task OnJsGoToOverride(IJSStreamReference jsStreamRef)
     {
-        await using Stream stream = await jsStreamRef.OpenReadStreamAsync(1_000_000_000L);
-        await using MemoryStream ms = new();
-        await stream.CopyToAsync(ms);
-        ms.Seek(0, SeekOrigin.Begin);
-        byte[] encodedJson = ms.ToArray();
-        string json = Encoding.UTF8.GetString(encodedJson);
-        GoToOverrideParameters goToParameters = JsonSerializer.Deserialize<GoToOverrideParameters>(
-            json, GeoBlazorSerialization.JsonSerializerOptions)!;
-        if (GoToOverride is not null)
+        GoToOverrideParameters? goToParameters = await jsStreamRef.ReadJsStreamReference<GoToOverrideParameters>()!;
+        if (GoToOverride is not null && goToParameters is not null)
         {
             await GoToOverride.Invoke(goToParameters);
         }

--- a/src/dymaptic.GeoBlazor.Core/Components/Widgets/PopupWidget.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Widgets/PopupWidget.cs
@@ -168,9 +168,9 @@ public partial class PopupWidget : Widget
             return null;
         }
         
-        IJSStreamReference streamRef = await JsComponentReference!.InvokeAsync<IJSStreamReference>(
+        IJSStreamReference jsStreamRef = await JsComponentReference!.InvokeAsync<IJSStreamReference>(
             "getSelectedFeature", CancellationTokenSource.Token);
-        SelectedFeature = await ReadJsStreamReference<Graphic?>(streamRef);
+        SelectedFeature = await jsStreamRef.ReadJsStreamReference<Graphic>();
         return SelectedFeature;
     }
 

--- a/src/dymaptic.GeoBlazor.Core/Model/Address.cs
+++ b/src/dymaptic.GeoBlazor.Core/Model/Address.cs
@@ -6,7 +6,7 @@ namespace dymaptic.GeoBlazor.Core.Model;
 ///     with the same name as the containing class
 /// </summary>
 public record Address(
-    [property: JsonPropertyName("Address")]
+    [property: JsonPropertyName("address")]
     string Street,
     string City,
     string State,

--- a/src/dymaptic.GeoBlazor.Core/Model/Address.cs
+++ b/src/dymaptic.GeoBlazor.Core/Model/Address.cs
@@ -2,5 +2,12 @@ namespace dymaptic.GeoBlazor.Core.Model;
 
 /// <summary>
 ///     A complete street address for use in an <see cref="AddressQuery" />
+///     note: the Street property is converted to Address in JavaScript, but C# does not allow properties
+///     with the same name as the containing class
 /// </summary>
-public record Address(string Street, string City, string State, string Zone);
+public record Address(
+    [property: JsonPropertyName("Address")]
+    string Street,
+    string City,
+    string State,
+    string Zone);

--- a/src/dymaptic.GeoBlazor.Core/Scripts/locationService.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/locationService.ts
@@ -15,14 +15,14 @@ import SuggestionResult = __esri.SuggestionResult;
 
 export default class LocatorWrapper extends LocationServiceGenerated {
 
-    async addressesToLocations(url: string, addresses: any, addressSearchString: string, countryCode: string | null,
+    async addressesToLocations(url: string, addresses: any, countryCode: string | null,
                                categories: string[] | null, locationType: string | null,
                                outSpatialReference: DotNetSpatialReference | null,
-                               requestOptions: any | null)
+                               requestOptions: any | null,  addressSearchString: string,)
         : Promise<any | null> {
 
         if (!hasValue(addressSearchString)) {
-            addressSearchString = 'Address';
+            addressSearchString = 'address';
         }
 
         let params;
@@ -73,11 +73,11 @@ export default class LocatorWrapper extends LocationServiceGenerated {
         return encoded;
     }
 
-    async addressToLocations(url: string, address: any, addressSearchString: string, categories: string[] | null, countryCode: string | null,
+    async addressToLocations(url: string, address: any, categories: string[] | null, countryCode: string | null,
                              forStorage: boolean | null, location: DotNetPoint | null, locationType: string | null,
                              magicKey: string | null, maxLocations: number | null, outFields: string[] | null,
                              outSpatialReference: DotNetSpatialReference | null, searchExtent: DotNetExtent | null,
-                             requestOptions: any | null)
+                             requestOptions: any | null, addressSearchString: string)
         : Promise<any | null> {
         let params;
         if (!hasValue(addressSearchString)) {

--- a/src/dymaptic.GeoBlazor.Core/Scripts/locationService.ts
+++ b/src/dymaptic.GeoBlazor.Core/Scripts/locationService.ts
@@ -89,6 +89,9 @@ export default class LocatorWrapper extends LocationServiceGenerated {
         } else if (typeof address === 'object' && address !== null) {
             // Handle object address (like {street, city, state, zone})
             params = {address: address} as locatorAddressToLocationsParams;
+        } else {
+            // Fallback: ensure params is always initialized
+            params = {address: {}} as locatorAddressToLocationsParams;
         }
 
         if (hasValue(categories)) {

--- a/src/dymaptic.GeoBlazor.Core/Serialization/IJSStreamReferenceHelper.cs
+++ b/src/dymaptic.GeoBlazor.Core/Serialization/IJSStreamReferenceHelper.cs
@@ -1,5 +1,8 @@
 namespace dymaptic.GeoBlazor.Core.Serialization;
 
+/// <summary>
+///     Extension methods for <see cref="IJSStreamReference" /> to facilitate reading data from JavaScript streams.
+/// </summary>
 public static class IJSStreamReferenceHelper
 {
     /// <summary>

--- a/src/dymaptic.GeoBlazor.Core/Serialization/IJSStreamReferenceHelper.cs
+++ b/src/dymaptic.GeoBlazor.Core/Serialization/IJSStreamReferenceHelper.cs
@@ -1,0 +1,29 @@
+namespace dymaptic.GeoBlazor.Core.Serialization;
+
+public static class IJSStreamReferenceHelper
+{
+    /// <summary>
+    ///     Convenience method to deserialize an <see cref="IJSStreamReference" /> to a specific .NET type.
+    /// </summary>
+    public static async Task<T?> ReadJsStreamReference<T>(this IJSStreamReference jsStreamReference,
+        long maxAllowedSize = 1_000_000_000L)
+    {
+        return (T?)await ReadJsStreamReference(jsStreamReference, typeof(T), maxAllowedSize);
+    }
+
+    /// <summary>
+    ///     Convenience method to deserialize an <see cref="IJSStreamReference" /> to a specific .NET type.
+    ///     This overload returns an <see cref="object" />, so the type does not need to be known at compile time.
+    /// </summary>
+    public static async Task<object?> ReadJsStreamReference(this IJSStreamReference jsStreamReference, Type returnType,
+        long maxAllowedSize = 1_000_000_000)
+    {
+        await using Stream stream =
+            await jsStreamReference.OpenReadStreamAsync(maxAllowedSize);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        var json = await reader.ReadToEndAsync();
+
+        return JsonSerializer.Deserialize(json, returnType, GeoBlazorSerialization.JsonSerializerOptions);
+    }
+}

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/LocationServiceTests.cs
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/LocationServiceTests.cs
@@ -1,0 +1,95 @@
+﻿using dymaptic.GeoBlazor.Core.Components;
+using dymaptic.GeoBlazor.Core.Model;
+using Microsoft.AspNetCore.Components;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+
+#pragma warning disable BL0005
+
+
+namespace dymaptic.GeoBlazor.Core.Test.Blazor.Shared.Components;
+
+public class LocationServiceTests : TestRunnerBase
+{
+    /*
+     * test data and expected results
+     * 380 New York St, Redlands, California, 92373 100 - 34.056097983409,-117.195426038092
+     * 400 New York St, Redlands, California, 92373 100 - 34.057451663745,-117.195611240849
+     */
+    
+    [Inject]
+    public required LocationService LocationService { get; set; }
+
+    [TestMethod]
+    public async Task TestPerformAddressesToLocation(Action renderHandler)
+    {
+        var addresses = new List<Address>
+        {
+            new Address("380 New York Street", "Redlands", "CA", "92373"),
+            new Address("400 New York Street", "Redlands", "CA", "92373")
+        };
+        var locations = await LocationService.AddressesToLocations(addresses);
+
+        var firstAddress = locations.FirstOrDefault(x => x.Address!.Contains("380 New York"));
+
+        Assert.IsNotNull(firstAddress?.Location);
+        Assert.AreEqual(firstAddress!.Location.Latitude, 34.056097983409);
+        Assert.AreEqual(firstAddress!.Location.Longitude, -117.195426038092);
+
+        var secondAddress = locations.FirstOrDefault(x => x.Address!.Contains("400 New York"));
+
+        Assert.IsNotNull(secondAddress?.Location);
+        Assert.AreEqual(secondAddress!.Location.Latitude, 34.057451663745);
+        Assert.AreEqual(secondAddress!.Location.Longitude, -117.195611240849);
+    }
+
+    [TestMethod]
+    public async Task TestPerformAddressToLocation(Action renderHandler)
+    {
+        var address = new Address("380 New York Street", "Redlands", "CA", "92373");
+
+        var location = await LocationService.AddressToLocations(address);
+
+        var firstAddress = location.FirstOrDefault(x => x.Address!.Contains("380 New York"));
+
+        Assert.IsNotNull(firstAddress?.Location);
+        Assert.AreEqual(firstAddress!.Location.Latitude, 34.056097983409);
+        Assert.AreEqual(firstAddress!.Location.Longitude, -117.195426038092);
+    }
+
+    [TestMethod]
+    public async Task TestPerformAddressToLocationString(Action renderHandler)
+    {
+        var address = "380 New York Street, Redlands, CA 92373";
+
+        var location = await LocationService.AddressToLocations(address);
+
+        var firstAddress = location.FirstOrDefault(x => x.Address!.Contains("380 New York"));
+
+        Assert.IsNotNull(firstAddress?.Location);
+        Assert.AreEqual(firstAddress!.Location.Latitude, 34.056097983409);
+        Assert.AreEqual(firstAddress!.Location.Longitude, -117.195426038092);
+    }
+
+    [TestMethod]
+    public async Task TestPerformAddressesToLocationString(Action renderHandler)
+    {
+        var addresses = new List<string>
+        {
+            "380 New York Street, Redlands, CA 92373", "400 New York Street, Redlands, CA 92373",
+        };
+        var locations = await LocationService.AddressesToLocations(addresses);
+
+        var firstAddress = locations.FirstOrDefault(x => x.Address!.Contains("380 New York"));
+
+        Assert.IsNotNull(firstAddress?.Location);
+        Assert.AreEqual(firstAddress!.Location.Latitude, 34.056097983409);
+        Assert.AreEqual(firstAddress!.Location.Longitude, -117.195426038092);
+
+        var secondAddress = locations.FirstOrDefault(x => x.Address!.Contains("400 New York"));
+
+        Assert.IsNotNull(secondAddress?.Location);
+        Assert.AreEqual(secondAddress!.Location.Latitude, 34.057451663745);
+        Assert.AreEqual(secondAddress!.Location.Longitude, -117.195611240849);
+    }
+}


### PR DESCRIPTION
Closes #461 

Updates the Address class used by the `LocationService` class send the correct parameters to the service.
Adds the overloads to `LocationService` to support searching by a full address string