### PR TITLE
`activatorutilitesconstructor` attribute validation console app

### DIFF
--- a/src/dymaptic.GeoBlazor.Core.sln
+++ b/src/dymaptic.GeoBlazor.Core.sln
@@ -40,6 +40,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dymaptic.GeoBlazor.Core.Sam
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dymaptic.GeoBlazor.Core.Sample.TokenRefresh.Client", "..\samples\dymaptic.GeoBlazor.Core.Sample.TokenRefresh\dymaptic.GeoBlazor.Core.Sample.TokenRefresh.Client\dymaptic.GeoBlazor.Core.Sample.TokenRefresh.Client.csproj", "{6CB414BD-0536-A361-CEFF-C84EE3906931}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dymaptic.GeoBlazor.Core.Test.ConstructorTesting", "..\test\dymaptic.GeoBlazor.Core.Test.ConstructorTesting\dymaptic.GeoBlazor.Core.Test.ConstructorTesting.csproj", "{B1234567-89AB-CDEF-0123-456789ABCDEF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -112,6 +114,10 @@ Global
 		{6CB414BD-0536-A361-CEFF-C84EE3906931}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6CB414BD-0536-A361-CEFF-C84EE3906931}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6CB414BD-0536-A361-CEFF-C84EE3906931}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1234567-89AB-CDEF-0123-456789ABCDEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1234567-89AB-CDEF-0123-456789ABCDEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1234567-89AB-CDEF-0123-456789ABCDEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1234567-89AB-CDEF-0123-456789ABCDEF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/dymaptic.GeoBlazor.Core/Components/Geometries/OldPolyLine.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Geometries/OldPolyLine.cs
@@ -10,6 +10,7 @@ public class PolyLine : Polyline
     /// <summary>
     ///     Constructor for the PolyLine class.
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public PolyLine()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/Components/Renderers/DimensionalDefinitionValues.cs
+++ b/src/dymaptic.GeoBlazor.Core/Components/Renderers/DimensionalDefinitionValues.cs
@@ -10,6 +10,7 @@ public class DimensionalDefinitionValues : MapComponent
     /// <summary>
     ///     Constructor for use as a razor component
     /// </summary>
+    [ActivatorUtilitiesConstructor]
     public DimensionalDefinitionValues()
     {
     }

--- a/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
+++ b/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
@@ -114,4 +114,12 @@
         <Message Importance="high" Text="Clearing locks on esBuild files..." />
         <Exec Command="pwsh $(ProjectDir)../../esBuildClearLocks.ps1" ContinueOnError="false" />
     </Target>
+
+    <Target Name="ValidateConstructors" AfterTargets="Build">
+        <Message Importance="high" Text="Validating constructor patterns..." />
+        <Exec Command="dotnet run --project $(ProjectDir)../../test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/dymaptic.GeoBlazor.Core.Test.ConstructorTesting.csproj --configuration $(Configuration)"
+              WorkingDirectory="$(ProjectDir)"
+              ContinueOnError="true"
+              IgnoreExitCode="true" />
+    </Target>
 </Project>

--- a/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
+++ b/src/dymaptic.GeoBlazor.Core/dymaptic.GeoBlazor.Core.csproj
@@ -117,9 +117,10 @@
 
     <Target Name="ValidateConstructors" AfterTargets="Build">
         <Message Importance="high" Text="Validating constructor patterns..." />
-        <Exec Command="dotnet run --project $(ProjectDir)../../test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/dymaptic.GeoBlazor.Core.Test.ConstructorTesting.csproj --configuration $(Configuration)"
+        <Exec Command="$(ProjectDir)../../test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/bin/$(Configuration)/net9.0/dymaptic.GeoBlazor.Core.Test.ConstructorTesting.exe"
               WorkingDirectory="$(ProjectDir)"
               ContinueOnError="true"
-              IgnoreExitCode="true" />
+              IgnoreExitCode="true"
+              Condition="Exists('$(ProjectDir)../../test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/bin/$(Configuration)/net9.0/dymaptic.GeoBlazor.Core.Test.ConstructorTesting.exe')" />
     </Target>
 </Project>

--- a/test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/Program.cs
+++ b/test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/Program.cs
@@ -1,0 +1,145 @@
+using Microsoft.Build.Locator;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.MSBuild;
+
+namespace dymaptic.GeoBlazor.Core.Test.ConstructorTesting;
+
+class Program
+{
+    static async Task<int> Main(string[] args)
+    {
+        // Register MSBuild
+        MSBuildLocator.RegisterDefaults();
+
+        // Find the solution file
+        var currentDirectory = Directory.GetCurrentDirectory();
+        var solutionPath = FindSolutionFile(currentDirectory);
+
+        if (string.IsNullOrEmpty(solutionPath))
+        {
+            Console.WriteLine("Could not find solution file (.sln) in the repository.");
+            return 1;
+        }
+
+        using var workspace = MSBuildWorkspace.Create();
+        var solution = await workspace.OpenSolutionAsync(solutionPath);
+
+        var nonCompliantClasses = new List<(string className, string filePath)>();
+
+        foreach (var project in solution.Projects)
+        {
+            var compilation = await project.GetCompilationAsync();
+            if (compilation == null) continue;
+
+            foreach (var syntaxTree in compilation.SyntaxTrees)
+            {
+                var semanticModel = compilation.GetSemanticModel(syntaxTree);
+                var root = await syntaxTree.GetRootAsync();
+
+                // Find all class declarations
+                var classDeclarations = root.DescendantNodes().OfType<ClassDeclarationSyntax>();
+
+                foreach (var classDeclaration in classDeclarations)
+                {
+                    var classSymbol = semanticModel.GetDeclaredSymbol(classDeclaration);
+                    if (classSymbol == null) continue;
+
+                    // Check if the class inherits from ComponentBase
+                    if (!InheritsFromComponentBase(classSymbol)) continue;
+
+                    // Get all constructors
+                    var constructors = classSymbol.Constructors
+                        .Where(c => !c.IsImplicitlyDeclared && c.DeclaredAccessibility == Accessibility.Public)
+                        .ToList();
+
+                    // Check if class has 2 or more constructors
+                    if (constructors.Count >= 2)
+                    {
+                        // Check if there's a parameterless constructor with [ActivatorUtilitiesConstructor]
+                        var hasCompliantParameterlessConstructor = constructors.Any(c =>
+                            c.Parameters.Length == 0 &&
+                            HasActivatorUtilitiesConstructorAttribute(c));
+
+                        if (!hasCompliantParameterlessConstructor)
+                        {
+                            var filePath = syntaxTree.FilePath;
+                            var relativePath = Path.GetRelativePath(Path.GetDirectoryName(solutionPath)!, filePath);
+                            nonCompliantClasses.Add((classSymbol.Name, relativePath));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Output results
+        if (nonCompliantClasses.Count == 0)
+        {
+            Console.WriteLine("All classes with 2+ constructors have a parameterless constructor using the [ActivatorUtilitiesConstructor] attribute.");
+            return 0;
+        }
+        else
+        {
+            Console.WriteLine("The following classes contain 2+ constructors, but do not have a parameterless constructor that correctly uses the [ActivatorUtilitiesConstructor] attribute. Please update the following list of the class names:");
+            foreach (var (className, filePath) in nonCompliantClasses)
+            {
+                Console.WriteLine($"- {className} - {filePath}");
+            }
+            return 1;
+        }
+    }
+
+    static string FindSolutionFile(string startDirectory)
+    {
+        var directory = new DirectoryInfo(startDirectory);
+
+        while (directory != null)
+        {
+            // Look for the specific solution file
+            var solutionFile = Path.Combine(directory.FullName, "src", "dymaptic.GeoBlazor.Core.sln");
+            if (File.Exists(solutionFile))
+            {
+                return solutionFile;
+            }
+
+            // Move up one directory
+            directory = directory.Parent;
+        }
+
+        return string.Empty;
+    }
+
+    static bool InheritsFromComponentBase(INamedTypeSymbol classSymbol)
+    {
+        var baseType = classSymbol.BaseType;
+
+        while (baseType != null)
+        {
+            // Check for ComponentBase (could be in Microsoft.AspNetCore.Components namespace)
+            if (baseType.Name == "ComponentBase" ||
+                baseType.ToString()?.Contains("ComponentBase") == true)
+            {
+                return true;
+            }
+
+            // Also check for MapComponent which likely inherits from ComponentBase
+            if (baseType.Name == "MapComponent" ||
+                baseType.ToString()?.Contains("MapComponent") == true)
+            {
+                return true;
+            }
+
+            baseType = baseType.BaseType;
+        }
+
+        return false;
+    }
+
+    static bool HasActivatorUtilitiesConstructorAttribute(IMethodSymbol constructor)
+    {
+        return constructor.GetAttributes().Any(attr =>
+            attr.AttributeClass?.Name == "ActivatorUtilitiesConstructorAttribute" ||
+            attr.AttributeClass?.Name == "ActivatorUtilitiesConstructor");
+    }
+}

--- a/test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/Program.cs
+++ b/test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/Program.cs
@@ -6,90 +6,172 @@ using Microsoft.CodeAnalysis.MSBuild;
 
 namespace dymaptic.GeoBlazor.Core.Test.ConstructorTesting;
 
+/// <summary>
+/// Console application that validates ComponentBase-derived classes have proper constructor attributes.
+/// </summary>
 class Program
 {
+    private const string SUCCESS_MESSAGE = "All classes with 2+ constructors have a parameterless constructor using the [ActivatorUtilitiesConstructor] attribute.";
+    private const string FAILURE_MESSAGE = "The following classes contain 2+ constructors, but do not have a parameterless constructor that correctly uses the [ActivatorUtilitiesConstructor] attribute. Please update the following list of the class names:";
+
     static async Task<int> Main(string[] args)
     {
-        // Register MSBuild
-        MSBuildLocator.RegisterDefaults();
-
-        // Find the solution file
-        var currentDirectory = Directory.GetCurrentDirectory();
-        var solutionPath = FindSolutionFile(currentDirectory);
-
-        if (string.IsNullOrEmpty(solutionPath))
+        try
         {
-            Console.WriteLine("Could not find solution file (.sln) in the repository.");
-            return 1;
-        }
+            // Initialize MSBuild for Roslyn workspace
+            MSBuildLocator.RegisterDefaults();
 
-        using var workspace = MSBuildWorkspace.Create();
-        var solution = await workspace.OpenSolutionAsync(solutionPath);
-
-        var nonCompliantClasses = new List<(string className, string filePath)>();
-
-        foreach (var project in solution.Projects)
-        {
-            var compilation = await project.GetCompilationAsync();
-            if (compilation == null) continue;
-
-            foreach (var syntaxTree in compilation.SyntaxTrees)
+            // Locate and load the solution
+            var solutionPath = FindSolutionFile(Directory.GetCurrentDirectory());
+            if (string.IsNullOrEmpty(solutionPath))
             {
-                var semanticModel = compilation.GetSemanticModel(syntaxTree);
-                var root = await syntaxTree.GetRootAsync();
-
-                // Find all class declarations
-                var classDeclarations = root.DescendantNodes().OfType<ClassDeclarationSyntax>();
-
-                foreach (var classDeclaration in classDeclarations)
-                {
-                    var classSymbol = semanticModel.GetDeclaredSymbol(classDeclaration);
-                    if (classSymbol == null) continue;
-
-                    // Check if the class inherits from ComponentBase
-                    if (!InheritsFromComponentBase(classSymbol)) continue;
-
-                    // Get all constructors
-                    var constructors = classSymbol.Constructors
-                        .Where(c => !c.IsImplicitlyDeclared && c.DeclaredAccessibility == Accessibility.Public)
-                        .ToList();
-
-                    // Check if class has 2 or more constructors
-                    if (constructors.Count >= 2)
-                    {
-                        // Check if there's a parameterless constructor with [ActivatorUtilitiesConstructor]
-                        var hasCompliantParameterlessConstructor = constructors.Any(c =>
-                            c.Parameters.Length == 0 &&
-                            HasActivatorUtilitiesConstructorAttribute(c));
-
-                        if (!hasCompliantParameterlessConstructor)
-                        {
-                            var filePath = syntaxTree.FilePath;
-                            var relativePath = Path.GetRelativePath(Path.GetDirectoryName(solutionPath)!, filePath);
-                            nonCompliantClasses.Add((classSymbol.Name, relativePath));
-                        }
-                    }
-                }
+                Console.WriteLine("Could not find solution file (.sln) in the repository.");
+                return 1;
             }
-        }
 
-        // Output results
-        if (nonCompliantClasses.Count == 0)
-        {
-            Console.WriteLine("All classes with 2+ constructors have a parameterless constructor using the [ActivatorUtilitiesConstructor] attribute.");
-            return 0;
+            // Analyze all projects in the solution
+            var nonCompliantClasses = await AnalyzeSolution(solutionPath);
+
+            // Report results
+            return ReportResults(nonCompliantClasses);
         }
-        else
+        catch (Exception ex)
         {
-            Console.WriteLine("The following classes contain 2+ constructors, but do not have a parameterless constructor that correctly uses the [ActivatorUtilitiesConstructor] attribute. Please update the following list of the class names:");
-            foreach (var (className, filePath) in nonCompliantClasses)
-            {
-                Console.WriteLine($"- {className} - {filePath}");
-            }
+            Console.WriteLine($"Error: {ex.Message}");
             return 1;
         }
     }
 
+    /// <summary>
+    /// Analyzes all projects in the solution for constructor compliance.
+    /// </summary>
+    static async Task<List<(string className, string filePath)>> AnalyzeSolution(string solutionPath)
+    {
+        using var workspace = MSBuildWorkspace.Create();
+        var solution = await workspace.OpenSolutionAsync(solutionPath);
+        var nonCompliantClasses = new List<(string className, string filePath)>();
+
+        foreach (var project in solution.Projects)
+        {
+            var projectViolations = await AnalyzeProject(project, solutionPath);
+            nonCompliantClasses.AddRange(projectViolations);
+        }
+
+        return nonCompliantClasses;
+    }
+
+    /// <summary>
+    /// Analyzes a single project for constructor compliance.
+    /// </summary>
+    static async Task<List<(string className, string filePath)>> AnalyzeProject(Project project, string solutionPath)
+    {
+        var violations = new List<(string className, string filePath)>();
+        var compilation = await project.GetCompilationAsync();
+        if (compilation == null) return violations;
+
+        foreach (var syntaxTree in compilation.SyntaxTrees)
+        {
+            var classViolations = await AnalyzeSyntaxTree(syntaxTree, compilation, solutionPath);
+            violations.AddRange(classViolations);
+        }
+
+        return violations;
+    }
+
+    /// <summary>
+    /// Analyzes a single syntax tree (file) for constructor compliance.
+    /// </summary>
+    static async Task<List<(string className, string filePath)>> AnalyzeSyntaxTree(
+        SyntaxTree syntaxTree,
+        Compilation compilation,
+        string solutionPath)
+    {
+        var violations = new List<(string className, string filePath)>();
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+        var root = await syntaxTree.GetRootAsync();
+
+        // Find all class declarations in this file
+        var classDeclarations = root.DescendantNodes().OfType<ClassDeclarationSyntax>();
+
+        foreach (var classDeclaration in classDeclarations)
+        {
+            var violation = AnalyzeClass(classDeclaration, semanticModel, syntaxTree.FilePath, solutionPath);
+            if (violation.HasValue)
+            {
+                violations.Add(violation.Value);
+            }
+        }
+
+        return violations;
+    }
+
+    /// <summary>
+    /// Analyzes a single class for constructor compliance.
+    /// Returns violation info if non-compliant, null otherwise.
+    /// </summary>
+    static (string className, string filePath)? AnalyzeClass(
+        ClassDeclarationSyntax classDeclaration,
+        SemanticModel semanticModel,
+        string filePath,
+        string solutionPath)
+    {
+        var classSymbol = semanticModel.GetDeclaredSymbol(classDeclaration);
+        if (classSymbol == null) return null;
+
+        // Skip classes that don't inherit from ComponentBase
+        if (!InheritsFromComponentBase(classSymbol)) return null;
+
+        // Get public constructors (excluding compiler-generated ones)
+        var constructors = classSymbol.Constructors
+            .Where(c => !c.IsImplicitlyDeclared && c.DeclaredAccessibility == Accessibility.Public)
+            .ToList();
+
+        // Only check classes with 2 or more constructors
+        if (constructors.Count < 2) return null;
+
+        // Check for compliant parameterless constructor
+        var hasCompliantParameterlessConstructor = constructors.Any(IsCompliantParameterlessConstructor);
+
+        if (!hasCompliantParameterlessConstructor)
+        {
+            var relativePath = Path.GetRelativePath(Path.GetDirectoryName(solutionPath)!, filePath);
+            return (classSymbol.Name, relativePath);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Checks if a constructor is parameterless and has the required attribute.
+    /// </summary>
+    static bool IsCompliantParameterlessConstructor(IMethodSymbol constructor)
+    {
+        return constructor.Parameters.Length == 0 &&
+               HasActivatorUtilitiesConstructorAttribute(constructor);
+    }
+
+    /// <summary>
+    /// Reports the analysis results to the console.
+    /// </summary>
+    static int ReportResults(List<(string className, string filePath)> nonCompliantClasses)
+    {
+        if (nonCompliantClasses.Count == 0)
+        {
+            Console.WriteLine(SUCCESS_MESSAGE);
+            return 0;
+        }
+
+        Console.WriteLine(FAILURE_MESSAGE);
+        foreach (var (className, filePath) in nonCompliantClasses)
+        {
+            Console.WriteLine($"- {className} - {filePath}");
+        }
+        return 1;
+    }
+
+    /// <summary>
+    /// Finds the solution file by traversing up from the current directory.
+    /// </summary>
     static string FindSolutionFile(string startDirectory)
     {
         var directory = new DirectoryInfo(startDirectory);
@@ -110,22 +192,26 @@ class Program
         return string.Empty;
     }
 
+    /// <summary>
+    /// Checks if a class inherits from ComponentBase (directly or through MapComponent).
+    /// Most GeoBlazor components inherit from MapComponent, which inherits from ComponentBase.
+    /// </summary>
     static bool InheritsFromComponentBase(INamedTypeSymbol classSymbol)
     {
         var baseType = classSymbol.BaseType;
 
         while (baseType != null)
         {
-            // Check for ComponentBase (could be in Microsoft.AspNetCore.Components namespace)
-            if (baseType.Name == "ComponentBase" ||
-                baseType.ToString()?.Contains("ComponentBase") == true)
+            var typeName = baseType.Name;
+
+            // Check for MapComponent first (most common in this codebase)
+            if (typeName == "MapComponent")
             {
                 return true;
             }
 
-            // Also check for MapComponent which likely inherits from ComponentBase
-            if (baseType.Name == "MapComponent" ||
-                baseType.ToString()?.Contains("MapComponent") == true)
+            // Check for ComponentBase (base class of MapComponent and other Blazor components)
+            if (typeName == "ComponentBase")
             {
                 return true;
             }
@@ -136,6 +222,9 @@ class Program
         return false;
     }
 
+    /// <summary>
+    /// Checks if a constructor has the [ActivatorUtilitiesConstructor] attribute.
+    /// </summary>
     static bool HasActivatorUtilitiesConstructorAttribute(IMethodSymbol constructor)
     {
         return constructor.GetAttributes().Any(attr =>

--- a/test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/README.md
+++ b/test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/README.md
@@ -1,0 +1,144 @@
+# Constructor Testing Console Application
+
+## Overview
+
+This console application validates that all ComponentBase-derived classes in the GeoBlazor solution follow the required constructor pattern. Specifically, it ensures that any class inheriting from `ComponentBase` (or `MapComponent`) that has 2 or more constructors includes a parameterless constructor decorated with the `[ActivatorUtilitiesConstructor]` attribute.
+
+## Purpose
+
+In Blazor applications, components with multiple constructors must explicitly mark which constructor should be used for dependency injection. This is done using the `[ActivatorUtilitiesConstructor]` attribute on the parameterless constructor. This pattern is critical for GeoBlazor components to work correctly in both Razor markup and C# code contexts.
+
+## How It Works
+
+The application uses Roslyn (the .NET Compiler Platform) to:
+1. Load the entire `dymaptic.GeoBlazor.Core.sln` solution
+2. Analyze all projects and their source files
+3. Identify classes that inherit from `ComponentBase` or `MapComponent`
+4. Check if classes with 2+ constructors have a compliant parameterless constructor
+5. Report any violations found
+
+## Running the Application
+
+### Command Line
+
+From the repository root:
+```bash
+dotnet run --project test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/dymaptic.GeoBlazor.Core.Test.ConstructorTesting.csproj
+```
+
+From the project directory:
+```bash
+cd test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting
+dotnet run
+```
+
+### Build and Run
+```bash
+# Build the project
+dotnet build test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/dymaptic.GeoBlazor.Core.Test.ConstructorTesting.csproj
+
+# Run the compiled executable
+dotnet test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/bin/Debug/net9.0/dymaptic.GeoBlazor.Core.Test.ConstructorTesting.dll
+```
+
+## Output
+
+### Success
+When all classes comply with the constructor requirements:
+```
+All classes with 2+ constructors have a parameterless constructor using the [ActivatorUtilitiesConstructor] attribute.
+```
+Exit code: 0
+
+### Failure
+When violations are found:
+```
+The following classes contain 2+ constructors, but do not have a parameterless constructor that correctly uses the [ActivatorUtilitiesConstructor] attribute. Please update the following list of the class names:
+- ClassName1 - src/dymaptic.GeoBlazor.Core/Components/SomeComponent.cs
+- ClassName2 - samples/SampleProject/SomeOtherComponent.cs
+```
+Exit code: 1
+
+## Integration with Build Process
+
+### PostBuild Event (Future Implementation)
+
+To add this validation to the build process, add the following to the main project file (`dymaptic.GeoBlazor.Core.csproj`):
+
+```xml
+<Target Name="ValidateConstructors" AfterTargets="Build">
+  <Exec Command="dotnet run --project $(MSBuildThisFileDirectory)../../test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/dymaptic.GeoBlazor.Core.Test.ConstructorTesting.csproj"
+        WorkingDirectory="$(MSBuildProjectDirectory)"
+        ContinueOnError="false" />
+</Target>
+```
+
+Or for a more lightweight approach after publishing the tool:
+
+```xml
+<Target Name="ValidateConstructors" AfterTargets="Build">
+  <Exec Command="dotnet $(MSBuildThisFileDirectory)../../test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/bin/$(Configuration)/net9.0/dymaptic.GeoBlazor.Core.Test.ConstructorTesting.dll"
+        ContinueOnError="false" />
+</Target>
+```
+
+### CI/CD Pipeline Integration
+
+Add to your CI/CD pipeline (e.g., GitHub Actions, Azure DevOps):
+
+```yaml
+- name: Validate Constructor Patterns
+  run: dotnet run --project test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/dymaptic.GeoBlazor.Core.Test.ConstructorTesting.csproj
+```
+
+## Technical Details
+
+### What Gets Checked
+
+- **Inheritance**: Classes inheriting from `ComponentBase` or `MapComponent`
+- **Constructor Count**: Only classes with 2 or more public constructors
+- **Compliance**: Presence of a parameterless constructor with `[ActivatorUtilitiesConstructor]`
+
+### Example of Compliant Class
+
+```csharp
+public partial class MyComponent : MapComponent
+{
+    /// <summary>
+    /// Parameterless constructor for use as a Razor Component.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public MyComponent()
+    {
+    }
+
+    /// <summary>
+    /// Constructor for use in C# code.
+    /// </summary>
+    public MyComponent(string param1, int param2)
+    {
+        // Set properties
+    }
+}
+```
+
+## Dependencies
+
+- .NET 9.0 SDK
+- Microsoft.CodeAnalysis.CSharp (Roslyn)
+- Microsoft.Build.Locator
+- Access to the GeoBlazor solution file
+
+## Troubleshooting
+
+### "Could not find solution file"
+- Ensure you're running from within the GeoBlazor repository
+- The tool looks for `src/dymaptic.GeoBlazor.Core.sln` relative to current directory
+
+### Build errors
+- Ensure all projects in the solution can build successfully
+- Run `dotnet build src/dymaptic.GeoBlazor.Core.sln` first
+
+### MSBuild not found
+- Ensure .NET SDK is properly installed
+- The tool uses MSBuildLocator to find the appropriate MSBuild version

--- a/test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/dymaptic.GeoBlazor.Core.Test.ConstructorTesting.csproj
+++ b/test/dymaptic.GeoBlazor.Core.Test.ConstructorTesting/dymaptic.GeoBlazor.Core.Test.ConstructorTesting.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\dymaptic.GeoBlazor.Core\dymaptic.GeoBlazor.Core.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
adds the console app to the build process that checks to ensure that all classes with 2+constructors have the required `ActivatorUtilitesConstructor` attribute.
-Claude Generated the main console app.
-tested the build process before and after finding and resolving the criteria that is targeted by the app...
Example Output before resolving the missing attributes:

Example Output after adding in the missing attributes
<img width="1686" height="419" alt="image" src="https://github.com/user-attachments/assets/2f8ad3a3-2199-4210-90ad-b1c49729c580" />
