### PR TITLE
remove portal url manipulation and update documentation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <CoreVersion>4.2.1.0-beta-2.1</CoreVersion>
+    <CoreVersion>4.2.1.0-beta-3</CoreVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CompressionEnabled Condition="$(Configuration) != 'RELEASE' OR $(EnableCompression) != 'true'">false</CompressionEnabled>
     <DefineConstants Condition="$(EnableCompression) == 'true'">$(DefineConstants);ENABLE_COMPRESSION</DefineConstants>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <CoreVersion>4.2.1.0-beta-3</CoreVersion>
+    <CoreVersion>4.2.1.0-beta-4</CoreVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CompressionEnabled Condition="$(Configuration) != 'RELEASE' OR $(EnableCompression) != 'true'">false</CompressionEnabled>
     <DefineConstants Condition="$(EnableCompression) == 'true'">$(DefineConstants);ENABLE_COMPRESSION</DefineConstants>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.TokenRefresh/dymaptic.GeoBlazor.Core.Sample.TokenRefresh.Client/Pages/Home.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.TokenRefresh/dymaptic.GeoBlazor.Core.Sample.TokenRefresh.Client/Pages/Home.razor
@@ -57,7 +57,7 @@
                     <strong>Configuring your ArcGISPortalUrl value</strong>
                     <ul>
                         <li><strong>ArcGIS Online (default):</strong> If you do not specify an <code>ArcGISPortalUrl</code> in your appsettings or user secrets, the application will default to <code>https://www.arcgis.com</code>. You can also explicitly set it to <code>https://www.arcgis.com</code>. Do <em>not</em> add <code>/portal</code>.</li>
-                        <li><strong>Enterprise Portal:</strong> Set <code>ArcGISPortalUrl</code> to your portal host. You may include or omit <code>/portal</code> — both are accepted and normalized. Examples: <code>https://your-server</code> or <code>https://your-server/portal</code>. Trailing slashes are optional.</li>
+                        <li><strong>Enterprise Portal:</strong> Set <code>ArcGISPortalUrl</code> to your portal host. This typically would be a path ending with <code>/portal</code>.</li>
                     </ul>
                 </div>
 

--- a/samples/dymaptic.GeoBlazor.Core.Sample.TokenRefresh/dymaptic.GeoBlazor.Core.Sample.TokenRefresh.Client/Pages/Home.razor
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.TokenRefresh/dymaptic.GeoBlazor.Core.Sample.TokenRefresh.Client/Pages/Home.razor
@@ -56,7 +56,7 @@
                 <div class="alert alert-warning">
                     <strong>Configuring your ArcGISPortalUrl value</strong>
                     <ul>
-                        <li><strong>ArcGIS Online (default):</strong> If you do not specify an <code>ArcGISPortalUrl</code> in your appsettings or user secrets, the application will default to <code>https://www.arcgis.com</code>. You can also explicitly set it to <code>https://www.arcgis.com</code>. Do <em>not</em> add <code>/portal</code>.</li>
+                        <li><strong>ArcGIS Online (default):</strong> This can either be <code>https://www.arcgis.com</code> or an organizational subdomain like <code>https://your-company.arcgis.com</code>.</li>
                         <li><strong>Enterprise Portal:</strong> Set <code>ArcGISPortalUrl</code> to your portal host. This typically would be a path ending with <code>/portal</code>.</li>
                     </ul>
                 </div>

--- a/samples/dymaptic.GeoBlazor.Core.Sample.TokenRefresh/dymaptic.GeoBlazor.Core.Sample.TokenRefresh/ReadMe.md
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.TokenRefresh/dymaptic.GeoBlazor.Core.Sample.TokenRefresh/ReadMe.md
@@ -15,7 +15,7 @@ Configure your ArcGIS authentication settings in `appsettings.Development.json` 
 - **ArcGISPortalUrl**:
   - If not specified, defaults to `https://www.arcgis.com` (ArcGIS Online).
   - For an organizational AGOL account, set to `https://your-company.arcgis.com`.
-  - For Enterprise Portal, set to your portal host (e.g., `https://your-server/portal`), which typically ends with `/portal.
+  - For Enterprise Portal, set to your portal host (e.g., `https://your-server/portal`), which typically ends with `/portal`.
     On rare occasion, the Enterprise setup will have altered the endpoint to not end with `/portal`.
 - **ArcGISAppId**: Your registered application's Client ID.
 - **ArcGISClientSecret**: Your application's Client Secret.

--- a/samples/dymaptic.GeoBlazor.Core.Sample.TokenRefresh/dymaptic.GeoBlazor.Core.Sample.TokenRefresh/ReadMe.md
+++ b/samples/dymaptic.GeoBlazor.Core.Sample.TokenRefresh/dymaptic.GeoBlazor.Core.Sample.TokenRefresh/ReadMe.md
@@ -14,7 +14,9 @@ Configure your ArcGIS authentication settings in `appsettings.Development.json` 
 
 - **ArcGISPortalUrl**:
   - If not specified, defaults to `https://www.arcgis.com` (ArcGIS Online).
-  - For Enterprise Portal, set to your portal host (e.g., `https://your-server` or `https://your-server/portal`). Trailing slashes and `/portal` are optional.
+  - For an organizational AGOL account, set to `https://your-company.arcgis.com`.
+  - For Enterprise Portal, set to your portal host (e.g., `https://your-server/portal`), which typically ends with `/portal.
+    On rare occasion, the Enterprise setup will have altered the endpoint to not end with `/portal`.
 - **ArcGISAppId**: Your registered application's Client ID.
 - **ArcGISClientSecret**: Your application's Client Secret.
 - **ArcGISAppTokenCacheFile**: Path to a file for caching tokens (e.g., `App_Data/arcgis_token_cache.json`).
@@ -27,7 +29,8 @@ Example configuration:
   "ArcGISAppTokenCacheFile": "arcgis_token_cache.json",
   "ApplicationBaseUrl": "https://localhost:7143",
   "ArcGISTokenExpirationMinutes": 60,
-  "ArcGISPortalUrl": "https://your_company.arcgis.com", // or "https://your_company.com/portal" for Enterprise
+  "ArcGISPortalUrl": "https://arcgis.your_company.com/portal" // for Enterprise
+  // OR "ArcGISPortalUrl": "https://your_company.arcgis.com" for AGOL
   "ArcGISAppId": "YOUR_CLIENT_ID",
   "ArcGISClientSecret": "YOUR_CLIENT_SECRET",
   "GeoBlazor": {

--- a/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/AuthenticationManagerTests.cs
+++ b/test/dymaptic.GeoBlazor.Core.Test.Blazor.Shared/Components/AuthenticationManagerTests.cs
@@ -28,8 +28,7 @@ namespace dymaptic.GeoBlazor.Core.Test.Blazor.Shared.Components;
      * NOTES:
      * - You need SEPARATE app registrations for AGOL and for Enterprise Portal if you test both.
      * - For AGOL, use TestAGOUrl = https://www.arcgis.com   (do NOT append /portal)
-     * - For Enterprise, TestPortalUrl can be either https://yourserver OR https://yourserver/portal
-     *   (AuthenticationManager will normalize it to the correct format internally.)
+     * - For Enterprise, TestPortalUrl should be https://yourserver/portal
      *
      * Recommended: keep secrets out of source control using .NET user-secrets:
      *


### PR DESCRIPTION
Closes #480 

There will also be a matching PR in Pro for documentation, please review both. 

# Changes

- Removed `AuthenticationManager.NormalizePortalUrl`. We are going to make it the responsibility of the user to set the correct portal url, since not all Enterprise portals end with `/portal`.
- Updated the documentation in `ReadMe.md` and `Home.razor` in the `TokenRefresh` sample project to explain that Enterprise portals _typically_ end with `/portal`, but not always. Also updated the AGOL portion to point out that the token refresh query works against both `arcgis.com` and `your_company.arcgis.com`.

# Testing

- Run the `TokenRefresh` WebApp sample with dymaptic Enterprise app credentials. Use the url `https://arcgis.dymaptic.com/portal` for `ArcGISPortalUrl`. Verify that the token queries and maps work in Wasm and Server modes.
- Run the `TokenRefresh` WebApp sample with dymaptic AGOL app credentials. Use the url `https://moraveclabsllc.arcgis.com` for `ArcGISPortalUrl`. Verify that the token queries and maps work in Wasm and Server modes.
- Run the `TokenRefresh` WebApp sample with dymaptic AGOL app credentials. Use the url `https://arcgis.com` for `ArcGISPortalUrl`. Verify that the token queries and maps work in Wasm and Server modes.
- Run the Test runner `dymaptic.GeoBlazor.Core.Test.WebApp` and the `AuthenticationManagerTests` using the same urls and tokens as above.