### PR TITLE
Added featurelayer tests

### DIFF
--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerTests.razor
@@ -470,4 +470,359 @@
         await AssertJavaScript("assertLayerExists", args: "tile");
         await AssertJavaScript("assertLayerExists", args: "feature");
     }
+
+    [TestMethod]
+    public async Task FeatureLayer_BasicPropertyRoundtrip_And_JS_Asserts(Action renderHandler)
+    {
+        FeatureLayer? layer = null;
+
+        AddMapRenderFragment(
+            @<MapView class="map-view" OnViewRendered="renderHandler">
+                <Map>
+                    <Basemap>
+                        <BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" />
+                    </Basemap>
+                    <FeatureLayer @ref="layer"
+                                  Source="@([])"
+                                  OutFields="@(["*"])"
+                                  SpatialReference="SpatialReference.Wgs84"
+                                  GeometryType="FeatureGeometryType.Point"
+                                  ObjectIdField="OBJECT_ID" />
+                </Map>
+            </MapView>);
+
+        await WaitForMapToRender();
+        await AssertJavaScript("assertLayerExists", args: "feature");
+
+        await layer!.SetLegendEnabled(false);
+        Assert.AreEqual(false, await layer.GetLegendEnabled());
+        await AssertJavaScript("assertFeatureLayerBooleanPropEquals", args: [layer!.Id, "legendEnabled", false]);
+
+        await layer!.SetPopupEnabled(true);
+        Assert.AreEqual(true, await layer.GetPopupEnabled());
+        await AssertJavaScript("assertFeatureLayerBooleanPropEquals", args: [layer!.Id, "popupEnabled", true]);
+
+        await layer!.SetLabelsVisible(false);
+        Assert.AreEqual(false, await layer.GetLabelsVisible());
+        await AssertJavaScript("assertFeatureLayerBooleanPropEquals", args: [layer!.Id, "labelsVisible", false]);
+
+        await layer!.SetReturnM(true);
+        Assert.AreEqual(true, await layer.GetReturnM());
+        await AssertJavaScript("assertFeatureLayerBooleanPropEquals", args: [layer!.Id, "returnM", true]);
+
+        await layer!.SetReturnZ(true);
+        Assert.AreEqual(true, await layer.GetReturnZ());
+        await AssertJavaScript("assertFeatureLayerBooleanPropEquals", args: [layer!.Id, "returnZ", true]);
+
+        await layer!.SetDisplayFilterEnabled(false);
+        Assert.AreEqual(false, await layer.GetDisplayFilterEnabled());
+        await AssertJavaScript("assertFeatureLayerBooleanPropEquals", args: [layer!.Id, "displayFilterEnabled", false]);
+
+        await layer!.SetEditingEnabled(false);
+        Assert.AreEqual(false, await layer.GetEditingEnabled());
+        await AssertJavaScript("assertFeatureLayerBooleanPropEquals", args: [layer!.Id, "editingEnabled", false]);
+
+        await layer!.SetUseViewTime(false);
+        Assert.AreEqual(false, await layer.GetUseViewTime());
+        await AssertJavaScript("assertFeatureLayerBooleanPropEquals", args: [layer!.Id, "useViewTime", false]);
+
+        await layer!.SetScreenSizePerspectiveEnabled(false);
+        Assert.AreEqual(false, await layer.GetScreenSizePerspectiveEnabled());
+        await AssertJavaScript("assertFeatureLayerBooleanPropEquals", args: [layer!.Id, "screenSizePerspectiveEnabled", false]);
+
+        await layer!.SetMinScale(5000);
+        Assert.AreEqual(5000, await layer.GetMinScale());
+        await AssertJavaScript("assertFeatureLayerNumberPropEquals", args: [layer!.Id, "minScale", 5000]);
+
+        await layer!.SetMaxScale(0);
+        Assert.AreEqual(0, await layer.GetMaxScale());
+        await AssertJavaScript("assertFeatureLayerNumberPropEquals", args: [layer!.Id, "maxScale", 0]);
+
+        await layer!.SetRefreshInterval(0.01);
+        Assert.AreEqual(0.01, await layer.GetRefreshInterval());
+        await AssertJavaScript("assertFeatureLayerNumberPropEquals", args: [layer!.Id, "refreshInterval", 0.01]);
+
+        await layer!.SetDefinitionExpression("1=1");
+        Assert.AreEqual("1=1", await layer.GetDefinitionExpression());
+        await AssertJavaScript("assertFeatureLayerStringPropEquals", args: [layer!.Id, "definitionExpression", "1=1"]);
+
+        await layer!.SetDateFieldsTimeZone("UTC");
+        Assert.AreEqual("UTC", await layer.GetDateFieldsTimeZone());
+        await AssertJavaScript("assertFeatureLayerStringPropEquals", args: [layer!.Id, "dateFieldsTimeZone", "UTC"]);
+
+        await layer!.SetDisplayField("OBJECT_ID");
+        Assert.AreEqual("OBJECT_ID", await layer.GetDisplayField());
+        await AssertJavaScript("assertFeatureLayerStringPropEquals", args: [layer!.Id, "displayField", "OBJECT_ID"]);
+    }
+
+    [TestMethod]
+    public async Task FeatureLayer_Collections_AddRemove_Roundtrip(Action renderHandler)
+    {
+        FeatureLayer? layer = null;
+
+        AddMapRenderFragment(
+            @<MapView class="map-view" OnViewRendered="renderHandler">
+                <Map>
+                    <Basemap><BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" /></Basemap>
+                    <FeatureLayer @ref="layer"
+                                  Source="@([])"
+                                  OutFields="@(["*"])"
+                                  SpatialReference="SpatialReference.Wgs84"
+                                  GeometryType="FeatureGeometryType.Point"
+                                  ObjectIdField="OBJECT_ID" />
+                </Map>
+            </MapView>);
+
+        await WaitForMapToRender();
+        await AssertJavaScript("assertLayerExists", args: "feature");
+
+        await layer!.SetOutFields(new []{ "*", "OBJECT_ID" });
+        var outFields = await layer!.GetOutFields();
+        CollectionAssert.AreEquivalent(new []{ "*", "OBJECT_ID" }, outFields?.ToArray());
+        await AssertJavaScript("assertFeatureLayerArrayPropEquals", args: [layer!.Id, "outFields", new []{ "*", "OBJECT_ID" }]);
+
+        await layer!.AddToOutFields("NEW_FIELD");
+        outFields = await layer!.GetOutFields();
+        CollectionAssert.AreEquivalent(new []{ "*", "OBJECT_ID", "NEW_FIELD" }, outFields?.ToArray());
+
+        await layer!.RemoveFromOutFields("NEW_FIELD");
+        outFields = await layer!.GetOutFields();
+        CollectionAssert.AreEquivalent(new []{ "*", "OBJECT_ID" }, outFields?.ToArray());
+
+        await layer!.SetOrderBy(new[]
+        {
+            new OrderByInfo(field: "OBJECTID", order: SortOrder.Ascending)
+        });
+        var orderBy = await layer!.GetOrderBy();
+        Assert.IsTrue(orderBy != null &&
+              orderBy.Any(o => o.Field == "OBJECTID" &&
+                               o.Order == SortOrder.Ascending));
+        await AssertJavaScript("assertFeatureLayerOrderByContains", args: [layer!.Id, "OBJECT_ID", "ASC"]);
+    }
+
+    [TestMethod]
+    public async Task FeatureLayer_ComplexProps_Roundtrip_Minimal(Action renderHandler)
+    {
+        FeatureLayer? layer = null;
+
+        AddMapRenderFragment(
+            @<MapView class="map-view" OnViewRendered="renderHandler">
+                <Map>
+                    <Basemap><BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" /></Basemap>
+                    <FeatureLayer @ref="layer"
+                                  Source="@([])"
+                                  OutFields="@(["*"])"
+                                  SpatialReference="SpatialReference.Wgs84"
+                                  GeometryType="FeatureGeometryType.Point"
+                                  ObjectIdField="OBJECT_ID" />
+                </Map>
+            </MapView>);
+
+        await WaitForMapToRender();
+        await AssertJavaScript("assertLayerExists", args: "feature");
+
+        var renderer = new SimpleRenderer(new SimpleMarkerSymbol(color: new MapColor("red")));
+        await layer!.SetRenderer(renderer);
+        var gotRenderer = await layer!.GetRenderer();
+        Assert.IsNotNull(gotRenderer);
+        await AssertJavaScript("assertFeatureLayerRendererType", args: [layer!.Id, "simple"]);
+
+        var pt = new PopupTemplate("Test title");
+        await layer!.SetPopupTemplate(pt);
+        var gotPt = await layer!.GetPopupTemplate();
+        Assert.IsNotNull(gotPt);
+        await AssertJavaScript("assertFeatureLayerPopupTitle", args: [layer!.Id, "Test title"]);
+
+        var effect = new Effect("drop-shadow(2px,2px,2px)");
+        await layer!.SetEffect(effect);
+        var gotEffect = await layer!.GetEffect();
+        Assert.IsNotNull(gotEffect);
+    }
+
+    [TestMethod]
+    public async Task FeatureLayer_RemainingQueries_And_Clone_And_Refresh_And_Events(Action renderHandler)
+    {
+        FeatureLayer? layer = null;
+
+        AddMapRenderFragment(
+            @<MapView class="map-view" OnViewRendered="renderHandler" Longitude="-97.75188" Latitude="37.23308">
+                <Map>
+                    <Basemap><BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" /></Basemap>
+                    <FeatureLayer @ref="layer" OutFields="@(new [] { "*" })"
+                                  Url="https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/US_National_Parks_Annual_Visitation/FeatureServer/0" />
+                </Map>
+            </MapView>);
+
+        await WaitForMapToRender();
+
+        var q = await layer!.CreateQuery();
+        q.ReturnGeometry = true;
+        q.OutFields = ["*"];
+
+        var count = await layer!.QueryFeatureCount(q);
+        Assert.IsTrue(count >= 0);
+
+        var extent = await layer!.QueryExtent(q);
+        Assert.IsNotNull(extent);
+
+        string[] orderByField = ["TOTAL DESC"];
+        TopFeaturesQuery topQuery = new()
+        {
+            TopFilter = new TopFilter(["State"], orderByField, 3),
+            ReturnGeometry = true,
+            OutFields = ["State, TOTAL, F2018, F2019, F2020, Park"]
+        };
+
+        var topCount = await layer!.QueryTopFeatureCount(topQuery);
+        Assert.IsTrue(topCount > 0);
+
+        var topExtent = await layer!.QueryTopFeaturesExtent(topQuery);
+        Assert.IsNotNull(topExtent);
+
+        FeatureLayer? relLayer = null;
+        AddMapRenderFragment(
+            @<MapView class="map-view">
+                <Map>
+                    <FeatureLayer @ref="relLayer" OutFields="@(new[] { "*" })">
+                        <PortalItem PortalItemId="234d2e3f6f554e0e84757662469c26d3" />
+                    </FeatureLayer>
+                </Map>
+                <Extent Xmax="-13620669.8431" Xmin="-13640432.281" Ymax="4556710.618000001" Ymin="4536523.6511999965">
+                    <SpatialReference Wkid="102100" />
+                </Extent>
+            </MapView>);
+        await Task.Delay(500);
+
+        var relQuery = new RelationshipQuery
+        {
+            RelationshipId = 0,                 // set this to a valid relationship id
+            ObjectIds      = new[] { new ObjectId(1) }
+        };
+
+        var relCounts = await relLayer!.QueryRelatedFeaturesCount(relQuery);
+        Assert.IsNotNull(relCounts);
+        Assert.IsTrue(relCounts!.Values.All(c => c >= 0));
+
+        var clone = await layer!.Clone();
+        Assert.IsNotNull(clone);
+
+        var editsTcs   = new TaskCompletionSource<FeatureLayerEditsEvent>();
+        var refreshTcs = new TaskCompletionSource<RefreshEvent>();
+
+        AddMapRenderFragment(
+        @<MapView class="map-view">
+            <Map>
+                <FeatureLayer @ref="layer"
+                    Url="https://services.arcgis.com/..."
+                    OutFields="@(new[] { "*" })"
+                    OnEdits="@(EventCallback.Factory.Create<FeatureLayerEditsEvent>(this, e => editsTcs.TrySetResult(e)))"
+                    OnRefresh="@(EventCallback.Factory.Create<RefreshEvent>(this, e => refreshTcs.TrySetResult(e)))" />
+            </Map>
+        </MapView>);
+
+        await layer!.Add(new Graphic(new Point(-117, 34, 0), new SimpleMarkerSymbol(color: new MapColor("black"))));
+        var editsEvent = await Task.WhenAny(editsTcs.Task, Task.Delay(5000));
+        Assert.AreSame(editsTcs.Task, editsEvent);
+
+        await layer.Refresh();
+        var refreshEvent = await Task.WhenAny(refreshTcs.Task, Task.Delay(5000));
+        Assert.AreSame(refreshTcs.Task, refreshEvent);
+    }
+
+    [TestMethod]
+    public async Task FeatureLayer_All_Getters_Invoke_JS(Action renderHandler)
+    {
+        FeatureLayer? layer = null;
+
+        AddMapRenderFragment(
+            @<MapView class="map-view" OnViewRendered="renderHandler">
+                <Map>
+                    <Basemap><BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" /></Basemap>
+                    <FeatureLayer @ref="layer"
+                                  Source="@([])"
+                                  OutFields="@(["*"])"
+                                  SpatialReference="SpatialReference.Wgs84"
+                                  GeometryType="FeatureGeometryType.Point"
+                                  ObjectIdField="OBJECT_ID" />
+                </Map>
+            </MapView>);
+
+        await WaitForMapToRender();
+
+        _ = await layer!.GetApiKey();
+        _ = await layer!.GetAttributeTableTemplate();
+        _ = await layer!.GetBlendMode();
+        _ = await layer!.GetCapabilities();
+        _ = await layer!.GetCharts();
+        _ = await layer!.GetCopyright();
+        _ = await layer!.GetDateFieldsTimeZone();
+        _ = await layer!.GetDatesInUnknownTimezone();
+        _ = await layer!.GetDefinitionExpression();
+        _ = await layer!.GetDisplayField();
+        _ = await layer!.GetDisplayFilterEnabled();
+        _ = await layer!.GetDisplayFilterInfo();
+        _ = await layer!.GetDynamicDataSource();
+        _ = await layer!.GetEditFieldsInfo();
+        _ = await layer!.GetEditingEnabled();
+        _ = await layer!.GetEditingInfo();
+        _ = await layer!.GetEffect();
+        _ = await layer!.GetEffectiveCapabilities();
+        _ = await layer!.GetEffectiveEditingEnabled();
+        _ = await layer!.GetElevationInfo();
+        _ = await layer!.GetFeatureEffect();
+        _ = await layer!.GetFeatureReduction();
+        var g = new Graphic(new Point(-117, 34, 0)); // x, y, z
+        _ = await layer!.GetFeatureType(g);
+        _ = await layer!.GetField("OBJECT_ID");
+        _ = await layer!.GetFieldDomain("OBJECT_ID");
+        _ = await layer!.GetFields();
+        _ = await layer!.GetFieldsIndex();
+        _ = await layer!.GetFloorInfo();
+        _ = await layer!.GetFormTemplate();
+        _ = await layer!.GetGdbVersion();
+        _ = await layer!.GetGeometryFieldsInfo();
+        _ = await layer!.GetGeometryType();
+        _ = await layer!.GetGlobalIdField();
+        _ = await layer!.GetHasM();
+        _ = await layer!.GetHasZ();
+        _ = await layer!.GetHistoricMoment();
+        _ = await layer!.GetIsTable();
+        _ = await layer!.GetLabelingInfo();
+        _ = await layer!.GetLabelsVisible();
+        _ = await layer!.GetLayerIndex();
+        _ = await layer!.GetLegendEnabled();
+        _ = await layer!.GetMaxScale();
+        _ = await layer!.GetMinScale();
+        _ = await layer!.GetObjectIdField();
+        _ = await layer!.GetOrderBy();
+        _ = await layer!.GetOutFields();
+        _ = await layer!.GetPopupEnabled();
+        _ = await layer!.GetPopupTemplate();
+        _ = await layer!.GetPortalItem();
+        _ = await layer!.GetPreferredTimeZone();
+        _ = await layer!.GetPublishingInfo();
+        _ = await layer!.GetRefreshInterval();
+        _ = await layer!.GetRelationships();
+        _ = await layer!.GetRenderer();
+        _ = await layer!.GetReturnM();
+        _ = await layer!.GetReturnZ();
+        _ = await layer!.GetScreenSizePerspectiveEnabled();
+        _ = await layer!.GetServiceDefinitionExpression();
+        _ = await layer!.GetServiceItemId();
+        _ = await layer!.GetSourceJSON();
+        _ = await layer!.GetSpatialReference();
+        _ = await layer!.GetSubtypeField();
+        _ = await layer!.GetSubtypes();
+        _ = await layer!.GetTemplates();
+        _ = await layer!.GetTimeExtent();
+        _ = await layer!.GetTimeInfo();
+        _ = await layer!.GetTimeOffset();
+        _ = await layer!.GetTrackInfo();
+        _ = await layer!.GetTypeIdField();
+        _ = await layer!.GetTypes();
+        _ = await layer!.GetUniqueIdFields();
+        _ = await layer!.GetUrl();
+        _ = await layer!.GetUseViewTime();
+        _ = await layer!.GetVersion();
+    }
 }

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerViewTests.razor
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/FeatureLayerViewTests.razor
@@ -58,4 +58,127 @@
         Assert.IsNotNull(result);
         Assert.IsTrue(result.Features!.Count > 0);
     }
+
+    [TestMethod]
+    public async Task FeatureLayerView_PropertyRoundtrips_And_Queries(Action renderHandler)
+    {
+        FeatureLayer? layer = null;
+        FeatureLayerView? layerView = null;
+
+        void OnLayerViewCreate(LayerViewCreateEvent e)
+        {
+            if (e.Layer is FeatureLayer && e.LayerView is FeatureLayerView flv)
+            {
+                layerView = flv;
+            }
+        }
+
+        List<Graphic> graphics = [];
+        graphics.Add(new Graphic(new Point(0, 0), attributes: new AttributesDictionary(new Dictionary<string, object?> { ["OBJECTID"] = 1 })));
+        graphics.Add(new Graphic(new Point(1, 1), attributes: new AttributesDictionary(new Dictionary<string, object?> { ["OBJECTID"] = 2 })));
+
+        AddMapRenderFragment(
+            @<MapView class="map-view" OnViewRendered="renderHandler" OnLayerViewCreate="OnLayerViewCreate">
+            <Map>
+                <Basemap><BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" /></Basemap>
+                <FeatureLayer @ref="layer"
+                              Source="graphics"
+                              OutFields="@(["*"])"
+                              SpatialReference="SpatialReference.Wgs84"
+                              GeometryType="FeatureGeometryType.Point"
+                              ObjectIdField="OBJECTID" />
+            </Map>
+        </MapView>);
+
+        await WaitForMapToRender();
+
+        var tries = 100;
+        while (layerView is null && tries-- > 0) { await Task.Delay(50); }
+        Assert.IsNotNull(layerView);
+
+        var filter = new FeatureFilter(where: "OBJECTID > 0");
+        await layerView!.SetFilter(filter);
+        var gotFilter = await layerView!.GetFilter();
+        Assert.IsNotNull(gotFilter);
+        await AssertJavaScript("assertFeatureLayerViewFilterWhere", args: [layer!.Id, "OBJECTID > 0"]);
+
+        await layerView!.SetFeatureEffect(new FeatureEffect());
+        var gotFx = await layerView!.GetFeatureEffect();
+        Assert.IsNotNull(gotFx);
+
+        var hl = new HighlightOptions(color: new MapColor("cyan"), fillOpacity: 1.0, haloOpacity: 1.0);
+        await layerView!.SetHighlightOptions(hl);
+        await layerView!.SetHighlightOptions(hl);
+        var gotHl = await layerView!.GetHighlightOptions();
+        Assert.IsNotNull(gotHl);
+
+        await layerView!.SetMaximumNumberOfFeatures(10);
+        Assert.AreEqual(10, await layerView!.GetMaximumNumberOfFeatures());
+        await AssertJavaScript("assertFeatureLayerViewMaxFeatures", args: [layer!.Id, 10]);
+
+        await layerView!.SetMaximumNumberOfFeaturesExceeded(false);
+        Assert.AreEqual(false, await layerView!.GetMaximumNumberOfFeaturesExceeded());
+
+        var q = await layerView!.CreateQuery();
+        q.ReturnGeometry = true;
+        q.OutFields = ["*"];
+
+        var cnt = await layerView!.QueryFeatureCount(q);
+        Assert.IsTrue(cnt >= 0);
+
+        var ex = await layerView!.QueryExtent(q);
+        Assert.IsNotNull(ex);
+
+        var ids = await layerView.QueryObjectIds(q);
+        Assert.IsNotNull(ids);
+        Assert.IsTrue(ids!.Length >= 0);
+
+        var handle1 = await layerView!.Highlight(graphics[0]);
+        Assert.IsNotNull(handle1);
+
+        var handle2 = await layerView!.Highlight(new ObjectId(1));
+        Assert.IsNotNull(handle2);
+    }
+
+    [TestMethod]
+    public async Task FeatureLayerView_All_Getters_Invoke_JS(Action renderHandler)
+    {
+        FeatureLayer? layer = null;
+        FeatureLayerView? layerView = null;
+
+        void OnLayerViewCreate(LayerViewCreateEvent e)
+        {
+            if (e.Layer is FeatureLayer && e.LayerView is FeatureLayerView flv) layerView = flv;
+        }
+
+        AddMapRenderFragment(
+            @<MapView class="map-view" OnViewRendered="renderHandler" OnLayerViewCreate="OnLayerViewCreate">
+            <Map>
+                <Basemap><BasemapStyle Name="BasemapStyleName.ArcgisTopographicBase" /></Basemap>
+                <FeatureLayer @ref="layer"
+                              Source="@([])"
+                              OutFields="@(["*"])"
+                              SpatialReference="SpatialReference.Wgs84"
+                              GeometryType="FeatureGeometryType.Point"
+                              ObjectIdField="OBJECTID" />
+            </Map>
+        </MapView>);
+
+        await WaitForMapToRender();
+
+        var tries = 100;
+        while (layerView is null && tries-- > 0) { await Task.Delay(50); }
+        Assert.IsNotNull(layerView);
+
+        _ = await layerView!.GetAvailableFields();
+        _ = await layerView!.GetDataUpdating();
+        _ = await layerView!.GetFeatureEffect();
+        _ = await layerView!.GetFilter();
+        _ = await layerView!.GetHasAllFeatures();
+        _ = await layerView!.GetHasAllFeaturesInView();
+        _ = await layerView!.GetHasFullGeometries();
+        _ = await layerView!.GetHighlightOptions();
+        _ = await layerView!.GetMaximumNumberOfFeatures();
+        _ = await layerView!.GetMaximumNumberOfFeaturesExceeded();
+    }
 }

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/wwwroot/featureLayerAsserts.js
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/wwwroot/featureLayerAsserts.js
@@ -1,0 +1,72 @@
+﻿(function (root) {
+  function resolveLayerById(id) {
+    if (root.getLayerById) return root.getLayerById(id);
+    if (root.geoBlazor?.interop?.getLayerById) return root.geoBlazor.interop.getLayerById(id);
+    const views = root.__geoblazor_views || (root.__map?.views ? [root.__map.views[0]] : []);
+    for (const v of views) {
+      if (!v?.map?.layers) continue;
+      const lyr = v.map.layers.find?.(l => l.id === id);
+      if (lyr) return lyr;
+    }
+    throw new Error("Layer not found for id: " + id);
+  }
+
+  function assertEq(actual, expected, msg) {
+    if (Array.isArray(expected)) {
+      const pass = Array.isArray(actual) && expected.length === actual.length
+        ? expected.every((v, i) => v === actual[i])
+        : false;
+      if (!pass) throw new Error(msg + ` (expected: ${JSON.stringify(expected)}, actual: ${JSON.stringify(actual)})`);
+      return;
+    }
+    if (actual !== expected) {
+      throw new Error(msg + ` (expected: ${JSON.stringify(expected)}, actual: ${JSON.stringify(actual)})`);
+    }
+  }
+
+  root.assertFeatureLayerBooleanPropEquals = function (id, prop, expected) {
+    const layer = resolveLayerById(id);
+    assertEq(!!layer[prop], !!expected, `Boolean property mismatch: ${prop}`);
+  };
+
+  root.assertFeatureLayerNumberPropEquals = function (id, prop, expected) {
+    const layer = resolveLayerById(id);
+    assertEq(Number(layer[prop]), Number(expected), `Number property mismatch: ${prop}`);
+  };
+
+  root.assertFeatureLayerStringPropEquals = function (id, prop, expected) {
+    const layer = resolveLayerById(id);
+    assertEq(String(layer[prop] ?? ""), String(expected ?? ""), `String property mismatch: ${prop}`);
+  };
+
+  root.assertFeatureLayerArrayPropEquals = function (id, prop, expected) {
+    const layer = resolveLayerById(id);
+    const arr = Array.isArray(layer[prop]) ? layer[prop] : [];
+    assertEq(arr, expected, `Array property mismatch: ${prop}`);
+  };
+
+  root.assertFeatureLayerRendererType = function (id, expectedType) {
+    const layer = resolveLayerById(id);
+    const t = layer.renderer?.type;
+    if (t !== expectedType) {
+      throw new Error(`Renderer type mismatch. expected=${expectedType}, actual=${t}`);
+    }
+  };
+
+  root.assertFeatureLayerPopupTitle = function (id, expectedTitle) {
+    const layer = resolveLayerById(id);
+    const t = layer.popupTemplate?.title;
+    if (String(t ?? "") !== String(expectedTitle ?? "")) {
+      throw new Error(`PopupTemplate.title mismatch. expected=${expectedTitle}, actual=${t}`);
+    }
+  };
+
+  root.assertFeatureLayerOrderByContains = function (id, field, order) {
+    const layer = resolveLayerById(id);
+    const items = layer.orderBy || [];
+    const hit = items.some(i => i?.field === field && String(i?.order || "").toUpperCase() === String(order).toUpperCase());
+    if (!hit) {
+      throw new Error(`orderBy missing expected entry: ${field} ${order}`);
+    }
+  };
+})(window);

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/wwwroot/featureLayerViewAsserts.js
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/wwwroot/featureLayerViewAsserts.js
@@ -1,0 +1,30 @@
+﻿(function (root) {
+  function resolveLayerView(layerId) {
+    if (root.getLayerViewByLayerId) return root.getLayerViewByLayerId(layerId);
+    const views = root.__geoblazor_views || (root.__map?.views ? [root.__map.views[0]] : []);
+    for (const v of views) {
+      if (!v?.map?.layers) continue;
+      const lyr = v.map.layers.find?.(l => l.id === layerId);
+      if (!lyr) continue;
+      const lv = v?.whenLayerView ? v.layerViews?.find?.(x => x.layer?.id === layerId) : null;
+      return lv || lyr?.views?.[0] || null;
+    }
+    throw new Error("LayerView not found for layerId: " + layerId);
+  }
+
+  root.assertFeatureLayerViewFilterWhere = function (layerId, expectedWhere) {
+    const lv = resolveLayerView(layerId);
+    const w = lv?.filter?.where ?? "";
+    if (String(w) !== String(expectedWhere)) {
+      throw new Error(`LayerView.filter.where mismatch. expected=${expectedWhere}, actual=${w}`);
+    }
+  };
+
+  root.assertFeatureLayerViewMaxFeatures = function (layerId, expected) {
+    const lv = resolveLayerView(layerId);
+    const v = lv?.maximumNumberOfFeatures;
+    if (Number(v) !== Number(expected)) {
+      throw new Error(`maximumNumberOfFeatures mismatch. expected=${expected}, actual=${v}`);
+    }
+  };
+})(window);


### PR DESCRIPTION
I expanded our end-to-end test coverage around FeatureLayer and stood up the JavaScript assertion helpers. The FeatureLayer test suite now exercises real rendering of a map/layer, visibility toggling, adding/updating/deleting features via `ApplyEdits` and `Add`, and the core query flows (`QueryFeatures`, `QueryObjectIds`, `QueryRelatedFeatures`, and `QueryTopFeatures`). It also validates key metadata accessors such as capabilities and field/domain inspection, and includes a scenario that confirms we can use a public FeatureLayer without an API key. On the view side, I established baseline coverage for `FeatureLayerView` by adding a query test. To support all of this, I added small JS helpers (`featureLayerAsserts.js` and `featureLayerViewAsserts.js`) that the Razor tests call through `AssertJavaScript`, so each test asserts the state of the underlying ArcGIS JS objects. Net result: broader, more reliable coverage of our FeatureLayer interop paths with minimal harness changes.

Closes #472 